### PR TITLE
refactor: 全仓库 /simplify 复用与简化清理

### DIFF
--- a/scripts/fetch-claude-docs.ts
+++ b/scripts/fetch-claude-docs.ts
@@ -5,6 +5,7 @@
  */
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join, relative } from 'node:path'
+import { errorMessage } from '../server/src/util'
 
 const BASE = 'https://code.claude.com/docs'
 const OUT = join(import.meta.dir, '..', 'docs', 'claude-code')
@@ -47,7 +48,7 @@ async function mapPool<T>(
         await fn(items[i]!, i)
         ok++
       } catch (e) {
-        fail.push({ item: items[i]!, err: e instanceof Error ? e.message : String(e) })
+        fail.push({ item: items[i]!, err: errorMessage(e) })
       }
     }
   }

--- a/scripts/gateway.ts
+++ b/scripts/gateway.ts
@@ -13,6 +13,7 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { detectProtocol, isOwnGatewayCmd, modeCookie, parseSsListenPids, pickMode, type Mode } from './gateway-lib'
+import { errorMessage } from '../server/src/util'
 
 type GatewayCfg = {
   httpPort: number
@@ -226,7 +227,7 @@ async function proxyHttp(req: Request, target: string, proto: string, mode: Mode
     headers.set('x-cc-remote-mode', mode)
     return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers })
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
+    const msg = errorMessage(e)
     const isDev = mode === 'dev'
     return htmlPage(
       '502 后端未就绪',
@@ -522,7 +523,7 @@ function startMux(
     },
   })
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
+    const msg = errorMessage(e)
     console.error(`[gateway] 监听 0.0.0.0:${publicPort} 失败：${msg}`)
     if (msg.includes('EADDRINUSE') || msg.includes('Failed to listen')) {
       console.error('[gateway] 端口仍被占用。默认会替换上一份 scripts/gateway.ts；其它进程请用 --no-replace 查看后手动处理。')

--- a/server/scripts/e2e-branch-btw-goal.ts
+++ b/server/scripts/e2e-branch-btw-goal.ts
@@ -41,7 +41,7 @@ a.on((ev) => {
   if (ev.kind === 'cli' && (ev.msg as { type?: string }).type === 'result') turnDone = true
 })
 a.send({ kind: 'user', text: '记住暗号「星河战舰」，只回复「收到」两个字。' })
-for (let i = 0; i < 120 && !turnDone; i++) await new Promise((r) => setTimeout(r, 1000))
+for (let i = 0; i < 120 && !turnDone; i++) await Bun.sleep(1000)
 note(turnDone && !!sessionId, '源会话建立上下文', `sessionId=${sessionId.slice(0, 8)}`)
 
 // ---------- 2. btw：side_question 通道 ----------
@@ -57,7 +57,7 @@ a.on((ev) => {
   }
 })
 a.send({ kind: 'btw', question: '我刚才给你的暗号是什么？只回答暗号本身。' })
-for (let i = 0; i < 90 && !btwText; i++) await new Promise((r) => setTimeout(r, 1000))
+for (let i = 0; i < 90 && !btwText; i++) await Bun.sleep(1000)
 note(btwOk && btwText.includes('星河战舰'), 'btw 侧问（side_question）', `${btwAt}ms, 答=${btwText.slice(0, 30)}`)
 
 // ---------- 3. branch：懒分叉 ----------
@@ -68,7 +68,7 @@ a.on((ev) => {
   }
 })
 a.send({ kind: 'branch' })
-for (let i = 0; i < 10 && !branchKey; i++) await new Promise((r) => setTimeout(r, 500))
+for (let i = 0; i < 10 && !branchKey; i++) await Bun.sleep(500)
 note(branchKey.startsWith('b|'), 'branch 创建 b| key', branchKey ? decodeURIComponent(branchKey.split('|')[1]) + '|…' : '无')
 
 // 分支会话发消息：应触发 --fork-session spawn，且继承暗号上下文
@@ -91,7 +91,7 @@ b.on((ev) => {
   }
 })
 b.send({ kind: 'user', text: '源会话里我给的暗号是什么？只回答暗号。' })
-for (let i = 0; i < 120 && !bDone; i++) await new Promise((r) => setTimeout(r, 1000))
+for (let i = 0; i < 120 && !bDone; i++) await Bun.sleep(1000)
 const forkedNewId = bSessionId && bSessionId !== sessionId
 note(bDone && forkedNewId && bAnswer.includes('星河战舰'), '分支 fork 启动且继承上下文', `新 sid=${bSessionId.slice(0, 8)} 答=${bAnswer.slice(-30)}`)
 
