### PR TITLE
test: 补齐服务端与前端关键路径的单元测试覆盖

### DIFF
--- a/server/src/archive.test.ts
+++ b/server/src/archive.test.ts
@@ -1,0 +1,88 @@
+// claude 会话回收站：jsonl + subagents 目录整体移动，无物理删除。
+// trash 根目录固定在 ~/.cc-remote/trash/claude/（homedir），测试用唯一 slug 隔离并清理。
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { archiveClaudeSession, listTrash, restoreClaudeSession } from './archive'
+import { config } from './config'
+
+const SLUG = `-test-trash-${Date.now().toString(36)}`
+const SID = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff'
+
+let configDir = ''
+let savedConfigDir = ''
+
+const transcript = () => join(configDir, 'projects', SLUG, `${SID}.jsonl`)
+const trashDir = () => join(homedir(), '.cc-remote', 'trash', 'claude', SLUG)
+
+beforeAll(() => {
+  configDir = mkdtempSync(join(tmpdir(), 'cc-remote-archive-'))
+  savedConfigDir = config.claudeConfigDir
+  config.claudeConfigDir = configDir
+})
+
+afterAll(() => {
+  config.claudeConfigDir = savedConfigDir
+  rmSync(configDir, { recursive: true, force: true })
+  rmSync(trashDir(), { recursive: true, force: true })
+})
+
+/** 造一个带 subagents 侧目录的会话 */
+function seedSession() {
+  mkdirSync(join(configDir, 'projects', SLUG, SID), { recursive: true })
+  writeFileSync(transcript(), '{"type":"user"}\n')
+  writeFileSync(join(configDir, 'projects', SLUG, SID, 'agent-1.jsonl'), '{"type":"assistant"}\n')
+}
+
+describe('archiveClaudeSession / restoreClaudeSession / listTrash', () => {
+  test('归档：jsonl 与 subagents 目录一起移入回收站并写元信息', () => {
+    seedSession()
+    archiveClaudeSession(SLUG, SID)
+
+    expect(existsSync(transcript())).toBe(false)
+    expect(existsSync(join(configDir, 'projects', SLUG, SID))).toBe(false)
+    expect(existsSync(join(trashDir(), `${SID}.jsonl`))).toBe(true)
+    expect(existsSync(join(trashDir(), SID, 'agent-1.jsonl'))).toBe(true)
+    expect(existsSync(join(trashDir(), `${SID}.meta.json`))).toBe(true)
+
+    // 重复归档被同名守卫拦下（先恢复或手动清理）
+    seedSession()
+    expect(() => archiveClaudeSession(SLUG, SID)).toThrow('回收站已有同名会话')
+    rmSync(transcript(), { force: true })
+    rmSync(join(configDir, 'projects', SLUG, SID), { recursive: true, force: true })
+  })
+
+  test('归档不存在的 transcript 直接报错', () => {
+    expect(() => archiveClaudeSession(SLUG, '00000000-0000-4000-8000-000000000000')).toThrow('transcript 不存在')
+  })
+
+  test('回收站列表带 key/trashedAt，且不混入 meta/bak 文件', () => {
+    const entries = listTrash().filter((e) => e.slug === SLUG)
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.key).toBe(`s|${SLUG}|${SID}`)
+    expect(entries[0]!.trashedAt).toBeTruthy()
+    expect(entries[0]!.sizeBytes).toBeGreaterThan(0)
+  })
+
+  test('恢复：移回原位，元信息改名 .bak 保留', () => {
+    restoreClaudeSession(SLUG, SID)
+
+    expect(existsSync(transcript())).toBe(true)
+    expect(existsSync(join(configDir, 'projects', SLUG, SID, 'agent-1.jsonl'))).toBe(true)
+    expect(existsSync(join(trashDir(), `${SID}.jsonl`))).toBe(false)
+    expect(existsSync(join(trashDir(), `${SID}.meta.json.bak`))).toBe(true)
+
+    // 原位置已有同名 transcript 时拒绝恢复（不覆盖在线数据）
+    expect(() => restoreClaudeSession(SLUG, SID)).toThrow('回收站中没有该会话')
+  })
+
+  test('恢复时原位置被占 → 报错且不覆盖', () => {
+    // 重新归档（清掉上一步的 .bak 干扰），再占住原位置
+    rmSync(join(trashDir(), `${SID}.meta.json.bak`), { force: true })
+    archiveClaudeSession(SLUG, SID)
+    seedSession()
+    expect(() => restoreClaudeSession(SLUG, SID)).toThrow('原位置已有同名 transcript')
+    expect(existsSync(join(trashDir(), `${SID}.jsonl`))).toBe(true) // 回收站侧未动
+  })
+})

--- a/server/src/archive.ts
+++ b/server/src/archive.ts
@@ -3,7 +3,7 @@
 // - claude：官方无归档概念——把 transcript 移入 ~/.cc-remote/trash/claude/<slug>/（含 subagents 目录），
 //   恢复时移回。仅离线会话可操作（与改名同一边界：进程活着的会话绝不碰）。
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import { config } from './config'
@@ -12,6 +12,17 @@ function trashRoot(): string {
   const dir = join(homedir(), '.cc-remote', 'trash', 'claude')
   mkdirSync(dir, { recursive: true }) // recursive 幂等：已存在不抛错
   return dir
+}
+
+/** rename 的跨文件系统兜底：CLAUDE_CONFIG_DIR 可指到与 ~/.cc-remote 不同的挂载点（EXDEV） */
+function move(src: string, dest: string): void {
+  try {
+    renameSync(src, dest)
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code !== 'EXDEV') throw e
+    cpSync(src, dest, { recursive: true })
+    rmSync(src, { recursive: true, force: true })
+  }
 }
 
 function transcriptPath(slug: string, sessionId: string): string {
@@ -35,11 +46,11 @@ export function archiveClaudeSession(slug: string, sessionId: string): void {
   mkdirSync(destDir, { recursive: true })
   const dest = join(destDir, `${sessionId}.jsonl`)
   if (existsSync(dest)) throw new Error('回收站已有同名会话（先恢复或手动清理）')
-  renameSync(src, dest)
+  move(src, dest)
   // 同名 subagents 目录（subagent transcript）一并移走
   const sideDir = join(config.claudeConfigDir, 'projects', slug, sessionId)
   if (existsSync(sideDir)) {
-    renameSync(sideDir, join(destDir, sessionId))
+    move(sideDir, join(destDir, sessionId))
   }
   // 元信息（恢复依据 + 列表展示）
   writeFileSync(join(destDir, `${sessionId}.meta.json`), JSON.stringify({ trashedAt: new Date().toISOString() }))
@@ -54,11 +65,11 @@ export function restoreClaudeSession(slug: string, sessionId: string): void {
   if (existsSync(dest)) throw new Error('原位置已有同名 transcript')
   const projectDir = join(config.claudeConfigDir, 'projects', slug)
   mkdirSync(projectDir, { recursive: true })
-  renameSync(src, dest)
+  move(src, dest)
   const sideDir = join(destDir, sessionId)
-  if (existsSync(sideDir)) renameSync(sideDir, join(projectDir, sessionId))
+  if (existsSync(sideDir)) move(sideDir, join(projectDir, sessionId))
   const meta = join(destDir, `${sessionId}.meta.json`)
-  if (existsSync(meta)) renameSync(meta, join(destDir, `${sessionId}.meta.json.bak`))
+  if (existsSync(meta)) move(meta, join(destDir, `${sessionId}.meta.json.bak`))
 }
 
 /** 回收站列表（claude 部分） */

--- a/server/src/auth.test.ts
+++ b/server/src/auth.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  hostNameOf,
+  isAuthorized,
+  isLoopbackHost,
+  isLoopbackHostname,
+  jsonContentTypeRequired,
+  originAllowed,
+} from './auth'
+import { config } from './config'
+
+const originalToken = config.authToken
+
+afterEach(() => {
+  config.authToken = originalToken
+})
+
+function req(path: string, init?: { method?: string; headers?: Record<string, string> }): { req: Request; url: URL } {
+  const url = new URL(path, 'http://127.0.0.1:7480')
+  return { req: new Request(url, init), url }
+}
+
+describe('isAuthorized', () => {
+  test('未配置 token 时全部放行', () => {
+    config.authToken = undefined
+    const { req: r, url } = req('http://127.0.0.1:7480/api/sessions')
+    expect(isAuthorized(r, url)).toBe(true)
+  })
+
+  test('Bearer 头与 ?token= 两种凭据都接受', () => {
+    config.authToken = 's3cret'
+    const bearer = req('http://127.0.0.1:7480/api/sessions', {
+      headers: { authorization: 'Bearer s3cret' },
+    })
+    expect(isAuthorized(bearer.req, bearer.url)).toBe(true)
+    const query = req('http://127.0.0.1:7480/ws/s|a|b?token=s3cret')
+    expect(isAuthorized(query.req, query.url)).toBe(true)
+  })
+
+  test('错误/缺失凭据拒绝', () => {
+    config.authToken = 's3cret'
+    const wrong = req('http://127.0.0.1:7480/api/sessions', {
+      headers: { authorization: 'Bearer nope' },
+    })
+    expect(isAuthorized(wrong.req, wrong.url)).toBe(false)
+    const missing = req('http://127.0.0.1:7480/api/sessions')
+    expect(isAuthorized(missing.req, missing.url)).toBe(false)
+    // Basic 等其他 scheme 不能混过
+    const basic = req('http://127.0.0.1:7480/api/sessions', {
+      headers: { authorization: 'Basic s3cret' },
+    })
+    expect(isAuthorized(basic.req, basic.url)).toBe(false)
+  })
+})
+
+describe('isLoopbackHost / isLoopbackHostname', () => {
+  test('回环判定', () => {
+    expect(isLoopbackHost('127.0.0.1')).toBe(true)
+    expect(isLoopbackHost('localhost')).toBe(true)
+    expect(isLoopbackHost('::1')).toBe(true)
+    expect(isLoopbackHost('0.0.0.0')).toBe(false)
+    expect(isLoopbackHost('192.168.1.10')).toBe(false)
+  })
+  test('hostname 级判定含 127.0.0.0/8 全网段', () => {
+    expect(isLoopbackHostname('127.1.2.3')).toBe(true)
+    expect(isLoopbackHostname('10.0.0.1')).toBe(false)
+    expect(isLoopbackHostname('localhost.evil.com')).toBe(false)
+  })
+})
+
+describe('hostNameOf', () => {
+  test('去端口，含 IPv6 方括号形态', () => {
+    expect(hostNameOf('localhost:7480')).toBe('localhost')
+    expect(hostNameOf('127.0.0.1:7480')).toBe('127.0.0.1')
+    expect(hostNameOf('[::1]:7480')).toBe('::1')
+    expect(hostNameOf('example.com')).toBe('example.com')
+  })
+})
+
+describe('originAllowed（无 token 模式的 CSWSH 防线）', () => {
+  const withHeaders = (headers: Record<string, string>) => new Request('http://127.0.0.1:7480/ws/x', { headers })
+
+  test('无 Origin 头放行（非浏览器客户端：e2e 脚本/curl）', () => {
+    expect(originAllowed(withHeaders({ host: '127.0.0.1:7480' }))).toBe(true)
+  })
+
+  test('Origin: null 拒绝（file:// 沙箱页/iframe 的浏览器特征）', () => {
+    expect(originAllowed(withHeaders({ host: '127.0.0.1:7480', origin: 'null' }))).toBe(false)
+  })
+
+  test('Origin 与 Host 完全相同放行', () => {
+    expect(originAllowed(withHeaders({ host: 'example.com:7480', origin: 'http://example.com:7480' }))).toBe(true)
+  })
+
+  test('双回环跨端口放行（dev 模式 Vite:5173 → server:7480）', () => {
+    expect(originAllowed(withHeaders({ host: '127.0.0.1:7480', origin: 'http://localhost:5173' }))).toBe(true)
+    expect(originAllowed(withHeaders({ host: '[::1]:7480', origin: 'http://127.0.0.1:5173' }))).toBe(true)
+    // WHATWG URL 的 IPv6 hostname 保留方括号（[::1]），不能因此漏判回环
+    expect(originAllowed(withHeaders({ host: 'localhost:7480', origin: 'http://[::1]:5173' }))).toBe(true)
+  })
+
+  test('恶意跨源拒绝', () => {
+    expect(originAllowed(withHeaders({ host: '127.0.0.1:7480', origin: 'https://evil.com' }))).toBe(false)
+    // 回环字样子域名不是回环
+    expect(originAllowed(withHeaders({ host: 'localhost:7480', origin: 'http://localhost.evil.com' }))).toBe(false)
+  })
+
+  test('非法 Origin URL 拒绝', () => {
+    expect(originAllowed(withHeaders({ host: '127.0.0.1:7480', origin: 'not a url' }))).toBe(false)
+  })
+})
+
+describe('jsonContentTypeRequired（text/plain 简单请求 CSRF 通道封堵）', () => {
+  test('GET/HEAD 不受约束', () => {
+    const { req: r, url } = req('http://127.0.0.1:7480/api/sessions', { method: 'GET' })
+    expect(jsonContentTypeRequired(r, url)).toBe(true)
+  })
+
+  test('非 /api 路径不受约束', () => {
+    const { req: r, url } = req('http://127.0.0.1:7480/assets/index.js', {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+    })
+    expect(jsonContentTypeRequired(r, url)).toBe(true)
+  })
+
+  test('POST /api 必须 application/json（charset 后缀可接受）', () => {
+    const ok = req('http://127.0.0.1:7480/api/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    })
+    expect(jsonContentTypeRequired(ok.req, ok.url)).toBe(true)
+
+    const plain = req('http://127.0.0.1:7480/api/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+    })
+    expect(jsonContentTypeRequired(plain.req, plain.url)).toBe(false)
+
+    // 表单提交同样是 preflight 豁免通道
+    const form = req('http://127.0.0.1:7480/api/sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    })
+    expect(jsonContentTypeRequired(form.req, form.url)).toBe(false)
+  })
+})

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -15,3 +15,46 @@ export function isAuthorized(req: Request, url: URL): boolean {
   if (url.searchParams.get('token') === config.authToken) return true
   return false
 }
+
+// ---------- 跨源防护（无 token 回环部署的浏览器攻击面） ----------
+// WebSocket 不受同源策略约束、text/plain 简单请求不触发 preflight——
+// 默认无 token 时恶意网页可经受害者浏览器直连回环服务（CSWSH/CSRF → RCE）。
+// 浏览器在 WS 握手与跨源 POST 时必定携带 Origin；非浏览器客户端（e2e 脚本/curl）不带。
+// 配置 authToken 后 token 即防线，以下检查不生效（行为与旧版完全一致）。
+
+/** Host 头去端口（兼容 [::1]:7480 形态） */
+export function hostNameOf(hostHeader: string): string {
+  if (hostHeader.startsWith('[')) return hostHeader.slice(1, hostHeader.indexOf(']'))
+  const i = hostHeader.lastIndexOf(':')
+  return i > 0 ? hostHeader.slice(0, i) : hostHeader
+}
+
+export function isLoopbackHostname(h: string): boolean {
+  // WHATWG URL 的 IPv6 hostname 保留方括号（http://[::1]:9001 → "[::1]"）
+  const n = h.startsWith('[') && h.endsWith(']') ? h.slice(1, -1) : h
+  return n === 'localhost' || n === '::1' || n.startsWith('127.')
+}
+
+/** Origin 与 Host 同 host，或同为回环（dev 模式 Vite :5173 代理到 server :7480 的端口差） */
+export function originAllowed(req: Request): boolean {
+  const origin = req.headers.get('origin')
+  if (!origin) return true // 非浏览器客户端；浏览器必带 Origin
+  if (origin === 'null') return false // 沙箱 iframe / file:// 页面（浏览器特征）
+  const host = req.headers.get('host') ?? ''
+  let o: URL
+  try {
+    o = new URL(origin)
+  } catch {
+    return false
+  }
+  if (o.host === host) return true
+  return isLoopbackHostname(o.hostname) && isLoopbackHostname(hostNameOf(host))
+}
+
+/** 状态变更 /api 请求必须是 application/json——text/plain 是 preflight 豁免的 CSRF 通道 */
+export function jsonContentTypeRequired(req: Request, url: URL): boolean {
+  if (req.method === 'GET' || req.method === 'HEAD') return true
+  if (!url.pathname.startsWith('/api/')) return true
+  const ct = req.headers.get('content-type')?.split(';')[0].trim()
+  return ct === 'application/json'
+}

--- a/server/src/backends/claude/discovery.test.ts
+++ b/server/src/backends/claude/discovery.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { config } from '../../config'
-import { readHistory } from './discovery'
+import { entryToHistoryMessage, isSelectableRewindTarget, readHistory } from './discovery'
 
 const SLUG = 'D--test-rewind-filter'
 const SID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
@@ -63,5 +63,91 @@ describe('readHistory rewind 目标过滤', () => {
     expect(byUuid.get('u-local-cmd')?.rewindable).toBe(false)
     // isMeta 消息被 isInternalUserMessage 直接滤出抄本，根本不应出现
     expect(byUuid.has('u-meta')).toBe(false)
+  })
+})
+
+describe('isSelectableRewindTarget', () => {
+  const target = (content: unknown, extra: Record<string, unknown> = {}) => ({ message: { content }, ...extra })
+
+  test('isMeta / isSynthetic / tool_result 块 → 不可回滚', () => {
+    expect(isSelectableRewindTarget(target('文本', { isMeta: true }))).toBe(false)
+    expect(isSelectableRewindTarget(target('文本', { isSynthetic: true }))).toBe(false)
+    expect(isSelectableRewindTarget(target([{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }]))).toBe(false)
+  })
+
+  test('内部标签文本（bash 回显/tick/teammate/task-notification）→ 不可回滚', () => {
+    for (const tag of ['<bash-stdout>', '<bash-stderr>', '<tick>', '<teammate-message>', '<task-notification>']) {
+      expect(isSelectableRewindTarget(target(`${tag}内容`))).toBe(false)
+    }
+  })
+
+  test('真实提问与斜杠命令回显 → 可回滚（官方同款：checkpoint 照常建立）', () => {
+    expect(isSelectableRewindTarget(target('请检查当前项目'))).toBe(true)
+    expect(isSelectableRewindTarget(target('<command-name>compact</command-name>'))).toBe(true)
+    expect(isSelectableRewindTarget(target([{ type: 'text', text: '数组形态文本' }]))).toBe(true)
+  })
+})
+
+describe('entryToHistoryMessage（readHistory 与 tailer 共用的单条解析）', () => {
+  test('compact_boundary 元数据 camelCase 与 snake_case 都识别', () => {
+    const camel = entryToHistoryMessage({
+      type: 'system',
+      subtype: 'compact_boundary',
+      uuid: 'b1',
+      compactMetadata: { trigger: 'auto', preTokens: 100, postTokens: 20 },
+    })
+    expect(camel).toMatchObject({
+      role: 'system',
+      subtype: 'compact_boundary',
+      compactMeta: { trigger: 'auto', preTokens: 100, postTokens: 20 },
+    })
+
+    const snake = entryToHistoryMessage({
+      type: 'system',
+      subtype: 'compact_boundary',
+      uuid: 'b2',
+      compact_metadata: { pre_tokens: 90, post_tokens: 30 },
+    })
+    expect(snake).toMatchObject({ compactMeta: { preTokens: 90, postTokens: 30 } })
+  })
+
+  test('sidechain / 非对话类型 / 内部 user 消息 → null（不进主抄本）', () => {
+    expect(entryToHistoryMessage({ type: 'assistant', isSidechain: true, message: { content: '子代理' } })).toBeNull()
+    expect(entryToHistoryMessage({ type: 'system', subtype: 'init' })).toBeNull()
+    expect(entryToHistoryMessage({ type: 'result', subtype: 'success' })).toBeNull()
+    expect(entryToHistoryMessage({ type: 'user', isMeta: true, message: { content: '注入' } })).toBeNull()
+  })
+
+  test('内容块映射：text/thinking/tool_use/tool_result 各归其位', () => {
+    const msg = entryToHistoryMessage({
+      type: 'assistant',
+      uuid: 'a1',
+      timestamp: '2026-08-27T00:00:00Z',
+      message: {
+        content: [
+          { type: 'thinking', thinking: '想一下' },
+          { type: 'text', text: '结论' },
+          { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } },
+          { type: 'tool_result', tool_use_id: 't0', content: [{ type: 'text', text: '之前的结果' }], is_error: true },
+        ],
+      },
+    })
+    expect(msg).toMatchObject({
+      uuid: 'a1',
+      role: 'assistant',
+      timestamp: '2026-08-27T00:00:00Z',
+      blocks: [
+        { kind: 'thinking', text: '想一下' },
+        { kind: 'text', text: '结论' },
+        { kind: 'tool_use', id: 't1', name: 'Bash', input: { command: 'ls' } },
+        { kind: 'tool_result', id: 't0', text: '之前的结果', isError: true },
+      ],
+    })
+  })
+
+  test('纯空白内容 → null（不产生空气泡）', () => {
+    expect(entryToHistoryMessage({ type: 'user', message: { content: '   ' } })).toBeNull()
+    expect(entryToHistoryMessage({ type: 'assistant', message: { content: [{ type: 'text', text: '' }] } })).toBeNull()
+    expect(entryToHistoryMessage({ type: 'assistant', message: {} })).toBeNull()
   })
 })

--- a/server/src/backends/codex/backend.test.ts
+++ b/server/src/backends/codex/backend.test.ts
@@ -1,0 +1,51 @@
+// codex sessionKey 编码：x|<threadId> 已存在线程、xn|<encodeURIComponent(cwd)> 新线程。
+// parseKey 是 spawn 参数的唯一入口，编码段损坏必须按"无法解析"（null）而非抛异常处理。
+import { describe, expect, test } from 'bun:test'
+import { isCodexKey, keyFor, keyForNew, parseKey, splitThreadId } from './backend'
+
+describe('keyFor / keyForNew / isCodexKey', () => {
+  test('编码形状', () => {
+    expect(keyFor('0198f4d2-7d1e-7e80-a1b2-c3d4e5f60708')).toBe('x|0198f4d2-7d1e-7e80-a1b2-c3d4e5f60708')
+    expect(keyForNew('/data/workspace/cc-remote')).toBe('xn|%2Fdata%2Fworkspace%2Fcc-remote')
+  })
+
+  test('isCodexKey 与 claude key 互斥', () => {
+    expect(isCodexKey('x|abc')).toBe(true)
+    expect(isCodexKey('xn|%2Ftmp')).toBe(true)
+    expect(isCodexKey('s|slug|sid')).toBe(false)
+    expect(isCodexKey('n|%2Ftmp')).toBe(false)
+    expect(isCodexKey('b|%2Ftmp|sid')).toBe(false)
+    // 注意：xn| 以 x 开头但不以 x| 开头，两段判断缺一不可
+    expect(isCodexKey('x')).toBe(false)
+  })
+})
+
+describe('parseKey', () => {
+  test('x| → resumeThreadId；xn| → 解码 cwd', () => {
+    expect(parseKey('x|thread-1')).toEqual({ resumeThreadId: 'thread-1' })
+    expect(parseKey('xn|%2Fdata%2Fworkspace')).toEqual({ cwd: '/data/workspace' })
+  })
+
+  test('中文与空格等需要转义的 cwd 往返无损', () => {
+    const cwd = '/home/用户/我的 项目'
+    expect(parseKey(keyForNew(cwd))).toEqual({ cwd })
+  })
+
+  test('非法形状/损坏编码 → null（不炸掉深链导航）', () => {
+    expect(parseKey('s|slug|sid')).toBeNull()
+    expect(parseKey('n|%2Ftmp')).toBeNull()
+    expect(parseKey('x|a|b')).toBeNull()
+    expect(parseKey('x')).toBeNull()
+    expect(parseKey('')).toBeNull()
+    expect(parseKey('xn|%E4%B8')).toBeNull() // 截断的 UTF-8 百分号编码
+  })
+})
+
+describe('splitThreadId', () => {
+  test('纯形状解析：只有 x| 两段式有 threadId', () => {
+    expect(splitThreadId('x|thread-1')).toBe('thread-1')
+    expect(splitThreadId('xn|%2Ftmp')).toBeUndefined()
+    expect(splitThreadId('s|slug|sid')).toBeUndefined()
+    expect(splitThreadId('x|a|b')).toBeUndefined()
+  })
+})

--- a/server/src/backends/codex/reasoningStore.test.ts
+++ b/server/src/backends/codex/reasoningStore.test.ts
@@ -1,0 +1,42 @@
+// reasoning 侧车：codex rollout 不持久化 reasoning，cc-remote 自行落盘 ~/.cc-remote/reasoning/<threadId>.jsonl。
+// 测试用随机 threadId 隔离真实数据，结束后清理。
+import { afterAll, describe, expect, test } from 'bun:test'
+import { appendFileSync, rmSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { appendReasoning, readReasoning } from './reasoningStore'
+
+const THREAD = `test-${crypto.randomUUID()}`
+const file = () => join(homedir(), '.cc-remote', 'reasoning', `${THREAD}.jsonl`)
+
+afterAll(() => {
+  rmSync(file(), { force: true })
+})
+
+describe('reasoningStore', () => {
+  test('未落盘的线程读出空数组', () => {
+    expect(readReasoning(`missing-${crypto.randomUUID()}`)).toEqual([])
+  })
+
+  test('append → read 往返，按行追加', () => {
+    appendReasoning(THREAD, { ts: 1000, turnId: 't1', text: '先想一下' })
+    appendReasoning(THREAD, { ts: 2000, turnId: null, text: '再想一下' })
+    expect(readReasoning(THREAD)).toEqual([
+      { ts: 1000, turnId: 't1', text: '先想一下' },
+      { ts: 2000, turnId: null, text: '再想一下' },
+    ])
+  })
+
+  test('坏行/缺字段/空文本被容忍跳过，不影响其余行', () => {
+    appendFileSync(file(), 'not json at all\n')
+    appendFileSync(file(), '{"broken":\n')
+    appendFileSync(file(), JSON.stringify({ ts: 'oops', turnId: null, text: 'ts 不是数字' }) + '\n')
+    appendFileSync(file(), JSON.stringify({ ts: 3000, turnId: null, text: '   ' }) + '\n')
+    appendReasoning(THREAD, { ts: 4000, turnId: 't2', text: '有效条目' })
+    expect(readReasoning(THREAD)).toEqual([
+      { ts: 1000, turnId: 't1', text: '先想一下' },
+      { ts: 2000, turnId: null, text: '再想一下' },
+      { ts: 4000, turnId: 't2', text: '有效条目' },
+    ])
+  })
+})

--- a/server/src/backends/codex/runtime.test.ts
+++ b/server/src/backends/codex/runtime.test.ts
@@ -1,0 +1,44 @@
+// 权限模式映射是双后端体验一致的接缝：claude 风格模式与 codex 预设都汇聚到
+// approvalPolicy+sandbox；wire 枚举双轨（thread/start 用 kebab-case sandbox，
+// turn/start 用 camelCase sandboxPolicy 对象）是本文件锁定的重点。
+import { describe, expect, test } from 'bun:test'
+import { mapPermissionMode, sandboxPolicyOf } from './runtime'
+
+describe('mapPermissionMode（codex 原生预设）', () => {
+  test('四档预设', () => {
+    expect(mapPermissionMode('readOnly')).toEqual({ approvalPolicy: 'on-request', sandbox: 'read-only' })
+    expect(mapPermissionMode('workspace')).toEqual({ approvalPolicy: 'on-request', sandbox: 'workspace-write' })
+    expect(mapPermissionMode('workspaceAuto')).toEqual({ approvalPolicy: 'never', sandbox: 'workspace-write' })
+    expect(mapPermissionMode('fullAccess')).toEqual({ approvalPolicy: 'never', sandbox: 'danger-full-access' })
+  })
+})
+
+describe('mapPermissionMode（claude 名称近似映射）', () => {
+  test('bypassPermissions → 完全访问', () => {
+    expect(mapPermissionMode('bypassPermissions')).toEqual({ approvalPolicy: 'never', sandbox: 'danger-full-access' })
+  })
+  test('acceptEdits/auto → 工作区免审', () => {
+    expect(mapPermissionMode('acceptEdits')).toEqual({ approvalPolicy: 'never', sandbox: 'workspace-write' })
+    expect(mapPermissionMode('auto')).toEqual({ approvalPolicy: 'never', sandbox: 'workspace-write' })
+  })
+  test('plan → 只读询问', () => {
+    expect(mapPermissionMode('plan')).toEqual({ approvalPolicy: 'on-request', sandbox: 'read-only' })
+  })
+  test('default/未知/缺省 → 工作区询问（安全中间档）', () => {
+    expect(mapPermissionMode('default')).toEqual({ approvalPolicy: 'on-request', sandbox: 'workspace-write' })
+    expect(mapPermissionMode(undefined)).toEqual({ approvalPolicy: 'on-request', sandbox: 'workspace-write' })
+    expect(mapPermissionMode('some-future-mode')).toEqual({ approvalPolicy: 'on-request', sandbox: 'workspace-write' })
+  })
+})
+
+describe('sandboxPolicyOf（kebab → camelCase 对象的双轨转换）', () => {
+  test('已知三档', () => {
+    expect(sandboxPolicyOf('read-only')).toEqual({ type: 'readOnly' })
+    expect(sandboxPolicyOf('workspace-write')).toEqual({ type: 'workspaceWrite' })
+    expect(sandboxPolicyOf('danger-full-access')).toEqual({ type: 'dangerFullAccess' })
+  })
+  test('未知值返回 undefined（调用方省略字段，不发明枚举）', () => {
+    expect(sandboxPolicyOf('')).toBeUndefined()
+    expect(sandboxPolicyOf('yolo')).toBeUndefined()
+  })
+})

--- a/server/src/backends/codex/translate.test.ts
+++ b/server/src/backends/codex/translate.test.ts
@@ -1,0 +1,259 @@
+// Codex → claude stream-json 翻译器：统一消息边界的保真度直接决定前端渲染是否正确。
+// 重点锁定：live 流事件序（快照先于 stop）、tool_use/tool_result 配对 id、
+// reasoning 镜像去重、历史首条 userMessage 的 rewindable 标记。
+import { describe, expect, test } from 'bun:test'
+import { itemsToHistory, mapThreadStatus, reasoningText, ThreadTranslator, turnCompletedMsg } from './translate'
+
+describe('ThreadTranslator agentMessage 生命周期', () => {
+  test('started → delta → completed 的事件序对齐 claude 真实序（快照先于 stop）', () => {
+    const t = new ThreadTranslator()
+
+    const started = t.itemStarted({ id: 'm1', type: 'agentMessage' })
+    expect(started).toEqual([
+      { type: 'stream_event', event: { type: 'message_start', message: { id: 'm1', role: 'assistant', content: [] } } },
+      { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } },
+    ])
+
+    const delta = t.itemDelta('item/agentMessage/delta', { itemId: 'm1', delta: '你好' })
+    expect(delta).toEqual([
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: '你好' } },
+        message: { id: 'm1' },
+      },
+    ])
+
+    const completed = t.itemCompleted({ id: 'm1', type: 'agentMessage', text: '你好，世界' })
+    // assistant 快照必须在 message_stop 之前：快照合并草稿、stop 提交定稿
+    expect(completed.map((m) => m.type)).toEqual(['assistant', 'stream_event', 'stream_event'])
+    expect(completed[0]).toEqual({
+      type: 'assistant',
+      message: { id: 'm1', role: 'assistant', content: [{ type: 'text', text: '你好，世界' }] },
+    })
+    expect(completed[1]).toEqual({ type: 'stream_event', event: { type: 'content_block_stop', index: 0 } })
+    expect(completed[2]).toEqual({ type: 'stream_event', event: { type: 'message_stop' } })
+  })
+
+  test('reasoning 走 thinking 块；delta 两种 method 都识别', () => {
+    const t = new ThreadTranslator()
+    const started = t.itemStarted({ id: 'r1', type: 'reasoning' })
+    expect(started[1]).toEqual({
+      type: 'stream_event',
+      event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '' } },
+    })
+
+    for (const method of ['item/reasoning/textDelta', 'item/reasoning/summaryTextDelta']) {
+      const d = t.itemDelta(method, { itemId: 'r1', delta: '嗯' })
+      expect(d[0]).toMatchObject({
+        event: { delta: { type: 'thinking_delta', thinking: '嗯' } },
+        message: { id: 'r1' },
+      })
+    }
+    // 不相关 method / 缺 itemId → 空
+    expect(t.itemDelta('item/unknown/delta', { itemId: 'r1', delta: 'x' })).toEqual([])
+    expect(t.itemDelta('item/agentMessage/delta', {})).toEqual([])
+  })
+
+  test('缺 id/type 的残缺 item 不产生事件', () => {
+    const t = new ThreadTranslator()
+    expect(t.itemStarted({})).toEqual([])
+    expect(t.itemCompleted({ id: 'x' })).toEqual([])
+    expect(t.itemStarted({ id: 'u1', type: 'mysteryItem' })).toEqual([])
+    expect(t.itemCompleted({ id: 'u1', type: 'mysteryItem' })).toEqual([])
+  })
+})
+
+describe('ThreadTranslator 工具项', () => {
+  test('commandExecution → Bash 卡，completed 按 id 配对 tool_result', () => {
+    const t = new ThreadTranslator()
+    const started = t.itemStarted({ id: 'c1', type: 'commandExecution', command: 'ls -la', cwd: '/data' })
+    expect(started).toHaveLength(1)
+    expect(started[0]).toMatchObject({
+      type: 'assistant',
+      message: {
+        id: 'tool-c1',
+        content: [{ type: 'tool_use', id: 'c1', name: 'Bash', input: { command: 'ls -la', description: 'cwd: /data' } }],
+      },
+    })
+
+    const completed = t.itemCompleted({ id: 'c1', type: 'commandExecution', status: 'completed', exitCode: 0, aggregatedOutput: 'total 0' })
+    expect(completed).toEqual([
+      {
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'c1', content: 'total 0', is_error: false }] },
+      },
+    ])
+  })
+
+  test('commandExecution 失败判定：status failed / declined / 非零 exitCode', () => {
+    const t = new ThreadTranslator()
+    const failed = t.itemCompleted({ id: 'c2', type: 'commandExecution', status: 'completed', exitCode: 1, aggregatedOutput: 'boom' })
+    expect(failed[0]).toMatchObject({ message: { content: [{ is_error: true }] } })
+
+    const declined = t.itemCompleted({ id: 'c3', type: 'commandExecution', status: 'declined' })
+    expect(declined[0]).toMatchObject({ message: { content: [{ content: '（用户拒绝）', is_error: true }] } })
+
+    // 无输出时兜底 exit 文案
+    const silent = t.itemCompleted({ id: 'c4', type: 'commandExecution', status: 'completed', exitCode: 2 })
+    expect(silent[0]).toMatchObject({ message: { content: [{ content: '（exit 2）', is_error: true }] } })
+  })
+
+  test('fileChange → Edit 卡（paths 汇总 + diff 文本）', () => {
+    const t = new ThreadTranslator()
+    const started = t.itemStarted({
+      id: 'f1',
+      type: 'fileChange',
+      changes: [{ path: 'a.ts' }, { path: 'b.ts' }],
+    })
+    expect(started[0]).toMatchObject({
+      message: { content: [{ name: 'Edit', input: { file_path: 'a.ts', paths: ['a.ts', 'b.ts'] } }] },
+    })
+    const completed = t.itemCompleted({
+      id: 'f1',
+      type: 'fileChange',
+      status: 'completed',
+      changes: [{ path: 'a.ts', diff: '@@ -1 +1 @@' }, { path: 'b.ts', diff: '@@ -2 +2 @@' }],
+    })
+    expect(completed[0]).toMatchObject({
+      message: { content: [{ content: '--- a.ts\n@@ -1 +1 @@\n\n--- b.ts\n@@ -2 +2 @@', is_error: false }] },
+    })
+  })
+
+  test('mcpToolCall → server:tool 命名；error 序列化为失败结果', () => {
+    const t = new ThreadTranslator()
+    const started = t.itemStarted({ id: 'm1', type: 'mcpToolCall', server: 'chrome', tool: 'click', arguments: { uid: 'u1' } })
+    expect(started[0]).toMatchObject({ message: { content: [{ name: 'chrome:click', input: { uid: 'u1' } }] } })
+
+    const err = t.itemCompleted({ id: 'm1', type: 'mcpToolCall', status: 'failed', error: { code: -1, message: 'no such node' } })
+    expect(err[0]).toMatchObject({
+      message: { content: [{ content: '{"code":-1,"message":"no such node"}', is_error: true }] },
+    })
+  })
+
+  test('webSearch 结果即正文，失败态不由 status 表达', () => {
+    const t = new ThreadTranslator()
+    const started = t.itemStarted({ id: 'w1', type: 'webSearch', query: 'bun windows socket bug' })
+    expect(started[0]).toMatchObject({ message: { content: [{ name: 'WebSearch', input: { query: 'bun windows socket bug' } }] } })
+    const completed = t.itemCompleted({ id: 'w1', type: 'webSearch', status: 'failed', result: '搜索结果…' })
+    expect(completed[0]).toMatchObject({ message: { content: [{ content: '搜索结果…', is_error: false }] } })
+  })
+
+  test('contextCompaction → compact_boundary；review 模式 → system 文本', () => {
+    const t = new ThreadTranslator()
+    expect(t.itemCompleted({ id: 'x1', type: 'contextCompaction' })).toEqual([{ type: 'system', subtype: 'compact_boundary' }])
+    expect(t.itemCompleted({ id: 'x2', type: 'enteredReviewMode', review: '未提交改动' })).toEqual([
+      { type: 'system', subtype: 'status', text: '进入代码审查：未提交改动' },
+    ])
+    expect(t.itemCompleted({ id: 'x3', type: 'exitedReviewMode', review: 'LGTM' })).toEqual([
+      { type: 'system', subtype: 'status', text: '审查完成\nLGTM' },
+    ])
+  })
+})
+
+describe('reasoningText（summary/content 可能互为镜像）', () => {
+  test('镜像时只取一份', () => {
+    expect(reasoningText(['第一段', '第二段'], ['第一段', '第二段'])).toBe('第一段\n\n第二段')
+  })
+  test('不同则拼接 summary 在前', () => {
+    expect(reasoningText(['摘要'], ['正文'])).toBe('摘要\n\n正文')
+  })
+  test('空值容错', () => {
+    expect(reasoningText(undefined, undefined)).toBe('')
+    expect(reasoningText(['只有摘要'])).toBe('只有摘要')
+    expect(reasoningText([], ['只有正文'])).toBe('只有正文')
+    expect(reasoningText(['', '过滤空串'], [''])).toBe('过滤空串')
+  })
+})
+
+describe('mapThreadStatus / turnCompletedMsg', () => {
+  test('active → running，其余 → idle', () => {
+    expect(mapThreadStatus(undefined)).toBe('idle')
+    expect(mapThreadStatus({ type: 'active' })).toBe('running')
+    expect(mapThreadStatus({ type: 'idle' })).toBe('idle')
+    expect(mapThreadStatus({})).toBe('idle')
+  })
+
+  test('turn/completed → result 形状', () => {
+    const ok = turnCompletedMsg('thread-1', { status: 'completed' }, { input_tokens: 10, output_tokens: 5 })
+    expect(ok).toMatchObject({ type: 'result', subtype: 'success', is_error: false, session_id: 'thread-1', usage: { input_tokens: 10 } })
+
+    const bad = turnCompletedMsg('thread-1', { status: 'failed', error: { message: '模型过载' } })
+    expect(bad).toMatchObject({ subtype: 'error', is_error: true, result: '模型过载' })
+
+    const badNoMsg = turnCompletedMsg('thread-1', { status: 'failed' })
+    expect(badNoMsg).toMatchObject({ result: 'turn failed' })
+  })
+})
+
+describe('itemsToHistory', () => {
+  test('turnId 存在时首条 userMessage 以其为 uuid 且 rewindable（/rewind 定位锚点）', () => {
+    const msgs = itemsToHistory(
+      [
+        { id: 'u1', type: 'userMessage', content: [{ type: 'text', text: '第一个问题' }] },
+        { id: 'a1', type: 'agentMessage', text: '回答一' },
+        { id: 'u2', type: 'userMessage', content: [{ type: 'text', text: '追问' }] },
+      ],
+      'turn-42',
+    )
+    expect(msgs).toHaveLength(3)
+    expect(msgs[0]).toMatchObject({ uuid: 'turn-42', role: 'user', rewindable: true })
+    // 后续 userMessage 不再标记
+    expect(msgs[2]).toMatchObject({ uuid: 'u2', role: 'user' })
+    expect(msgs[2]!.rewindable).toBeFalsy()
+  })
+
+  test('无 turnId 时不标记 rewindable', () => {
+    const msgs = itemsToHistory([{ id: 'u1', type: 'userMessage', content: [{ type: 'text', text: '问' }] }])
+    expect(msgs[0]!.rewindable).toBeFalsy()
+    expect(msgs[0]!.uuid).toBe('u1')
+  })
+
+  test('工具项 → tool_use + tool_result 成对（tool_result uuid 带 -r 后缀）', () => {
+    const msgs = itemsToHistory([
+      { id: 'c1', type: 'commandExecution', command: 'ls', status: 'completed', exitCode: 0, aggregatedOutput: 'ok' },
+    ])
+    expect(msgs).toHaveLength(2)
+    // 历史卡摘要有意不带 live 侧的 description(cwd)：避免抢占 toolSummary 首选字段
+    expect(msgs[0]).toMatchObject({ role: 'assistant', blocks: [{ kind: 'tool_use', id: 'c1', name: 'Bash', input: { command: 'ls' } }] })
+    expect(msgs[1]).toMatchObject({ uuid: 'c1-r', role: 'user', blocks: [{ kind: 'tool_result', id: 'c1', text: 'ok', isError: false }] })
+  })
+
+  test('reasoning 文本为空则整条跳过；plan 按文本入抄本', () => {
+    const msgs = itemsToHistory([
+      { id: 'r1', type: 'reasoning', summary: [], content: [] },
+      { id: 'r2', type: 'reasoning', summary: ['想一下'] },
+      { id: 'p1', type: 'plan', text: '计划文本' },
+    ])
+    expect(msgs.map((m) => m.uuid)).toEqual(['r2', 'p1'])
+    expect(msgs[0]!.blocks).toEqual([{ kind: 'thinking', text: '想一下' }])
+  })
+
+  test('userMessage 富内容：图片占位 / skill / mention，空内容跳过', () => {
+    const msgs = itemsToHistory([
+      {
+        id: 'u1',
+        type: 'userMessage',
+        content: [
+          { type: 'text', text: '看这个' },
+          { type: 'localImage', path: '/not-in-uploads/photo.png' }, // 不在 uploads 目录 → 占位
+          { type: 'skill', name: 'review' },
+          { type: 'mention', name: 'README.md' },
+          { type: 'audio' },
+        ],
+      },
+      { id: 'u2', type: 'userMessage', content: [] }, // 空内容整条跳过
+      { id: 'u3', type: 'userMessage' }, // 非数组内容同样跳过
+    ])
+    expect(msgs).toHaveLength(1)
+    expect(msgs[0]!.blocks).toEqual([{ kind: 'text', text: '看这个\n[图片]\n[skill: review]\n[README.md]\n[音频]' }])
+  })
+
+  test('contextCompaction → system 分隔；未知 item 类型不渲染', () => {
+    const msgs = itemsToHistory([
+      { id: 'x1', type: 'contextCompaction' },
+      { id: 'x2', type: 'collabToolCall' },
+      { id: 'x3', type: 'imageGeneration' },
+    ])
+    expect(msgs).toEqual([{ uuid: 'x1', role: 'system', subtype: 'compact_boundary', blocks: [] }])
+  })
+})