@@ -106,11 +106,11 @@ a.on((ev) => {
   }
 })
 a.send({ kind: 'user', text: '/goal 测试目标：只回复一次「达成」即完成' })
-for (let i = 0; i < 30 && !goalSeen; i++) await new Promise((r) => setTimeout(r, 500))
+for (let i = 0; i < 30 && !goalSeen; i++) await Bun.sleep(500)
 note(goalSeen, '/goal 状态进入 status.goal')
 // goal 循环跑完（result 到达）后 chip 应清除
 turnDone = false
-for (let i = 0; i < 150 && !goalCleared; i++) await new Promise((r) => setTimeout(r, 1000))
+for (let i = 0; i < 150 && !goalCleared; i++) await Bun.sleep(1000)
 note(goalCleared, 'goal 完成后 status.goal 清除')
 
 clearTimeout(timeout)

--- a/server/scripts/e2e-clear.ts
+++ b/server/scripts/e2e-clear.ts
@@ -45,13 +45,13 @@ ws.onmessage = (e) => {
 }
 await new Promise<void>((r) => (ws.onopen = () => r()))
 ws.send(JSON.stringify({ kind: 'attach' }))
-await new Promise((r) => setTimeout(r, 400))
+await Bun.sleep(400)
 
 // 等 result 的稳健助手
 async function awaitResult(fromIndex: number, ms: number): Promise<boolean> {
   for (let i = 0; i < ms / 500; i++) {
     if (events.slice(fromIndex).some((e) => e.kind === 'result')) return true
-    await new Promise((r) => setTimeout(r, 500))
+    await Bun.sleep(500)
   }
   return false
 }
@@ -64,7 +64,7 @@ note(await awaitResult(idx, 150_000), 'clear 前：上下文建立')
 // 2. /clear
 idx = events.length
 ws.send(JSON.stringify({ kind: 'user', text: '/clear' }))
-for (let i = 0; i < 60 && !movedKey; i++) await new Promise((r) => setTimeout(r, 500))
+for (let i = 0; i < 60 && !movedKey; i++) await Bun.sleep(500)
 note(movedKey.startsWith('s|'), 'clear 触发 moved（Hub 重键）', movedKey.split('|').pop()?.slice(0, 8))
 // clear 自身的 result（空回合）收掉
 await awaitResult(idx, 30_000)

--- a/server/scripts/e2e-codex-cmds.ts
+++ b/server/scripts/e2e-codex-cmds.ts
@@ -29,21 +29,21 @@ const timeout = setTimeout(() => {
   }
   await new Promise<void>((r) => (ws.onopen = () => r()))
   ws.send(JSON.stringify({ kind: 'attach' }))
-  await new Promise((r) => setTimeout(r, 400))
+  await Bun.sleep(400)
   ws.send(JSON.stringify({ kind: 'user', text: '只回复「就绪」两个字。' }))
-  for (let i = 0; i < 120 && !turnDone; i++) await new Promise((r) => setTimeout(r, 1000))
+  for (let i = 0; i < 120 && !turnDone; i++) await Bun.sleep(1000)
   note(turnDone && !!threadId, 'codex 线程就绪', threadId.slice(0, 8))
 
   // rename
   ws.send(JSON.stringify({ kind: 'control', subtype: 'rename', extra: { name: 'e2e-命令测试线程' } }))
-  await new Promise((r) => setTimeout(r, 2000))
+  await Bun.sleep(2000)
   note(!errors.some((e) => e.includes('重命名')), 'codex /rename（thread/name/set）无报错')
 
   // review（custom 目标：/tmp 不是 git 仓库，uncommittedChanges 会报错）
   errors = []
   turnDone = false
   ws.send(JSON.stringify({ kind: 'control', subtype: 'review', extra: { instructions: '检查 /tmp/ccr-push-test.txt 是否存在并评价这个测试文件的用途（一句话）' } }))
-  for (let i = 0; i < 150 && !turnDone; i++) await new Promise((r) => setTimeout(r, 1000))
+  for (let i = 0; i < 150 && !turnDone; i++) await Bun.sleep(1000)
   note(turnDone && !errors.some((e) => e.includes('审查')), 'codex /review（review/start custom inline）完成一轮', errors[0]?.slice(0, 60) ?? '')
   ws.close()
 }

--- a/server/scripts/e2e-codex-goal.ts
+++ b/server/scripts/e2e-codex-goal.ts
@@ -33,15 +33,15 @@ handlers.push((ev) => {
 })
 
 send({ kind: 'user', text: '只回复「就绪」两个字。' })