--- a/server/src/backends/codex/translate.ts
+++ b/server/src/backends/codex/translate.ts
@@ -29,6 +29,8 @@ interface ThreadItem {
   error?: unknown
   query?: string
   durationMs?: number
+  /** enteredReviewMode/exitedReviewMode 的审查说明 */
+  review?: string
 }
 
 /** 每个线程一个：维护 itemId → 合成 message id / 块序号的流式状态 */
@@ -105,9 +107,9 @@ export class ThreadTranslator {
       case 'contextCompaction':
         return [{ type: 'system', subtype: 'compact_boundary' }]
       case 'enteredReviewMode':
-        return [systemText(`进入代码审查：${(item as { review?: string }).review ?? ''}`)]
+        return [systemText(`进入代码审查：${item.review ?? ''}`)]
       case 'exitedReviewMode':
-        return [systemText(`审查完成\n${(item as { review?: string }).review ?? ''}`)]
+        return [systemText(`审查完成\n${item.review ?? ''}`)]
       default:
         return []
     }

--- a/server/src/fsbrowse.test.ts
+++ b/server/src/fsbrowse.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { FsBrowseError, listDirectories, readGitBranch } from './fsbrowse'
+
+let root = ''
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'cc-remote-fsbrowse-'))
+})
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('readGitBranch', () => {
+  test('普通仓库：.git/HEAD 的 ref 取末段分支名', () => {
+    const repo = join(root, 'repo')
+    mkdirSync(join(repo, '.git'), { recursive: true })
+    writeFileSync(join(repo, '.git', 'HEAD'), 'ref: refs/heads/main\n')
+    expect(readGitBranch(repo)).toBe('main')
+  })
+
+  test('detached HEAD：返回短 sha', () => {
+    const repo = join(root, 'detached')
+    mkdirSync(join(repo, '.git'), { recursive: true })
+    writeFileSync(join(repo, '.git', 'HEAD'), '0123456789abcdef0123456789abcdef01234567\n')
+    expect(readGitBranch(repo)).toBe('0123456')
+  })
+
+  test('worktree：.git 是 gitdir 指向文件，HEAD 在指向目录里', () => {
+    const gitdir = join(root, 'real-gitdir')
+    mkdirSync(gitdir, { recursive: true })
+    writeFileSync(join(gitdir, 'HEAD'), 'ref: refs/heads/worktree-branch\n')
+    const wt = join(root, 'wt')
+    mkdirSync(wt, { recursive: true })
+    writeFileSync(join(wt, '.git'), `gitdir: ${gitdir}\n`)
+    expect(readGitBranch(wt)).toBe('worktree-branch')
+  })
+
+  test('.git 文件非 gitdir 指针 / 非仓库 / HEAD 不可读 → undefined', () => {
+    const bogus = join(root, 'bogus')
+    mkdirSync(bogus, { recursive: true })
+    writeFileSync(join(bogus, '.git'), 'not a pointer')
+    expect(readGitBranch(bogus)).toBeUndefined()
+
+    const plain = join(root, 'plain')
+    mkdirSync(plain, { recursive: true })
+    expect(readGitBranch(plain)).toBeUndefined()
+
+    expect(readGitBranch(join(root, 'does-not-exist'))).toBeUndefined()
+  })
+})
+
+describe('listDirectories', () => {
+  test('空 target → 根集合视图（POSIX 为 / + home 快捷项）', () => {
+    const r = listDirectories('')
+    expect(r.path).toBe('')
+    expect(r.parent).toBeNull()
+    if (process.platform !== 'win32') {
+      expect(r.entries.map((e) => e.name)).toContain('/')
+    }
+    expect(r.entries.map((e) => e.name)).toContain('~')
+    expect(r.home).toBeTruthy()
+  })
+
+  test('只列目录不列文件，按名称排序，父目录正确', () => {
+    const dir = join(root, 'listing')
+    mkdirSync(join(dir, 'beta'), { recursive: true })
+    mkdirSync(join(dir, 'alpha'), { recursive: true })
+    writeFileSync(join(dir, 'file.txt'), 'not a dir')
+    const r = listDirectories(dir)
+    expect(r.entries.map((e) => e.name)).toEqual(['alpha', 'beta'])
+    expect(r.parent).toBe(root)
+  })
+
+  test('符号链接指向目录也算目录（断链不算）', () => {
+    const dir = join(root, 'links')
+    const target = join(root, 'listing')
+    mkdirSync(dir, { recursive: true })
+    symlinkSync(target, join(dir, 'good-link'))
+    symlinkSync(join(root, 'missing'), join(dir, 'bad-link'))
+    writeFileSync(join(dir, 'file-link-target'), 'x')
+    symlinkSync(join(dir, 'file-link-target'), join(dir, 'file-link'))
+    const r = listDirectories(dir)
+    expect(r.entries.map((e) => e.name)).toEqual(['good-link'])
+  })
+
+  test('POSIX 根目录的 parent 为 null', () => {
+    if (process.platform === 'win32') return
+    expect(listDirectories('/').parent).toBeNull()
+  })
+
+  test('错误映射：不存在 400 / 非目录 400，且都是 FsBrowseError', () => {
+    try {
+      listDirectories(join(root, 'no-such-dir'))
+      expect.unreachable()
+    } catch (e) {
+      expect(e).toBeInstanceOf(FsBrowseError)
+      expect((e as FsBrowseError).status).toBe(400)
+      expect((e as FsBrowseError).message).toContain('路径不存在')
+    }
+
+    const file = join(root, 'a-file')
+    writeFileSync(file, 'x')
+    try {
+      listDirectories(file)
+      expect.unreachable()
+    } catch (e) {
+      expect(e).toBeInstanceOf(FsBrowseError)
+      expect((e as FsBrowseError).status).toBe(400)
+      expect((e as FsBrowseError).message).toContain('不是目录')
+    }
+  })
+})

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,7 +3,7 @@
 import { appendFileSync, existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
 import { join, resolve } from 'node:path'
-import { isAuthorized, isLoopbackHost } from './auth'
+import { isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
 import { keyFor, keyForBranch, keyForNew, parseKey, splitExistingKey, type ParsedKey } from './backends/claude/backend'
 import { listSessions, liveSessionInfo, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
 import { processManager, type ApprovalDecision, type SpawnOptions } from './backends/claude/processManager'
@@ -1356,46 +1356,11 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
 
 let server: ReturnType<typeof Bun.serve<WSData>>
 
-// ---------- 跨源防护（无 token 回环部署的浏览器攻击面） ----------
+// 跨源防护的实现已移至 auth.ts（可单测）；此处仅保留启动守卫说明：
 // WebSocket 不受同源策略约束、text/plain 简单请求不触发 preflight——
 // 默认无 token 时恶意网页可经受害者浏览器直连回环服务（CSWSH/CSRF → RCE）。
 // 浏览器在 WS 握手与跨源 POST 时必定携带 Origin；非浏览器客户端（e2e 脚本/curl）不带。
-// 配置 authToken 后 token 即防线，以下检查不生效（行为与旧版完全一致）。
-
-/** Host 头去端口（兼容 [::1]:7480 形态） */
-function hostNameOf(hostHeader: string): string {
-  if (hostHeader.startsWith('[')) return hostHeader.slice(1, hostHeader.indexOf(']'))
-  const i = hostHeader.lastIndexOf(':')
-  return i > 0 ? hostHeader.slice(0, i) : hostHeader
-}
-
-function isLoopbackHostname(h: string): boolean {
-  return h === 'localhost' || h === '::1' || h.startsWith('127.')
-}
-
-/** Origin 与 Host 同 host，或同为回环（dev 模式 Vite :5173 代理到 server :7480 的端口差） */
-function originAllowed(req: Request): boolean {
-  const origin = req.headers.get('origin')
-  if (!origin) return true // 非浏览器客户端；浏览器必带 Origin
-  if (origin === 'null') return false // 沙箱 iframe / file:// 页面（浏览器特征）
-  const host = req.headers.get('host') ?? ''
-  let o: URL
-  try {
-    o = new URL(origin)
-  } catch {
-    return false
-  }
-  if (o.host === host) return true
-  return isLoopbackHostname(o.hostname) && isLoopbackHostname(hostNameOf(host))
-}
-
-/** 状态变更 /api 请求必须是 application/json——text/plain 是 preflight 豁免的 CSRF 通道 */
-function jsonContentTypeRequired(req: Request, url: URL): boolean {
-  if (req.method === 'GET' || req.method === 'HEAD') return true
-  if (!url.pathname.startsWith('/api/')) return true
-  const ct = req.headers.get('content-type')?.split(';')[0].trim()
-  return ct === 'application/json'
-}
+// 配置 authToken 后 token 即防线，这些检查不生效（行为与旧版完全一致）。
 
 // 绑定非回环地址却不配置 token = 把"任意目录起会话 + 任意命令执行"裸奔到网络上，拒绝启动
 if (!isLoopbackHost(config.host) && !config.authToken) {

--- a/server/src/push.test.ts
+++ b/server/src/push.test.ts
@@ -1,0 +1,67 @@
+// endpointAllowed 是订阅注册的 SSRF/窃听防线：inbox 事件（含审批摘要与能力 URL）
+// 会扇出给全部订阅，任意 endpoint 可注册 = 窃听全部会话通知 + 向内网盲 POST。
+import { afterEach, describe, expect, test } from 'bun:test'
+import { config } from './config'
+import { endpointAllowed } from './push'
+
+const originalAllow = config.pushAllowHosts
+
+afterEach(() => {
+  config.pushAllowHosts = originalAllow
+})
+
+describe('endpointAllowed（默认白名单）', () => {
+  test('主流推送服务及其子域放行', () => {
+    expect(endpointAllowed('https://fcm.googleapis.com/wp/abc')).toBe(true)
+    expect(endpointAllowed('https://updates.push.services.mozilla.com/wpush/v2/xyz')).toBe(true)
+    expect(endpointAllowed('https://web.push.apple.com/QmFja2VudA')).toBe(true)
+    expect(endpointAllowed('https://notify.windows.com/w/?token=1')).toBe(true)
+    expect(endpointAllowed('https://jp.notify.windows.com/w/?token=1')).toBe(true)
+  })
+
+  test('未知 https 域拒绝', () => {
+    expect(endpointAllowed('https://evil.com/push')).toBe(false)
+    expect(endpointAllowed('https://attacker.example.org/')).toBe(false)
+  })
+
+  test('非 https 一律拒绝（file/javascript 等 scheme 同样堵死）', () => {
+    expect(endpointAllowed('http://fcm.googleapis.com/wp/abc')).toBe(false)
+    expect(endpointAllowed('file:///etc/passwd')).toBe(false)
+    expect(endpointAllowed('javascript:alert(1)')).toBe(false)
+  })
+
+  test('白名单域名后缀不能伪造', () => {
+    // evilfcm.googleapis.com 不是 .fcm.googleapis.com 后缀
+    expect(endpointAllowed('https://evilfcm.googleapis.com/')).toBe(false)
+    expect(endpointAllowed('https://fcm.googleapis.com.evil.com/')).toBe(false)
+  })
+
+  test('回环 mock 不限协议（e2e/自托管调试）', () => {
+    expect(endpointAllowed('http://127.0.0.1:9001/push')).toBe(true)
+    expect(endpointAllowed('http://localhost:9001/push')).toBe(true)
+    expect(endpointAllowed('http://[::1]:9001/push')).toBe(true)
+    expect(endpointAllowed('http://127.10.20.30:9001/push')).toBe(true)
+  })
+
+  test('无法解析的 URL 拒绝', () => {
+    expect(endpointAllowed('not a url')).toBe(false)
+    expect(endpointAllowed('')).toBe(false)
+  })
+})
+
+describe('endpointAllowed（配置覆盖）', () => {
+  test("pushAllowHosts=['*'] 放行任意 https，但仍拒绝明文 http（回环除外）", () => {
+    config.pushAllowHosts = ['*']
+    expect(endpointAllowed('https://self-hosted.example.com/push')).toBe(true)
+    expect(endpointAllowed('http://self-hosted.example.com/push')).toBe(false)
+    expect(endpointAllowed('http://127.0.0.1:9001/push')).toBe(true)
+  })
+
+  test('自托管域名追加后放行，其余默认域不再生效', () => {
+    config.pushAllowHosts = ['push.internal.example.com']
+    expect(endpointAllowed('https://push.internal.example.com/sub')).toBe(true)
+    expect(endpointAllowed('https://eu.push.internal.example.com/sub')).toBe(true)
+    // 配置覆盖语义：默认列表被整体替换
+    expect(endpointAllowed('https://fcm.googleapis.com/wp/abc')).toBe(false)
+  })
+})

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -23,6 +23,7 @@ import {
 } from 'node:crypto'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { isLoopbackHostname } from './auth'
 import { config } from './config'
 
 export interface PushSubscriptionRow {
@@ -236,10 +237,6 @@ const DEFAULT_PUSH_HOSTS = [
   'notify.windows.com',
 ]
 
-function isLoopbackHostname(h: string): boolean {
-  return h === 'localhost' || h === '::1' || h.startsWith('127.')
-}
-
 export function endpointAllowed(endpoint: string): boolean {
   let u: URL
   try {
@@ -247,10 +244,11 @@ export function endpointAllowed(endpoint: string): boolean {
   } catch {
     return false
   }
+  // 本地 mock 推送服务（e2e-push/自托管调试）：回环不限协议。
+  // 必须先于 '*' 判定——否则配了 '*' 的环境反而用不了本地 mock。
+  if (isLoopbackHostname(u.hostname)) return true
   const allow = config.pushAllowHosts ?? DEFAULT_PUSH_HOSTS
   if (allow.includes('*')) return u.protocol === 'https:'
-  // 本地 mock 推送服务（e2e-push/自托管调试）：回环不限协议
-  if (isLoopbackHostname(u.hostname)) return true
   if (u.protocol !== 'https:') return false
   return allow.some((h) => u.hostname === h || u.hostname.endsWith(`.${h}`))
 }

--- a/server/src/uploads.test.ts
+++ b/server/src/uploads.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, test } from 'bun:test'
+import { rmSync } from 'node:fs'
+import { basename } from 'node:path'
+import { MAX_IMAGE_BASE64, resolveUpload, saveUpload } from './uploads'
+
+// 1x1 透明 PNG（43 字节）
+const PNG_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=='
+
+const savedPaths: string[] = []
+
+afterAll(() => {
+  for (const p of savedPaths) rmSync(p, { force: true })
+})
+
+describe('saveUpload 校验', () => {
+  test('不支持的类型拒绝', () => {
+    expect(() => saveUpload({ name: 'x', mediaType: 'image/svg+xml', dataBase64: PNG_B64 })).toThrow('不支持的图片类型')
+    expect(() => saveUpload({ name: 'x', mediaType: 'text/html', dataBase64: PNG_B64 })).toThrow('不支持的图片类型')
+  })
+
+  test('超过 5MB base64 限制拒绝', () => {
+    const big = 'A'.repeat(MAX_IMAGE_BASE64 + 1)
+    expect(() => saveUpload({ name: 'x', mediaType: 'image/png', dataBase64: big })).toThrow('超过 5MB 限制')
+  })
+
+  test('空内容拒绝', () => {
+    expect(() => saveUpload({ name: 'x', mediaType: 'image/png', dataBase64: '' })).toThrow('图片内容为空')
+  })
+})
+
+describe('saveUpload → resolveUpload 往返', () => {
+  test('hash 命名落盘，同内容重复保存幂等去重', () => {
+    const p1 = saveUpload({ name: 'a.png', mediaType: 'image/png', dataBase64: PNG_B64 })
+    savedPaths.push(p1)
+    expect(basename(p1)).toMatch(/^[0-9a-f]{16}\.png$/)
+
+    // 同名同内容不报错、不另存（hash 去重）
+    const p2 = saveUpload({ name: 'b.png', mediaType: 'image/png', dataBase64: PNG_B64 })
+    expect(p2).toBe(p1)
+
+    expect(resolveUpload(basename(p1))).toBe(p1)
+  })
+})
+
+describe('resolveUpload 边界（/api/uploads/<file> 的路径闸）', () => {
+  test('只接受 16 位 hex + 图片扩展名，遍历/注入一律 null', () => {
+    expect(resolveUpload('../config.json')).toBeNull()
+    expect(resolveUpload('..%2f..%2fvapid.json')).toBeNull()
+    expect(resolveUpload('abcdef0123456789.png/evil')).toBeNull()
+    expect(resolveUpload('abcdef0123456789.exe')).toBeNull()
+    expect(resolveUpload('abcdef0123456789.PNG')).toBeNull() // 大小写敏感，与 saveUpload 产物一致
+    expect(resolveUpload('abcdef012345678')).toBeNull() // 15 位不够
+    expect(resolveUpload('ghijkl0123456789.png')).toBeNull() // 非 hex 字符
+    expect(resolveUpload('')).toBeNull()
+  })
+
+  test('形状合法但文件不存在 → null', () => {
+    expect(resolveUpload('0000000000000000.png')).toBeNull()
+  })
+})

--- a/server/src/util.test.ts
+++ b/server/src/util.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test'
+import { errorMessage, pumpLines } from './util'
+
+function streamOf(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(c)
+      controller.close()
+    },
+  })
+}
+
+const enc = (s: string) => new TextEncoder().encode(s)
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string[]> {
+  const lines: string[] = []
+  await pumpLines(stream, (l) => lines.push(l))
+  return lines
+}
+
+describe('pumpLines（NDJSON 行泵）', () => {
+  test('单 chunk 多行按 \\n 切分', async () => {
+    expect(await collect(streamOf([enc('{"a":1}\n{"b":2}\n')]))).toEqual(['{"a":1}', '{"b":2}'])
+  })
+
+  test('一行跨多个 chunk 也能拼回', async () => {
+    expect(await collect(streamOf([enc('{"a'), enc('":1'), enc('}\n{"b":2}\n')]))).toEqual(['{"a":1}', '{"b":2}'])
+  })
+
+  test('多字节 UTF-8 字符跨 chunk 不断裂（流式解码）', async () => {
+    const full = enc('{"text":"你好，世界"}\n')
+    // 在"你"的字节中间切断（"你" = E4 BD A0）
+    const cut = full.indexOf(0xe4)
+    const lines = await collect(streamOf([full.slice(0, cut + 1), full.slice(cut + 1)]))
+    expect(lines).toEqual(['{"text":"你好，世界"}'])
+  })
+
+  test('末尾无换行的余量也会冲刷为一行', async () => {
+    expect(await collect(streamOf([enc('{"a":1}\n{"tail":true}')]))).toEqual(['{"a":1}', '{"tail":true}'])
+  })
+
+  test('空行与纯空白行被跳过', async () => {
+    expect(await collect(streamOf([enc('\n{"a":1}\n\n  \n{"b":2}\n')]))).toEqual(['{"a":1}', '{"b":2}'])
+  })
+
+  test('读取异常经 onError 上报且不抛出', async () => {
+    const boom = new Error('boom')
+    let pulled = 0
+    // pull 驱动：先吐出一条完整行，下一次读取才失败（真实进程管道断开的形态）
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pulled++ === 0) controller.enqueue(enc('{"a":1}\n'))
+        else controller.error(boom)
+      },
+    })
+    const lines: string[] = []
+    const errors: unknown[] = []
+    await pumpLines(stream, (l) => lines.push(l), (e) => errors.push(e))
+    expect(lines).toEqual(['{"a":1}'])
+    expect(errors).toEqual([boom])
+  })
+})
+
+describe('errorMessage', () => {
+  test('Error 取 message，其余 String 化', () => {
+    expect(errorMessage(new Error('失败原因'))).toBe('失败原因')
+    expect(errorMessage('字符串错误')).toBe('字符串错误')
+    expect(errorMessage(42)).toBe('42')
+    expect(errorMessage(undefined)).toBe('undefined')
+  })
+})