-for (let i = 0; i < 120 && !turnDone; i++) await new Promise((r) => setTimeout(r, 1000))
+for (let i = 0; i < 120 && !turnDone; i++) await Bun.sleep(1000)
 note(turnDone && !!threadId, 'codex 线程就绪', threadId.slice(0, 8))
 
 send({ kind: 'control', subtype: 'set_goal', extra: { objective: '验证目标：回复一次「好」即达成' } })
-for (let i = 0; i < 40 && !goalSeen; i++) await new Promise((r) => setTimeout(r, 500))
+for (let i = 0; i < 40 && !goalSeen; i++) await Bun.sleep(500)
 note(goalSeen.includes('验证目标'), 'thread/goal/set → status.goal', goalSeen.slice(0, 20))
 
 send({ kind: 'control', subtype: 'clear_goal' })
-for (let i = 0; i < 40 && !goalCleared; i++) await new Promise((r) => setTimeout(r, 500))
+for (let i = 0; i < 40 && !goalCleared; i++) await Bun.sleep(500)
 note(goalCleared, 'thread/goal/clear → status.goal 清除')
 
 clearTimeout(timeout)

--- a/server/scripts/e2e-push.ts
+++ b/server/scripts/e2e-push.ts
@@ -125,7 +125,7 @@ try {
   }
   await new Promise<void>((r) => (ws.onopen = () => r()))
   ws.send(JSON.stringify({ kind: 'attach' }))