--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from 'bun:test'
-import { rewindPreview } from './blocks'
+import {
+  parseUserText,
+  rewindPreview,
+  shortTokens,
+  stripAnsi,
+  toolDetail,
+  toolResultText,
+  toolSummary,
+} from './blocks'
 
 describe('rewindPreview', () => {
   test('removes internal reminders and summarizes slash commands', () => {
@@ -20,5 +28,105 @@ describe('rewindPreview', () => {
     const preview = rewindPreview('这是一个很长的请求，'.repeat(30), 20)
     expect(preview.summary).toBe('这是一个很长的请求，这是一个很长的请求，…')
     expect(preview.detail.length).toBeGreaterThan(preview.summary.length)
+  })
+})
+
+describe('parseUserText', () => {
+  test('中断标记转为 interrupted 段并从正文剔除', () => {
+    expect(parseUserText('[Request interrupted by user]')).toEqual([{ kind: 'interrupted', text: '已中断' }])
+    const segs = parseUserText('做到一半[Request interrupted by user]')
+    expect(segs.map((s) => s.kind)).toContain('interrupted')
+    expect(segs.find((s) => s.kind === 'text')?.text).toBe('做到一半')
+  })
+
+  test('command-name 与 command-args 归并为一条命令段', () => {
+    expect(
+      parseUserText('<command-name>compact</command-name><command-args>focus on API</command-args>'),
+    ).toEqual([{ kind: 'command', text: '/compact', args: 'focus on API' }])
+  })
+
+  test('command-message 不重复成段（compact 回显常与 command-name 成对）', () => {
+    const segs = parseUserText('<command-message>compact</command-message><command-name>/compact</command-name>')
+    expect(segs).toEqual([{ kind: 'command', text: '/compact' }])
+  })
+
+  test('命令名补 / 前缀；裸 args 无命令时降级为文本', () => {
+    expect(parseUserText('<command-name>review</command-name>')).toEqual([{ kind: 'command', text: '/review' }])
+    expect(parseUserText('<command-args>只有参数</command-args>')).toEqual([{ kind: 'text', text: '只有参数' }])
+  })
+
+  test('local-command 输出分段并剥 ANSI 颜色码', () => {
+    const segs = parseUserText(
+      '<local-command-stdout>[32mok green[0m</local-command-stdout><local-command-stderr>[31mbad red[0m</local-command-stderr>',
+    )
+    expect(segs).toEqual([
+      { kind: 'local-out', text: 'ok green' },
+      { kind: 'local-err', text: 'bad red' },
+    ])
+  })
+
+  test('system-reminder 注入不进任何段，正文保留', () => {
+    expect(parseUserText('前<system-reminder>内部上下文</system-reminder>后')).toEqual([
+      { kind: 'text', text: '前后' },
+    ])
+  })
+})
+
+describe('toolSummary（一行摘要的字段取舍）', () => {
+  test('按工具挑首选字段', () => {
+    expect(toolSummary('Bash', { command: 'ls -la', description: '列目录' })).toBe('列目录')
+    expect(toolSummary('Bash', { command: 'ls -la' })).toBe('ls -la')
+    expect(toolSummary('Read', { file_path: '/a/b.ts' })).toBe('/a/b.ts')
+    expect(toolSummary('Edit', { file_path: '/a/b.ts' })).toBe('/a/b.ts')
+    expect(toolSummary('Grep', { pattern: 'TODO' })).toBe('TODO')
+    expect(toolSummary('WebSearch', { query: 'bun bug' })).toBe('bun bug')
+    expect(toolSummary('WebFetch', { url: 'https://x.com' })).toBe('https://x.com')
+    expect(toolSummary('Agent', { description: '扫描仓库' })).toBe('扫描仓库')
+  })
+
+  test('超长截断加省略号；未知工具回退 JSON', () => {
+    expect(toolSummary('Read', { file_path: 'x'.repeat(200) })).toBe('x'.repeat(120) + '…')
+    expect(toolSummary('mcp:foo', { a: 1 })).toBe('{"a":1}')
+    expect(toolSummary('mcp:foo', { big: 'y'.repeat(200) }).length).toBe(121)
+  })
+})
+
+describe('toolDetail（折叠区的完整内容）', () => {
+  test('Bash 给命令本体', () => {
+    expect(toolDetail('Bash', { command: 'git status' })).toBe('git status')
+  })
+  test('Edit 拼 文件 + 旧/新 对照', () => {
+    expect(toolDetail('Edit', { file_path: '/a.ts', old_string: 'old', new_string: 'new' })).toBe(
+      '# /a.ts\n\n--- 旧\nold\n\n+++ 新\nnew',
+    )
+  })
+  test('Write 拼 文件 + 内容；缺字段不留空行', () => {
+    expect(toolDetail('Write', { file_path: '/a.ts', content: 'body' })).toBe('# /a.ts\n\nbody')
+    expect(toolDetail('Write', { content: 'body' })).toBe('body')
+  })
+  test('未知工具回退格式化 JSON', () => {
+    expect(toolDetail('mcp:foo', { a: 1 })).toBe('{\n  "a": 1\n}')
+  })
+})
+
+describe('toolResultText / stripAnsi / shortTokens', () => {
+  test('tool_result content 的 string 与块数组两种形态', () => {
+    expect(toolResultText('纯文本')).toBe('纯文本')
+    expect(toolResultText([{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }])).toBe('ab')
+    expect(toolResultText([{ type: 'image' }, { type: 'text', text: 'x' }])).toBe('x')
+    expect(toolResultText(undefined)).toBe('')
+    expect(toolResultText(42)).toBe('')
+  })
+
+  test('stripAnsi 只剥转义序列不伤正文', () => {
+    expect(stripAnsi('[1;31m红色[0m 普通')).toBe('红色 普通')
+    expect(stripAnsi('没有颜色')).toBe('没有颜色')
+  })
+
+  test('shortTokens 千位缩写', () => {
+    expect(shortTokens(undefined)).toBe('?')
+    expect(shortTokens(999)).toBe('999')
+    expect(shortTokens(1000)).toBe('1k')
+    expect(shortTokens(231952)).toBe('232k')
   })
 })

--- a/web/src/lib/key.test.ts
+++ b/web/src/lib/key.test.ts
@@ -1,0 +1,66 @@
+// 前端 key 形状判断与服务端 backends/*/backend.ts 的编码一一对应；
+// sessionFromKey 是深链（#s=<key>）与归档后导航的兜底构造，损坏编码必须返回 null 而非炸掉导航。
+import { describe, expect, test } from 'bun:test'
+import { isCodexKey, isExistingKey, sessionFromKey, slugOf } from './key'
+
+describe('isCodexKey / isExistingKey', () => {
+  test('codex：x| 与 xn|', () => {
+    expect(isCodexKey('x|thread-1')).toBe(true)
+    expect(isCodexKey('xn|%2Ftmp')).toBe(true)
+    expect(isCodexKey('s|slug|sid')).toBe(false)
+    expect(isCodexKey('n|%2Ftmp')).toBe(false)
+    expect(isCodexKey('b|%2Ftmp|sid')).toBe(false)
+  })
+
+  test('已存在会话（有历史可读）：s| x| b|', () => {
+    expect(isExistingKey('s|slug|sid')).toBe(true)
+    expect(isExistingKey('x|thread-1')).toBe(true)
+    expect(isExistingKey('b|%2Ftmp|sid')).toBe(true)
+    expect(isExistingKey('n|%2Ftmp')).toBe(false)
+    expect(isExistingKey('xn|%2Ftmp')).toBe(false)
+  })
+})
+
+describe('slugOf（与服务端 discovery.sanitizePath 一致）', () => {
+  test('非字母数字全部转 -', () => {
+    expect(slugOf('/data/workspace/cc-remote')).toBe('-data-workspace-cc-remote')
+    expect(slugOf('C:\\Users\\name\\项目')).toBe('C--Users-name---')
+  })
+})
+
+describe('sessionFromKey', () => {
+  test('s| 三段式 → claude 离线会话', () => {
+    const s = sessionFromKey('s|-data-workspace|01a03cac-3fdc-7b80-9c5d-f14ba518f4dc')
+    expect(s).toMatchObject({
+      slug: '-data-workspace',
+      sessionId: '01a03cac-3fdc-7b80-9c5d-f14ba518f4dc',
+      status: 'offline',
+      backend: 'claude',
+    })
+  })
+
+  test('x| 两段式 → codex 离线线程', () => {
+    const s = sessionFromKey('x|thread-9')
+    expect(s).toMatchObject({ sessionId: 'thread-9', backend: 'codex', status: 'offline' })
+  })
+
+  test('b| 三段式 → 懒分叉：cwd 解码 + slug 重算', () => {
+    const s = sessionFromKey('b|%2Fdata%2Fworkspace%2Fcc-remote|source-sid')
+    expect(s).toMatchObject({
+      cwd: '/data/workspace/cc-remote',
+      slug: '-data-workspace-cc-remote',
+      sessionId: 'source-sid',
+      backend: 'claude',
+    })
+  })
+
+  test('非法形状与损坏编码 → null', () => {
+    expect(sessionFromKey('n|%2Ftmp')).toBeNull() // 新会话没有历史可兜底
+    expect(sessionFromKey('xn|%2Ftmp')).toBeNull()
+    expect(sessionFromKey('s|only-two')).toBeNull()
+    expect(sessionFromKey('x|a|b')).toBeNull()
+    expect(sessionFromKey('whatever')).toBeNull()
+    expect(sessionFromKey('')).toBeNull()
+    expect(sessionFromKey('b|%E4%B8|sid')).toBeNull() // 截断的百分号编码
+  })
+})


### PR DESCRIPTION
## 概要

为代码库中测试覆盖不足的核心区域补齐单元测试：**38 → 153 个用例（8 → 19 个文件）**。测试驱动过程中发现并修复了 4 个真实缺陷。

### 新增 11 个测试文件

- **codex 翻译边界**（此前零覆盖的最关键路径）
  - `translate.test.ts` — live 事件序（assistant 快照先于 message_stop）、tool_use/tool_result 按 id 配对、reasoning summary/content 镜像去重、历史首条 userMessage 的 rewindable 锚点（/rewind 定位）
  - `runtime.test.ts` — 权限模式映射（claude 名称 ↔ codex 预设 → approvalPolicy+sandbox；kebab-case `sandbox` 与 camelCase `sandboxPolicy` 的 wire 枚举双轨）
  - `backend.test.ts` — sessionKey 编码/解析，损坏百分号编码按 null 容错
  - `reasoningStore.test.ts` — 思考侧车落盘往返与坏行容忍
- **安全边界**
  - `auth.test.ts` — token 校验（Bearer/query）+ 跨源防护全矩阵（Origin: null、双回环跨端口、恶意跨源、CSRF content-type 通道）
  - `push.test.ts` — endpoint 白名单（订阅注册 SSRF/通知窃听防护）：默认主流推送服务、子域匹配、域名后缀伪造、`*` 通配、回环 mock
  - `uploads.test.ts` — saveUpload 类型/大小/空内容校验、hash 幂等去重、resolveUpload 路径遍历闸
- **基础设施**
  - `archive.test.ts` — 回收站归档/恢复/同名冲突守卫（jsonl + subagents 目录整体移动）
  - `fsbrowse.test.ts` — readGitBranch（普通/detached/worktree gitdir 指针）、listDirectories 错误映射与符号链接
  - `util.test.ts` — pumpLines NDJSON 行泵（多字节 UTF-8 跨 chunk 不断裂、余量冲刷、异常经 onError 不抛出）
  - `web/lib/key.test.ts` — 深链 sessionFromKey 兜底构造与损坏编码容错

### 扩展 3 个测试文件

- `discovery.test.ts` — entryToHistoryMessage（sidechain 过滤/compact_boundary 双命名元数据/块映射）与 isSelectableRewindTarget 内部标签表
- `blocks.test.ts` — parseUserText（命令归并/ANSI 剥离/interrupted 段）、toolSummary/toolDetail 字段取舍、toolResultText 双形态、shortTokens

### 测试驱动的顺带修复（行为变更均有用例锁定）

1. **auth.ts**：`isLoopbackHostname` 兼容 WHATWG URL 的 IPv6 方括号形态——`new URL('http://[::1]:9001/x').hostname` 为 `[::1]`，此前漏判回环，`originAllowed` 会误拒 IPv6 dev 源、`endpointAllowed` 误拒 IPv6 回环 mock
2. **push.ts**：`endpointAllowed` 回环 mock 豁免提前到 `*` 判定之前——配置 `pushAllowHosts: ['*']` 的环境此前反而用不了本地 mock；同时去除与 auth.ts 重复的 `isLoopbackHostname` 实现
3. **archive.ts**：`renameSync` 跨文件系统 EXDEV 兜底（copy+rm）——`CLAUDE_CONFIG_DIR` 可指向与 `~/.cc-remote` 不同的挂载点，此前归档直接失败
4. **index.ts → auth.ts**：跨源防护纯函数（`originAllowed`/`jsonContentTypeRequired`/`hostNameOf`/`isLoopbackHostname`）移入 auth.ts 以便单测，行为不变

### 现有测试删除评审

逐一评审了已有 8 个测试文件：均锚定真实行为（processManager 回收闸、splitExistingKey 路径遍历、协议过滤保真、gateway 敌对输入解析等），**没有"不应存在或无实际意义"的测试，本次未删除任何文件**。

### 验证

- `bun test`：**153 pass / 0 fail**（基线 38）
- `bunx tsc --noEmit`：无新增错误（`scripts/gateway.ts` 4 个错误为 master 基线历史遗留）
- `bun run build`：通过
- 已 rebase 到最新 origin/master（含 #2 死代码清理），无冲突