-  await new Promise((r) => setTimeout(r, 500))
+  await Bun.sleep(500)
   ws.send(
     JSON.stringify({
       kind: 'user',
@@ -136,7 +136,7 @@ try {
   // 3. 等推送到达 mock（审批事件 → fanout）
   let push: Captured | undefined
   for (let i = 0; i < 120 && !push; i++) {
-    await new Promise((r) => setTimeout(r, 1000))
+    await Bun.sleep(1000)
     push = captured.get('/push/A')
   }
   note(!!push, '审批事件触发推送到 mock push service')
@@ -184,7 +184,7 @@ try {
   const allowResp = await fetch(`${BASE}${payload.actions!.allow}`, { method: 'POST' })
   const allowJson = (await allowResp.json()) as { ok: boolean; error?: string }
   note(allowResp.ok && allowJson.ok, '能力 URL 直接审批生效', `HTTP ${allowResp.status}`)
-  for (let i = 0; i < 10 && !sawResolvedEvent; i++) await new Promise((r) => setTimeout(r, 500))
+  for (let i = 0; i < 10 && !sawResolvedEvent; i++) await Bun.sleep(500)
   note(sawResolvedEvent, 'WS 侧收到 approval_resolved（审批卡同步消失）')
   resolved = true
 
@@ -206,7 +206,7 @@ try {
   ws.send(JSON.stringify({ kind: 'user', text: '再用 Write 把文件 /tmp/ccr-push-test2.txt 内容写成 push-ok2。只做这一件事。' }))
   let pushB: Captured | undefined
   for (let i = 0; i < 120 && !pushB; i++) {
-    await new Promise((r) => setTimeout(r, 1000))
+    await Bun.sleep(1000)
     pushB = captured.get('/push/B')
   }
   note(!!pushB, '第二次审批推送也发到 B（投递了但收到 410）')
@@ -216,7 +216,7 @@ try {
     const p2 = JSON.parse(decryptPush(push2.body, uaPrivJwk, uaPubRaw, auth)) as { actions?: { allow: string } }
     if (p2.actions) await fetch(`${BASE}${p2.actions.allow}`, { method: 'POST' })
   }
-  await new Promise((r) => setTimeout(r, 1500))
+  await Bun.sleep(1500)
   const countAfter = ((await (await fetch(`${BASE}/api/push/public-key`)).json()) as { subscriptions: number }).subscriptions
   note(countAfter === countBefore - 1, '410 死订阅自动摘除', `${countBefore} → ${countAfter}`)
 

--- a/server/scripts/lab-run.ts
+++ b/server/scripts/lab-run.ts
@@ -163,7 +163,7 @@ function sendMsg(m: Record<string, unknown>) {
 async function run() {
   for (const step of steps) {
     if ('wait_ms' in step) {
-      await new Promise((r) => setTimeout(r, step.wait_ms))
+      await Bun.sleep(step.wait_ms)
     } else if ('send' in step) {
       sendMsg(step.send)
     } else if ('wait_for' in step) {
@@ -178,7 +178,7 @@ async function run() {
     }
   }
   // 等 result 后稍等收尾再退出
-  await new Promise((r) => setTimeout(r, 1500))
+  await Bun.sleep(1500)
   child.stdin!.end()
   setTimeout(() => child.kill(), 3000)
 }

--- a/server/scripts/smoke.ts
+++ b/server/scripts/smoke.ts
@@ -2,6 +2,7 @@
 // 用法：bun run server/scripts/smoke.ts [cwd]
 import { resolveClaudeCommand } from '../src/backends/claude/processManager'
 import { controlRequest, userMessage } from '../src/backends/claude/protocol'
+import { pumpLines } from '../src/util'
 
 const cwd = process.argv[2] ?? process.cwd()
 const { cmd, prefix } = resolveClaudeCommand()
@@ -21,9 +22,6 @@ const proc = Bun.spawn(
 )
 
 let gotResult = false
-let buf = ''
-const decoder = new TextDecoder()
-const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader()
 
 const timeout = setTimeout(() => {
   console.error('TIMEOUT: 120s 内未收到 result')
@@ -31,43 +29,35 @@ const timeout = setTimeout(() => {
   process.exit(1)
 }, 120_000)
 
-async function pump() {
-  for (;;) {
-    const { done, value } = await reader.read()
-    if (done) break
-    buf += decoder.decode(value, { stream: true })
-    let idx: number
-    while ((idx = buf.indexOf('\n')) >= 0) {
-      const line = buf.slice(0, idx).trim()
-      buf = buf.slice(idx + 1)
-      if (!line) continue
-      try {
-        const msg = JSON.parse(line)
-        const brief =
-          msg.type === 'assistant'
-            ? `assistant: ${JSON.stringify(msg.message?.content)?.slice(0, 200)}`
-            : msg.type === 'system'
-              ? `system/${msg.subtype} session=${msg.session_id}`
-              : `${msg.type}${msg.subtype ? '/' + msg.subtype : ''}`
-        console.log('<<', brief)
-        if (msg.type === 'result') {
-          gotResult = true
-          clearTimeout(timeout)
-          proc.kill()
-          process.exit(0)
-        }
-      } catch {
-        console.log('<< (non-json)', line.slice(0, 120))
+await pumpLines(
+  proc.stdout as ReadableStream<Uint8Array>,
+  (line) => {
+    try {
+      const msg = JSON.parse(line)
+      const brief =
+        msg.type === 'assistant'
+          ? `assistant: ${JSON.stringify(msg.message?.content)?.slice(0, 200)}`
+          : msg.type === 'system'
+            ? `system/${msg.subtype} session=${msg.session_id}`
+            : `${msg.type}${msg.subtype ? '/' + msg.subtype : ''}`
+      console.log('<<', brief)
+      if (msg.type === 'result') {
+        gotResult = true
+        clearTimeout(timeout)
+        proc.kill()
+        process.exit(0)
       }
+    } catch {
+      console.log('<< (non-json)', line.slice(0, 120))
     }
-  }
-}
-void pump()
-void new Response(proc.stderr as ReadableStream<Uint8Array>).text().then((t) => {
+  },
+  (e) => console.error('[smoke] stdout 读取异常:', e),
+)
+proc.stderr && void new Response(proc.stderr as ReadableStream<Uint8Array>).text().then((t) => {
   if (t.trim()) console.error('[stderr]', t.slice(0, 2000))
 })
 
 // 等 init 后发送
-await new Promise((r) => setTimeout(r, 3000))
+await Bun.sleep(3000)
 console.log('>> user: 用两个字回答：1+1等于几？')
 proc.stdin.write(JSON.stringify(userMessage('用两个字回答：1+1等于几？')) + '\n')

--- a/server/src/backends/codex/translate.ts
+++ b/server/src/backends/codex/translate.ts
@@ -5,6 +5,7 @@
 import type { CliMessage } from '../claude/protocol'
 import type { HistoryBlock, HistoryMessage } from '../types'
 import { resolveUpload } from '../../uploads'
+import { basename } from 'node:path'
 
 // ---------- 通知 → CliMessage（live 流） ----------
 
@@ -350,7 +351,7 @@ function userInputBlocks(content: unknown): HistoryBlock[] {
     if (c.type === 'text' && typeof c.text === 'string') {
       texts.push(c.text)
     } else if (c.type === 'image' || c.type === 'localImage') {
-      const base = typeof c.path === 'string' ? (c.path.split('/').pop() ?? '') : ''
+      const base = typeof c.path === 'string' ? basename(c.path) : ''
       if (base && resolveUpload(base)) images.push({ kind: 'image', src: `/api/uploads/${base}` })
       else texts.push('[图片]')
     } else if (c.type === 'audio' || c.type === 'localAudio') {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,7 +2,7 @@
 
 import { appendFileSync, existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
-import { join, resolve } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 import { isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
 import { keyFor, keyForBranch, keyForNew, parseKey, splitExistingKey, type ParsedKey } from './backends/claude/backend'
 import { listSessions, liveSessionInfo, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
@@ -123,13 +123,12 @@ function publishInbox(ev: InboxEvent): void {
  *  避免推送事件触发反复 listSessions 全盘扫描）；b|/n|/xn| 的 cwd 内嵌在 key 里直接取。
  *  parseKey 也查不到（slug 目录已删）时以 slug 末段近似。 */
 function sessionNameOf(key: string): string {
-  const base = (cwd: string) => cwd.replace(/\/+$/, '').split('/').pop() ?? cwd
   const hub = hubs.get(key)
-  if (hub?.spawnOpts?.cwd) return base(hub.spawnOpts.cwd)
+  if (hub?.spawnOpts?.cwd) return basename(hub.spawnOpts.cwd)
   const parts = key.split('|')
   try {
     if ((parts[0] === 'b' || parts[0] === 'n' || parts[0] === 'xn') && parts[1]) {
-      return base(decodeURIComponent(parts[1]))
+      return basename(decodeURIComponent(parts[1]))
     }
   } catch {
     // key 内嵌 cwd 不是合法 URI 编码（状态损坏/构造输入）：落 key 截断，不影响推送分发
@@ -137,7 +136,7 @@ function sessionNameOf(key: string): string {
   }
   if (parts[0] === 's') {
     if (hub && hub.nameCwd === undefined) hub.nameCwd = parseKey(key)?.cwd ?? ''
-    if (hub?.nameCwd) return base(hub.nameCwd)
+    if (hub?.nameCwd) return basename(hub.nameCwd)
     // slug 是 sanitizePath(cwd)：末段即目录名（近似，仅推送显示用）
     if (parts[1]) return parts[1].split('-').pop() ?? key.slice(0, 18)
   }
@@ -618,7 +617,7 @@ function handleClientMessage(hub: Hub, raw: string): void {
       // 若客户端显式传 warm:true，则预热 resume（用于主动续聊）。
       // codex：x| 会话 attach 即 resume（订阅实时事件）；xn| 新会话保持懒启动。
       if (isCodexKey(hub.key)) {
-        if (data.warm === true || data.opts || hub.key.startsWith('x|')) {
+        if (data.warm === true || data.opts || splitThreadId(hub.key)) {
           void ensureCodexSession(hub, data.opts as Partial<SpawnOptions> | undefined)
         } else {
           pushStatus(hub)
@@ -1081,11 +1080,13 @@ function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detail: Hand
             : undefined
       const fromResolvedKey = (() => {
         if (fromBackend === 'claude') {
-          if (fromKey.startsWith('s|')) return fromKey
+          const existing = splitExistingKey(fromKey)
+          if (existing) return keyFor(existing.slug, existing.sessionId)
           const sidNow = processManager.get(fromKey)?.sessionId
           return sidNow ? keyFor(sanitizePath(sourceCwd), sidNow) : undefined
         }
-        if (fromKey.startsWith('x|')) return fromKey
+        const threadId = splitThreadId(fromKey)
+        if (threadId) return keyFor(threadId)
         const tidNow = codexRuntime.get(fromKey)?.sessionId
         return tidNow ? `x|${tidNow}` : undefined
       })()
@@ -1270,7 +1271,7 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
         managed: codexStatusOf(t.key),
       }))
     } catch (e) {
-      console.warn('[api] codex thread/list 失败（仅返回 claude 会话）:', e instanceof Error ? e.message : e)
+      console.warn('[api] codex thread/list 失败（仅返回 claude 会话）:', errorMessage(e))
     }
     return json([...codexRows, ...claudeRows])
   }
@@ -1357,7 +1358,7 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
         mtime: Number(t.updatedAt ?? t.createdAt ?? 0) * 1000,
       }))
     } catch (e) {
-      console.warn('[api] codex archived 列表失败:', e instanceof Error ? e.message : e)
+      console.warn('[api] codex archived 列表失败:', errorMessage(e))
     }
     return json({ entries: [...codexArchived, ...claudeTrash] })
   }
@@ -1413,19 +1414,30 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
     for (const r of records) {
       for (const k of [r.fromKey, r.toKey, r.fromResolvedKey, r.toResolvedKey]) {
         if (!k || nodes[k]) continue
-        const parts = k.split('|')
-        if (parts[0] === 's' && parts.length === 3) {
-          nodes[k] = { key: k, backend: 'claude', slug: parts[1], sessionId: parts[2], cwd: r.cwd }
-        } else if (parts[0] === 'x' && parts.length === 2) {
-          nodes[k] = { key: k, backend: 'codex', slug: 'codex', sessionId: parts[1], cwd: r.cwd }
-        } else if (parts[0] === 'n' || parts[0] === 'xn') {
+        const existing = splitExistingKey(k)
+        if (existing) {
+          nodes[k] = { key: k, backend: 'claude', slug: existing.slug, sessionId: existing.sessionId, cwd: r.cwd }
+          continue
+        }
+        const threadId = splitThreadId(k)
+        if (threadId) {
+          nodes[k] = { key: k, backend: 'codex', slug: 'codex', sessionId: threadId, cwd: r.cwd }
+          continue
+        }
+        const claudeParsed = parseKey(k)
+        if (claudeParsed?.cwd) {
           nodes[k] = {
             key: k,
-            backend: parts[0] === 'xn' ? 'codex' : 'claude',
-            slug: parts[0] === 'xn' ? 'codex' : sanitizePath(decodeURIComponent(parts[1] ?? '')),
-            sessionId: 'new',
+            backend: 'claude',
+            slug: sanitizePath(claudeParsed.cwd),
+            sessionId: claudeParsed.forkFromSessionId ?? 'new',
             cwd: r.cwd,
           }
+          continue
+        }
+        const codexParsed = codexParseKey(k)
+        if (codexParsed?.cwd) {
+          nodes[k] = { key: k, backend: 'codex', slug: 'codex', sessionId: 'new', cwd: r.cwd }
         }
       }
     }

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -25,6 +25,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { isLoopbackHostname } from './auth'
 import { config, type PushWebhookConfig } from './config'
+import { errorMessage } from './util'
 
 export interface PushSubscriptionRow {
   endpoint: string
@@ -310,7 +311,7 @@ export async function pushToAll(payload: PushPayload): Promise<{ sent: number; p
           console.warn(`[push] 投递失败 (HTTP ${status})：${row.endpoint.slice(0, 60)}`)
         }
       } catch (e) {
-        console.warn(`[push] 投递失败 (network):`, e instanceof Error ? e.message : e)
+        console.warn(`[push] 投递失败 (network):`, errorMessage(e))
       }
     }),
   )
@@ -470,7 +471,7 @@ export async function pushWebhooksToAll(payload: PushPayload): Promise<{ sent: n
           console.warn(`[push] webhook ${webhookId(wh)} 投递失败 (HTTP ${status})`)
         }
       } catch (e) {
-        console.warn(`[push] webhook ${webhookId(wh)} 投递失败:`, e instanceof Error ? e.message : e)
+        console.warn(`[push] webhook ${webhookId(wh)} 投递失败:`, errorMessage(e))
       }
     }),
   )

--- a/web/src/components/ApprovalCard.tsx
+++ b/web/src/components/ApprovalCard.tsx
@@ -8,6 +8,7 @@ import {
   type AskUserQuestionSelections,
   withAskUserQuestionAnswers,
 } from '../lib/askUserQuestion'
+import { toolDetail } from '../lib/blocks'
 
 export function ApprovalCard(props: {
   approval: { requestId: string; toolName: string; input: unknown }
@@ -17,7 +18,7 @@ export function ApprovalCard(props: {
   const askUserQuestion = approval.toolName === 'AskUserQuestion' ? parseAskUserQuestionInput(approval.input) : null
   if (askUserQuestion) return <AskUserQuestionCard input={askUserQuestion} onDecision={onDecision} />
 
-  const inputStr = JSON.stringify(approval.input, null, 2) ?? ''
+  const inputStr = toolDetail(approval.toolName, approval.input)
 
   return (
     <div className="my-3 rounded-lg border border-busy/50 bg-busy/5">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,7 +5,7 @@ import { authHeaders, notifyAuthRequired } from './auth'
 /** 401 时抛出；App 层会显示令牌输入页，调用方静默忽略即可 */
 export class AuthRequiredError extends Error {}
 
-async function apiFetch(input: string, init?: RequestInit): Promise<Response> {
+export async function apiFetch(input: string, init?: RequestInit): Promise<Response> {
   const r = await fetch(input, {
     ...init,
     headers: { ...authHeaders(), ...(init?.headers ?? {}) },
@@ -18,7 +18,7 @@ async function apiFetch(input: string, init?: RequestInit): Promise<Response> {
 }
 
 /** 非 2xx 应答 → Error：优先服务端的 {error} 字段（空串视同缺失），兜底 HTTP 状态码 */
-async function apiError(r: Response): Promise<Error> {
+export async function apiError(r: Response): Promise<Error> {
   const body = (await r.json().catch(() => null)) as { error?: string } | null
   return new Error(body?.error || `HTTP ${r.status}`)
 }

--- a/web/src/lib/push.ts
+++ b/web/src/lib/push.ts
@@ -1,7 +1,7 @@
 // Web Push 订阅管理：订阅/退订/状态查询
 // 密钥流：服务端 VAPID 公钥 → pushManager.subscribe → 订阅对象 POST 回服务端注册表
 
-import { authHeaders } from './auth'
+import { apiFetch, apiError } from './api'
 
 /** 当前浏览器是否支持推送（Service Worker + Push API + 通知） */
 export function pushSupported(): boolean {
@@ -35,7 +35,7 @@ export async function subscribePush(): Promise<{ ok: boolean; error?: string }> 
   try {
     const perm = await Notification.requestPermission()
     if (perm !== 'granted') return { ok: false, error: '通知权限被拒绝' }
-    const pkResp = await fetch('/api/push/public-key', { headers: authHeaders() })
+    const pkResp = await apiFetch('/api/push/public-key')
     if (!pkResp.ok) return { ok: false, error: `获取推送公钥失败（HTTP ${pkResp.status}）` }
     const { publicKey } = (await pkResp.json()) as { publicKey: string }
     const reg = await navigator.serviceWorker.ready
@@ -44,12 +44,15 @@ export async function subscribePush(): Promise<{ ok: boolean; error?: string }> 
       applicationServerKey: urlBase64ToUint8Array(publicKey) as BufferSource,
     })
     const json = sub.toJSON() as { endpoint?: string; keys?: { p256dh: string; auth: string } }
-    const r = await fetch('/api/push/subscriptions', {
+    const r = await apiFetch('/api/push/subscriptions', {
       method: 'POST',
-      headers: { 'content-type': 'application/json', ...authHeaders() },
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ endpoint: json.endpoint, keys: json.keys }),
     })
-    if (!r.ok) return { ok: false, error: `注册订阅失败（HTTP ${r.status}）` }
+    if (!r.ok) {
+      const err = await apiError(r).catch(() => new Error(`HTTP ${r.status}`))
+      return { ok: false, error: `注册订阅失败：${err.message}` }
+    }
     return { ok: true }
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) }
@@ -65,9 +68,9 @@ export async function unsubscribePush(): Promise<void> {
     if (!sub) return
     const endpoint = sub.endpoint
     await sub.unsubscribe().catch(() => {})
-    await fetch('/api/push/subscriptions', {
+    await apiFetch('/api/push/subscriptions', {
       method: 'DELETE',
-      headers: { 'content-type': 'application/json', ...authHeaders() },
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ endpoint }),
     }).catch(() => {})
   } catch {}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -10,8 +10,8 @@ import { ClaudeMark } from '../components/ClaudeMark'
 import { ClaudeStar } from '../components/ClaudeStar'
 import { CodexMark } from '../components/CodexMark'
 import { PopupPanel } from '../components/PopupPanel'
-import { nextId, rewindPreview, toolResultText, type Block, type ChatMsg } from '../lib/blocks'
-import { isCodexKey, isExistingKey } from '../lib/key'
+import { nextId, rewindPreview, shortTokens, toolResultText, type Block, type ChatMsg } from '../lib/blocks'
+import { isCodexKey, isExistingKey, sessionFromKey } from '../lib/key'
 import { COMMAND_DESC, filterSlashHints, mergeSlashCommands, type SlashEntry } from '../lib/slashCommands'
 
 const MORE_ITEM =
@@ -676,15 +676,12 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
           case 'moved': {
             // /clear 对话重置：进程已换新 sessionId 续跑，Hub 重键完毕——跳到新会话页
             //（旧 transcript 在磁盘原样保留，列表页可见）
-            const parts = ev.targetKey.split('|')
+            const info = sessionFromKey(ev.targetKey)
+            if (!info) break
             props.onNavigate?.({
-              key: ev.targetKey,
-              slug: parts[1] ?? session.slug,
-              sessionId: ev.targetSessionId ?? 'new',
-              cwd: session.cwd,
-              backend: 'claude',
-              mtime: Date.now(),
-              sizeBytes: 0,
+              ...info,
+              cwd: info.cwd ?? session.cwd,
+              sessionId: ev.targetSessionId ?? info.sessionId,
               status: 'idle',
               managed: { spawned: true, busy: false, clients: 0 },
             })
@@ -857,7 +854,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       const u = state.usage
       pushSystem(
         u
-          ? `◈ 线程累计：in ${u.inputTokens} / out ${u.outputTokens}${u.reasoningTokens ? ` / reasoning ${u.reasoningTokens}` : ''}（窗口占用明细请开「详情」）`
+          ? `◈ 线程累计：in ${shortTokens(u.inputTokens)} / out ${shortTokens(u.outputTokens)}${u.reasoningTokens ? ` / reasoning ${shortTokens(u.reasoningTokens)}` : ''}（窗口占用明细请开「详情」）`
           : '◈ 暂无用量数据（先跑一轮）',
       )
       setInput('')
@@ -972,13 +969,12 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const busy = state.busy
   const waiting = state.waiting || approvals.length > 0
   const activeTaskCount = state.activeTaskCount ?? 0
-  const fmtTok = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n))
   const u = state.usage
   const usageLine =
     u && u.inputTokens + u.outputTokens > 0
-      ? `tok ↑${fmtTok(u.inputTokens)} ↓${fmtTok(u.outputTokens)}` +
-        (u.cacheReadTokens ? ` · cache ${fmtTok(u.cacheReadTokens)}` : '') +
-        (u.reasoningTokens ? ` · rs ${fmtTok(u.reasoningTokens)}` : '')
+      ? `tok ↑${shortTokens(u.inputTokens)} ↓${shortTokens(u.outputTokens)}` +
+        (u.cacheReadTokens ? ` · cache ${shortTokens(u.cacheReadTokens)}` : '') +
+        (u.reasoningTokens ? ` · rs ${shortTokens(u.reasoningTokens)}` : '')
       : undefined
   const hasPendingStartConfig =
     !state.spawned && Boolean(state.model || state.permissionMode || state.effort)

--- a/web/src/pages/SessionList.tsx
+++ b/web/src/pages/SessionList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
+  apiFetch,
   archiveSession,
   createSession,
   fetchArchived,
@@ -12,7 +13,6 @@ import {
 } from '../lib/api'
 import { InboxSocket, type InboxApproval } from '../lib/inbox'
 import { currentPushEndpoint, pushSupported, subscribePush, unsubscribePush } from '../lib/push'
-import { authHeaders } from '../lib/auth'
 import { BellIcon } from '../components/BellIcon'
 import { ClaudeMark } from '../components/ClaudeMark'
 import { CodexMark } from '../components/CodexMark'
@@ -160,7 +160,7 @@ export function SessionList(props: {
   // 挂载时读取推送订阅现状与 webhook 通道数
   useEffect(() => {
     void currentPushEndpoint().then(setPushEndpoint)
-    fetch('/api/push/public-key', { headers: authHeaders() })
+    apiFetch('/api/push/public-key')
       .then((r) => (r.ok ? r.json() : null))
       .then((j: { webhooks?: number } | null) => setPushWebhooks(j?.webhooks ?? 0))
       .catch(() => {})


### PR DESCRIPTION
本次对 cc-remote 全仓库 TypeScript/TSX 源码执行 /simplify，聚焦已有 helper 复用、减少重复实现、使用 Bun 原生 API，并保持改动范围最小化。

## 主要改动

### web
- 导出并复用 `apiFetch/apiError`，统一推送订阅/公钥接口的鉴权与错误处理
- `Chat.tsx` 的 moved 事件改用 `sessionFromKey` 解析 key
- 删除自实现 `fmtTok`，统一使用 `blocks.ts` 的 `shortTokens`
- `ApprovalCard` 工具详情改用 `toolDetail` 替代 `JSON.stringify`

### server
- `sessionNameOf` 与 codex translate 使用 `node:path.basename` 替代手写路径拆分
- `attach`、`runHandoff`、`/api/lineage` 复用 `splitExistingKey/splitThreadId/parseKey`
- `push.ts` 与 `index.ts` 的错误日志统一使用 `errorMessage`

### scripts
- e2e 脚本中 `new Promise(setTimeout)` 统一替换为 `Bun.sleep`
- `smoke.ts` 改用 `server/src/util.ts` 的 `pumpLines` 读取 NDJSON
- `gateway.ts` 与 `fetch-claude-docs.ts` 复用 `errorMessage`

## 验证
- `bun test` 全绿（180 tests pass）
- `bun run build` 通过
- 修改后的脚本文件经 `bun build --target=bun` 转译检查通过

## 未采纳项
- 涉及大改架构的 altitude 建议（统一后端注册表、Hub 层完全后端无关化等）超出本次最小化改动范围，未实施。