### PR TITLE
refactor: 全仓库 /simplify 清理（复用/简化/效率/altitude）

### DIFF
--- a/scripts/gateway.ts
+++ b/scripts/gateway.ts
@@ -72,7 +72,8 @@ function num(v: unknown, fallback: number): number {
 }
 
 function str(v: unknown, fallback: string): string {
-  return typeof v === 'string' && v.trim() ? v.trim() : fallback
+  const s = typeof v === 'string' ? v.trim() : ''
+  return s || fallback
 }
 
 function bool(v: unknown, fallback: boolean): boolean {
@@ -186,25 +187,22 @@ function htmlPage(title: string, body: string): Response {
   )
 }
 
-function filterReqHeaders(req: Request, proto: string): Headers {
+/** 拷贝 headers（剔除 hop-by-hop 头）；请求/响应转发共用 */
+function copyHeaders(src: Headers): Headers {
   const out = new Headers()
-  req.headers.forEach((v, k) => {
+  src.forEach((v, k) => {
     if (HOP.has(k.toLowerCase())) return
     out.set(k, v)
   })
+  return out
+}
+
+function filterReqHeaders(req: Request, proto: string): Headers {
+  const out = copyHeaders(req.headers)
   const host = req.headers.get('host')
   if (host) out.set('x-forwarded-host', host)
   out.set('x-forwarded-proto', proto)
   out.set('x-cc-remote-gateway', '1')
-  return out
-}
-
-function filterResHeaders(res: Headers): Headers {
-  const out = new Headers()
-  res.forEach((v, k) => {
-    if (HOP.has(k.toLowerCase())) return
-    out.set(k, v)
-  })
   return out
 }
 
@@ -222,7 +220,7 @@ async function proxyHttp(req: Request, target: string, proto: string, mode: Mode
   }
   try {
     const upstream = await fetch(dest, init)
-    const headers = filterResHeaders(upstream.headers)
+    const headers = copyHeaders(upstream.headers)
     headers.set('x-cc-remote-mode', mode)
     return new Response(upstream.body, { status: upstream.status, statusText: upstream.statusText, headers })
   } catch (e) {
@@ -316,13 +314,12 @@ const wsHandler: import('bun').WebSocketHandler<WSProxyData> = {
     })
   },
   message(ws, raw) {
-    const payload = typeof raw === 'string' ? raw : raw
     const b = ws.data.backend
     if (!b || b.readyState !== WebSocket.OPEN) {
-      ws.data.queue.push(payload)
+      ws.data.queue.push(raw)
       return
     }
-    b.send(payload)
+    b.send(raw)
   },
   close(ws) {
     if (ws.data.keepalive) clearInterval(ws.data.keepalive)

--- a/server/scripts/e2e-branch-btw-goal.ts
+++ b/server/scripts/e2e-branch-btw-goal.ts
@@ -1,27 +1,10 @@
 // 验证链路：btw(side_question) → branch(懒分叉) → /goal 状态跟踪
 // 用法：bun run server/scripts/e2e-branch-btw-goal.ts
+import { connect, exitWithSummary, makeNote } from './e2e-lib'
+
 const cwd = '/tmp'
 const nKey = `n|${encodeURIComponent(cwd)}`
-const results: string[] = []
-function note(ok: boolean, label: string, detail = '') {
-  results.push(`${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`)
-  console.log(results[results.length - 1])
-}
-
-function connect(key: string) {
-  const ws = new WebSocket(`ws://localhost:7480/ws/sessions/${encodeURIComponent(key)}`)
-  const handlers: Array<(ev: Record<string, unknown>) => void> = []
-  ws.onmessage = (e) => {
-    const ev = JSON.parse(e.data)
-    for (const h of handlers) h(ev)
-  }
-  return {
-    ws,
-    on: (h: (ev: Record<string, unknown>) => void) => handlers.push(h),
-    send: (o: unknown) => ws.send(JSON.stringify(o)),
-    open: () => new Promise<void>((r) => { ws.onopen = () => r() }),
-  }
-}
+const { note, results } = makeNote()
 
 const timeout = setTimeout(() => {
   console.error('TIMEOUT\n' + results.join('\n'))
@@ -114,7 +97,4 @@ for (let i = 0; i < 150 && !goalCleared; i++) await new Promise((r) => setTimeou
 note(goalCleared, 'goal 完成后 status.goal 清除')
 
 clearTimeout(timeout)
-console.log('\n—— 汇总 ——')
-console.log(results.join('\n'))
-const failed = results.filter((r) => r.startsWith('✗')).length
-process.exit(failed ? 1 : 0)
+exitWithSummary(results)

--- a/server/scripts/e2e-clear.ts
+++ b/server/scripts/e2e-clear.ts
@@ -4,12 +4,9 @@
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { exitWithSummary, makeNote } from './e2e-lib'
 
-const results: string[] = []
-function note(ok: boolean, label: string, detail = '') {
-  results.push(`${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`)
-  console.log(results[results.length - 1])
-}
+const { note, results } = makeNote()
 
 const dir = mkdtempSync(join(tmpdir(), 'ccr-clear-'))
 const key = `n|${encodeURIComponent(dir)}`
@@ -83,6 +80,4 @@ for (const e of events) console.log(`  ${((e.at - events[0].at) / 1000).toFixed(
 ws.close()
 rmSync(dir, { recursive: true, force: true })
 clearTimeout(timeout)
-console.log('\n—— 汇总 ——')
-console.log(results.join('\n'))
-process.exit(results.some((r) => r.startsWith('✗')) ? 1 : 0)
+exitWithSummary(results)

--- a/server/scripts/e2e-codex-cmds.ts
+++ b/server/scripts/e2e-codex-cmds.ts
@@ -1,11 +1,9 @@
 // E2E：codex /review（review/start）与 /rename（thread/name/set）
 // 用法：bun run server/scripts/e2e-codex-cmds.ts（需服务端已启动）
 // 注：claude /clear 的覆盖在 e2e-clear.ts（本文件的 claude 段曾因共享 n|/tmp key 被跨测试残留污染，已拆出重写）
-const results: string[] = []
-function note(ok: boolean, label: string, detail = '') {
-  results.push(`${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`)
-  console.log(results[results.length - 1])
-}
+import { exitWithSummary, makeNote } from './e2e-lib'
+
+const { note, results } = makeNote()
 
 const timeout = setTimeout(() => {
   console.error('TIMEOUT\n' + results.join('\n'))
@@ -49,6 +47,4 @@ const timeout = setTimeout(() => {
 }
 
 clearTimeout(timeout)
-console.log('\n—— 汇总 ——')
-console.log(results.join('\n'))
-process.exit(results.some((r) => r.startsWith('✗')) ? 1 : 0)
+exitWithSummary(results)

--- a/server/scripts/e2e-codex-goal.ts
+++ b/server/scripts/e2e-codex-goal.ts
@@ -1,19 +1,11 @@
 // codex goal 链路验证：新线程 → thread/goal/set → status.goal → clear
-const key = `xn|${encodeURIComponent('/tmp')}`
-const results: string[] = []
-function note(ok: boolean, label: string, detail = '') {
-  results.push(`${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`)
-  console.log(results[results.length - 1])
-}
+import { connect, exitWithSummary, makeNote } from './e2e-lib'
 
-const ws = new WebSocket(`ws://localhost:7480/ws/sessions/${encodeURIComponent(key)}`)
-const handlers: Array<(ev: Record<string, unknown>) => void> = []
-ws.onmessage = (e) => {
-  const ev = JSON.parse(e.data)
-  for (const h of handlers) h(ev)
-}
-const send = (o: unknown) => ws.send(JSON.stringify(o))
-await new Promise<void>((r) => { ws.onopen = () => r() })
+const key = `xn|${encodeURIComponent('/tmp')}`
+const { note, results } = makeNote()
+
+const { on, send, open } = connect(key)
+await open()
 
 const timeout = setTimeout(() => { console.error('TIMEOUT\n' + results.join('\n')); process.exit(1) }, 180_000)
 
@@ -22,7 +14,7 @@ let turnDone = false
 let goalSeen = ''
 let goalCleared = false
 send({ kind: 'attach' })
-handlers.push((ev) => {
+on((ev) => {
   if (ev.kind === 'status') {
     const st = ev.state as { sessionId?: string; goal?: { condition: string } | null }
     if (st.sessionId) threadId = st.sessionId
@@ -45,5 +37,4 @@ for (let i = 0; i < 40 && !goalCleared; i++) await new Promise((r) => setTimeout
 note(goalCleared, 'thread/goal/clear → status.goal 清除')
 
 clearTimeout(timeout)
-console.log('\n' + results.join('\n'))
-process.exit(results.some((r) => r.startsWith('✗')) ? 1 : 0)
+exitWithSummary(results)

--- a/server/scripts/e2e-codex.ts
+++ b/server/scripts/e2e-codex.ts
@@ -98,7 +98,7 @@ async function pump(): Promise<void> {
 }
 
 void pump()
-proc.stderr && void new Response(proc.stderr as ReadableStream<Uint8Array>).text().then((t) => {
+void new Response(proc.stderr as ReadableStream<Uint8Array>).text().then((t) => {
   if (t.trim()) console.error('[stderr]', t.slice(0, 800))
 })
 

--- a/server/scripts/e2e-handoff.ts
+++ b/server/scripts/e2e-handoff.ts
@@ -86,6 +86,9 @@ async function waitTargetFirstTurn(targetKey: string, targetSessionId: string | 
 
 let pass = true
 
+/** 简报质量探针：实验项目的关键词应出现在简报里（两个方向共用） */
+const PROJECT_KEYWORDS = /notebox|搜索|export|简报/i
+
 // 方向 1：claude → codex
 {
   const r = await handoff(CLAUDE_KEY, 'codex', 'cc→cx')
@@ -93,8 +96,9 @@ let pass = true
     console.log(`[cc→cx] FAIL: ${r.error}`)
     pass = false
   } else {
-    console.log(`[cc→cx] 简报 ${r.brief!.length} 字，含项目关键词=${/notebox|搜索|export|简报/i.test(r.brief!)}`)
-    if (!/notebox|搜索|export|简报/i.test(r.brief!)) pass = false
+    const hasKeywords = PROJECT_KEYWORDS.test(r.brief!)
+    console.log(`[cc→cx] 简报 ${r.brief!.length} 字，含项目关键词=${hasKeywords}`)
+    if (!hasKeywords) pass = false
     if (!(await waitTargetFirstTurn(r.targetKey!, r.targetSessionId, 'cc→cx'))) pass = false
   }
 }
@@ -106,8 +110,9 @@ let pass = true
     console.log(`[cx→cc] FAIL: ${r.error}`)
     pass = false
   } else {
-    console.log(`[cx→cc] 简报 ${r.brief!.length} 字，含项目关键词=${/notebox|搜索|export|简报/i.test(r.brief!)}`)
-    if (!/notebox|搜索|export|简报/i.test(r.brief!)) pass = false
+    const hasKeywords = PROJECT_KEYWORDS.test(r.brief!)
+    console.log(`[cx→cc] 简报 ${r.brief!.length} 字，含项目关键词=${hasKeywords}`)
+    if (!hasKeywords) pass = false
   }
 }
 

--- a/server/scripts/e2e-lib.ts
+++ b/server/scripts/e2e-lib.ts
@@ -1,0 +1,35 @@
+// e2e 脚本共享小工具：结果记录（note）与 WS 连接封装（connect）。
+// 各 e2e-*.ts 脚本是独立运行的手工验证入口，只共享这两段逐字重复的样板。
+
+/** 结果汇总：note() 记录并打印一行，results 供超时/结尾汇总 */
+export function makeNote(): { note: (ok: boolean, label: string, detail?: string) => void; results: string[] } {
+  const results: string[] = []
+  const note = (ok: boolean, label: string, detail = '') => {
+    results.push(`${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`)
+    console.log(results[results.length - 1])
+  }
+  return { note, results }
+}
+
+/** 打印汇总并按是否有 ✗ 退出 */
+export function exitWithSummary(results: string[]): never {
+  console.log('\n—— 汇总 ——')
+  console.log(results.join('\n'))
+  process.exit(results.some((r) => r.startsWith('✗')) ? 1 : 0)
+}
+
+/** WS 连接封装：handlers 数组 + send + open Promise */
+export function connect(key: string) {
+  const ws = new WebSocket(`ws://localhost:7480/ws/sessions/${encodeURIComponent(key)}`)
+  const handlers: Array<(ev: Record<string, unknown>) => void> = []
+  ws.onmessage = (e) => {
+    const ev = JSON.parse(e.data)
+    for (const h of handlers) h(ev)
+  }
+  return {
+    ws,
+    on: (h: (ev: Record<string, unknown>) => void) => handlers.push(h),
+    send: (o: unknown) => ws.send(JSON.stringify(o)),
+    open: () => new Promise<void>((r) => { ws.onopen = () => r() }),
+  }
+}

--- a/server/scripts/e2e-push.ts
+++ b/server/scripts/e2e-push.ts
@@ -14,17 +14,13 @@ import {
 import { readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { exitWithSummary, makeNote } from './e2e-lib'
 
 const BASE = process.env.CC_REMOTE_BASE ?? 'http://127.0.0.1:7480'
 const WS_BASE = BASE.replace(/^http/, 'ws')
 const TOKEN_Q = process.env.CC_REMOTE_TOKEN ? `?token=${process.env.CC_REMOTE_TOKEN}` : ''
-const results: string[] = []
-function note(ok: boolean, label: string, detail = '') {
-  results.push(`${ok ? '✓' : '✗'} ${label}${detail ? ` — ${detail}` : ''}`)
-  console.log(results[results.length - 1])
-}
+const { note, results } = makeNote()
 const b64url = (b: Buffer) => b.toString('base64url')
-
 // ---------- mock push service ----------
 interface Captured {
   path: string
@@ -235,6 +231,4 @@ try {
   mock.stop(true)
 }
 
-console.log('\n—— 汇总 ——')
-console.log(results.join('\n'))
-process.exit(results.some((r) => r.startsWith('✗')) ? 1 : 0)
+exitWithSummary(results)

--- a/server/scripts/e2e-slash.ts
+++ b/server/scripts/e2e-slash.ts
@@ -36,7 +36,7 @@ ws.onmessage = (e) => {
   } else if (ev.kind === 'btw_result') {
     console.log(`<< btw_result ok=${ev.ok}:`, ev.text.slice(0, 300))
     clearTimeout(timeout)
-    process.exit(ev.ok && compactDone ? 0 : compactDone ? 0 : 1)
+    process.exit(compactDone ? 0 : 1)
   } else if (ev.kind === 'error') {
     console.log('<< error:', ev.message)
   }

--- a/server/scripts/lab-run.ts
+++ b/server/scripts/lab-run.ts
@@ -1,5 +1,5 @@
 // lab-run.ts — spawn 真实 claude CLI，把 stdout NDJSON 逐行落盘 + stderr 单独落盘。
-// 用法: bun run lab-run.ts <scenario名>   (从 D:/Coder/Agents/cc-remote/.tmp/lab 目录运行)
+// 用法: bun run server/scripts/lab-run.ts <scenario名>（输出落 <cwd>/raw/）
 // scenario 定义在下方 SCENARIOS。
 import { spawn } from 'node:child_process'
 import { createWriteStream, mkdirSync } from 'node:fs'

--- a/server/src/archive.ts
+++ b/server/src/archive.ts
@@ -4,12 +4,12 @@
 //   恢复时移回。仅离线会话可操作（与改名同一边界：进程活着的会话绝不碰）。
 
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import { config } from './config'
+import { ccDataDir } from './util'
 
 function trashRoot(): string {
-  const dir = join(homedir(), '.cc-remote', 'trash', 'claude')
+  const dir = join(ccDataDir(), 'trash', 'claude')
   mkdirSync(dir, { recursive: true }) // recursive 幂等：已存在不抛错
   return dir
 }
@@ -80,7 +80,6 @@ export function listTrash(): TrashEntry[] {
     const dir = join(root, slug)
     for (const file of readdirSync(dir)) {
       if (!file.endsWith('.jsonl')) continue
-      if (file.endsWith('.meta.json') || file.endsWith('.bak')) continue
       const sessionId = basename(file, '.jsonl')
       const p = join(dir, file)
       let trashedAt: string | undefined

--- a/server/src/backends/claude/discovery.ts
+++ b/server/src/backends/claude/discovery.ts
@@ -82,6 +82,18 @@ function readPidFiles(): Map<string, PidFile> {
   return map
 }
 
+/** message.content（string 或块数组）→ 纯文本（只取 text 块，sep 连接） */
+function textOfContent(content: unknown, sep: string): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .filter((c): c is { type: string; text?: string } => c?.type === 'text')
+      .map((c) => c.text ?? '')
+      .join(sep)
+  }
+  return ''
+}
+
 /** 从 jsonl 提取标题/首条提示/cwd。只读前 64KB + 末 64KB，避免大文件全量解析 */
 function extractMeta(path: string): { title?: string; lastPrompt?: string; cwd?: string } {
   let head: string
@@ -128,21 +140,11 @@ function extractMeta(path: string): { title?: string; lastPrompt?: string; cwd?:
         title = obj.summary
       } else if (type === 'user') {
         const content = (obj.message as { content?: unknown } | undefined)?.content
-        const text =
-          typeof content === 'string'
-            ? content
-            : Array.isArray(content)
-              ? content
-                  .filter((c): c is { type: string; text?: string } => c?.type === 'text')
-                  .map((c) => c.text ?? '')
-                  .join(' ')
-              : ''
-        const clean = text.trim()
+        const clean = textOfContent(content, ' ').trim()
         // 跳过 tool_result / isMeta / 斜杠命令回显等系统注入消息
         if (clean && !obj.isMeta && !clean.startsWith('<local-command') && !clean.startsWith('<command-name')) {
           if (!firstPrompt && !isTail) firstPrompt = clean.slice(0, 120)
           if (isTail) lastPrompt = clean.slice(0, 120)
-          else lastPrompt = lastPrompt ?? undefined
         }
       }
     }
@@ -253,9 +255,7 @@ export type { HistoryMessage } from '../types'
 
 /** 提取 tool_result 的纯文本内容（content 可能是 string 或 text 块数组） */
 function toolResultText(rc: unknown): string {
-  if (typeof rc === 'string') return rc
-  if (Array.isArray(rc)) return rc.map((x) => (x?.type === 'text' ? (x.text ?? '') : '')).join('')
-  return ''
+  return textOfContent(rc, '')
 }
 
 /**
@@ -281,15 +281,7 @@ export function isSelectableRewindTarget(obj: Record<string, unknown>): boolean 
   if (Array.isArray(content)) {
     if ((content[0] as { type?: unknown } | undefined)?.type === 'tool_result') return false
   }
-  const text =
-    typeof content === 'string'
-      ? content
-      : Array.isArray(content)
-        ? content
-            .filter((c): c is { type: string; text?: string } => c?.type === 'text')
-            .map((c) => c.text ?? '')
-            .join(' ')
-        : ''
+  const text = textOfContent(content, ' ')
   return !INTERNAL_TEXT_TAGS.some((tag) => text.includes(tag))
 }
 

--- a/server/src/backends/claude/processManager.ts
+++ b/server/src/backends/claude/processManager.ts
@@ -185,29 +185,27 @@ export class ClaudeSession {
     if (this.opts.permissionMode) args.push('--permission-mode', this.opts.permissionMode)
 
     console.log(`[session ${this.key}] spawn: ${cmd} ${args.join(' ')}`)
-    const proc = (() => {
-      try {
-        return spawn([cmd, ...args], {
-          cwd: this.opts.cwd,
-          stdin: 'pipe',
-          stdout: 'pipe',
-          stderr: 'pipe', // 吞掉 stderr，避免干扰；需要诊断时可改为 inherit
-          env: {
-            ...process.env,
-            // headless/SDK 模式下文件检查点默认关闭，rewind_files 需要它
-            CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: '1',
-            // 启用权威 idle/running/requires_action 事件（Claude Code sessionState.ts）
-            CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
-          },
-        })
-      } catch (e) {
-        this.exited = true
-        this.proc = undefined
-        const detail = errorMessage(e)
-        throw new Error(`无法启动 claude CLI (${cmd}): ${detail}`)
-      }
-    })()
-    this.proc = proc
+    try {
+      this.proc = spawn([cmd, ...args], {
+        cwd: this.opts.cwd,
+        stdin: 'pipe',
+        stdout: 'pipe',
+        stderr: 'pipe', // 吞掉 stderr，避免干扰；需要诊断时可改为 inherit
+        env: {
+          ...process.env,
+          // headless/SDK 模式下文件检查点默认关闭，rewind_files 需要它
+          CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: '1',
+          // 启用权威 idle/running/requires_action 事件（Claude Code sessionState.ts）
+          CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
+        },
+      })
+    } catch (e) {
+      this.exited = true
+      this.proc = undefined
+      const detail = errorMessage(e)
+      throw new Error(`无法启动 claude CLI (${cmd}): ${detail}`)
+    }
+    const proc = this.proc
     console.log(`[session ${this.key}] spawned pid=${proc.pid} parent=${process.pid}`)
     this.exited = false
     this.exitEmitted = false
@@ -528,10 +526,13 @@ export class ClaudeSession {
     // token 用量累计：result.usage（费用字段不进累加器、不进 UI）
     if (msg.type === 'result' && msg.usage && typeof msg.usage === 'object') {
       const u = msg.usage as Record<string, unknown>
-      this.usageAcc.inputTokens += Number(u.input_tokens ?? 0) || 0
-      this.usageAcc.outputTokens += Number(u.output_tokens ?? 0) || 0
-      this.usageAcc.cacheReadTokens += Number(u.cache_read_input_tokens ?? 0) || 0
-      this.usageAcc.cacheWriteTokens += Number(u.cache_creation_input_tokens ?? 0) || 0
+      const acc = (field: keyof typeof this.usageAcc, v: unknown) => {
+        this.usageAcc[field] += Number(v ?? 0) || 0
+      }
+      acc('inputTokens', u.input_tokens)
+      acc('outputTokens', u.output_tokens)
+      acc('cacheReadTokens', u.cache_read_input_tokens)
+      acc('cacheWriteTokens', u.cache_creation_input_tokens)
       this.cb.onStatusChange?.()
     }
 

--- a/server/src/backends/codex/runtime.ts
+++ b/server/src/backends/codex/runtime.ts
@@ -40,21 +40,16 @@ export interface CodexSpawnOpts {
 export function mapPermissionMode(mode?: string): { approvalPolicy?: string; sandbox?: string } {
   switch (mode) {
     case 'readOnly':
+    case 'plan': // claude 名称的近似映射（spawnOpts 缓存/接力默认值可能带过来）
       return { approvalPolicy: 'on-request', sandbox: 'read-only' }
     case 'workspaceAuto':
-      return { approvalPolicy: 'never', sandbox: 'workspace-write' }
-    case 'fullAccess':
-      return { approvalPolicy: 'never', sandbox: 'danger-full-access' }
-    case 'workspace':
-      return { approvalPolicy: 'on-request', sandbox: 'workspace-write' }
-    // claude 名称的近似映射（spawnOpts 缓存/接力默认值可能带过来）
-    case 'bypassPermissions':
-      return { approvalPolicy: 'never', sandbox: 'danger-full-access' }
     case 'acceptEdits':
     case 'auto':
       return { approvalPolicy: 'never', sandbox: 'workspace-write' }
-    case 'plan':
-      return { approvalPolicy: 'on-request', sandbox: 'read-only' }
+    case 'fullAccess':
+    case 'bypassPermissions':
+      return { approvalPolicy: 'never', sandbox: 'danger-full-access' }
+    case 'workspace':
     case 'default':
     default:
       return { approvalPolicy: 'on-request', sandbox: 'workspace-write' }
@@ -358,19 +353,18 @@ export class CodexSession {
       const turnId = this.currentTurnId
       void this.runtime
         .rpcRequest('turn/steer', { threadId: this.threadId, input, expectedTurnId: turnId })
-        .catch(() => {
-          // 轮刚好结束/不可 steer：回退普通新轮
-          void this.runtime
-            .rpcRequest('turn/start', { threadId: this.threadId, input, approvalsReviewer: 'user', ...this.turnOverrides })
-            .catch((e) => this.emitError(`发送失败: ${errorMessage(e)}`))
-        })
+        .catch(() => this.startTurn(input)) // 轮刚好结束/不可 steer：回退普通新轮
       return
     }
+    this.startTurn(input)
+  }
+
+  /** 普通新轮：审批一律路由给远程用户（cc-remote 的存在意义），覆盖用户配置里的 auto_review */
+  private startTurn(input: unknown[]): void {
     void this.runtime
       .rpcRequest('turn/start', {
         threadId: this.threadId,
         input,
-        // 审批必须路由给远程用户（cc-remote 的存在意义），覆盖用户配置里的 auto_review
         approvalsReviewer: 'user',
         ...this.turnOverrides,
       })
@@ -744,6 +738,22 @@ export class CodexRuntime {
     this.rpc = undefined
   }
 
+  /** 分页拉取：cursor 翻页直到无 nextCursor 或达到 limitPages */
+  private async paginate(method: string, baseParams: Params, limitPages = 3): Promise<Params[]> {
+    const out: Params[] = []
+    let cursor: string | null = null
+    for (let page = 0; page < limitPages; page++) {
+      const res = (await this.rpcRequest(method, { ...baseParams, cursor, limit: 100 })) as {
+        data?: Params[]
+        nextCursor?: string | null
+      }
+      out.push(...(res.data ?? []))
+      cursor = res.nextCursor ?? null
+      if (!cursor) break
+    }
+    return out
+  }
+
   /** 模型目录：model/list 分页拉全（含每个模型支持的 effort 列表与默认 effort） */
   async listModels(): Promise<
     Array<{
@@ -755,17 +765,7 @@ export class CodexRuntime {
       isDefault: boolean
     }>
   > {
-    const out: Array<Record<string, unknown>> = []
-    let cursor: string | null = null
-    for (let page = 0; page < 3; page++) {
-      const res = (await this.rpcRequest('model/list', { cursor, limit: 100 })) as {
-        data?: Array<Record<string, unknown>>
-        nextCursor?: string | null
-      }
-      out.push(...(res.data ?? []))
-      cursor = res.nextCursor ?? null
-      if (!cursor) break
-    }
+    const out = await this.paginate('model/list', {})
     return out
       .filter((m) => m.hidden !== true)
       .map((m) => ({
@@ -785,20 +785,11 @@ export class CodexRuntime {
 
   /** 会话发现：thread/list 分页拉全（含 cli/exec/appServer 来源） */
   async listThreads(limitPages = 3): Promise<Params[]> {
-    const out: Params[] = []
-    let cursor: string | null = null
-    for (let page = 0; page < limitPages; page++) {
-      const res = (await this.rpcRequest('thread/list', {
-        cursor,
-        limit: 100,
-        sortKey: 'updated_at',
-        sourceKinds: ['cli', 'vscode', 'exec', 'appServer'],
-      })) as { data?: Params[]; nextCursor?: string | null }
-      out.push(...(res.data ?? []))
-      cursor = res.nextCursor ?? null
-      if (!cursor) break
-    }
-    return out
+    return this.paginate(
+      'thread/list',
+      { sortKey: 'updated_at', sourceKinds: ['cli', 'vscode', 'exec', 'appServer'] },
+      limitPages,
+    )
   }
 
   /** 历史：thread/read includeTurns（只读，不加载不订阅）+ 侧车 reasoning 按 turn 时间窗回插 */

--- a/server/src/backends/codex/translate.ts
+++ b/server/src/backends/codex/translate.ts
@@ -33,6 +33,23 @@ interface ThreadItem {
   review?: string
 }
 
+/** message_start + content_block_start 开头流（agentMessage 文本 / reasoning 思考共用） */
+function streamStart(id: string, block: Record<string, unknown>): CliMessage[] {
+  return [
+    { type: 'stream_event', event: { type: 'message_start', message: { id, role: 'assistant', content: [] } } },
+    { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: block } },
+  ]
+}
+
+/** assistant 快照 + block/message stop（对齐 claude 真实序：快照合并草稿、stop 提交） */
+function assistantFinal(id: string, block: Record<string, unknown>): CliMessage[] {
+  return [
+    { type: 'assistant', message: { id, role: 'assistant', content: [block] } },
+    { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+    { type: 'stream_event', event: { type: 'message_stop' } },
+  ]
+}
+
 /** 每个线程一个：维护 itemId → 合成 message id / 块序号的流式状态 */
 export class ThreadTranslator {
   /** item/started：agentMessage 开头流（message_start + block_start）；工具项发 tool_use */
@@ -40,15 +57,9 @@ export class ThreadTranslator {
     if (!item.id || !item.type) return []
     switch (item.type) {
       case 'agentMessage':
-        return [
-          { type: 'stream_event', event: { type: 'message_start', message: { id: item.id, role: 'assistant', content: [] } } },
-          { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } } },
-        ]
+        return streamStart(item.id, { type: 'text', text: '' })
       case 'reasoning':
-        return [
-          { type: 'stream_event', event: { type: 'message_start', message: { id: item.id, role: 'assistant', content: [] } } },
-          { type: 'stream_event', event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '' } } },
-        ]
+        return streamStart(item.id, { type: 'thinking', thinking: '' })
       case 'commandExecution':
       case 'fileChange':
       case 'mcpToolCall':
@@ -71,25 +82,9 @@ export class ThreadTranslator {
     if (!item.id || !item.type) return []
     switch (item.type) {
       case 'agentMessage':
-        return [
-          {
-            type: 'assistant',
-            message: { id: item.id, role: 'assistant', content: [{ type: 'text', text: item.text ?? '' }] },
-          },
-          { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
-          { type: 'stream_event', event: { type: 'message_stop' } },
-        ]
-      case 'reasoning': {
-        const text = reasoningText(item.summary, item.content)
-        return [
-          {
-            type: 'assistant',
-            message: { id: item.id, role: 'assistant', content: [{ type: 'thinking', thinking: text }] },
-          },
-          { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
-          { type: 'stream_event', event: { type: 'message_stop' } },
-        ]
-      }
+        return assistantFinal(item.id, { type: 'text', text: item.text ?? '' })
+      case 'reasoning':
+        return assistantFinal(item.id, { type: 'thinking', thinking: reasoningText(item.summary, item.content) })
       case 'commandExecution':
       case 'fileChange':
       case 'mcpToolCall':
@@ -238,6 +233,22 @@ export function turnCompletedMsg(threadId: string, turn: Params, lastUsage?: Rec
 
 // ---------- 历史（thread.turns）→ HistoryMessage ----------
 
+/** 工具项历史对：tool_use + tool_result 两条消息（live 侧分两次发，历史落一起由前端归并） */
+function pushToolPair(
+  out: HistoryMessage[],
+  uuid: string | undefined,
+  toolUse: HistoryBlock,
+  item: ThreadItem,
+): void {
+  out.push({ uuid, role: 'assistant', blocks: [toolUse] })
+  const r = toolResultFromItem(item)
+  out.push({
+    uuid: `${item.id}-r`,
+    role: 'user',
+    blocks: [{ kind: 'tool_result', id: item.id, text: r.text, isError: r.isError }],
+  })
+}
+
 /** turn.items[] → 历史消息序列（tool_use/tool_result 跨消息配对由前端归并）。
  *  turnId 存在时：该轮首条 userMessage 以 turnId 为 uuid 且 rewindable——
  *  供 /rewind 分叉回滚定位（thread/fork 的 beforeTurnId 目标）。 */
@@ -271,65 +282,22 @@ export function itemsToHistory(items: ThreadItem[], turnId?: string): HistoryMes
       case 'plan':
         out.push({ uuid, role: 'assistant', blocks: [{ kind: 'text', text: item.text ?? '' }] })
         break
-      case 'commandExecution': {
+      case 'commandExecution':
         // tool_use 有意不用 live 的 toolUseBlock：历史卡摘要应显示命令本身，
         // live 侧的 description(cwd) 会抢占 toolSummary 的首选字段
-        out.push({
-          uuid,
-          role: 'assistant',
-          blocks: [{ kind: 'tool_use', id: item.id, name: 'Bash', input: { command: item.command ?? '' } }],
-        })
-        const r = toolResultFromItem(item)
-        out.push({
-          uuid: `${item.id}-r`,
-          role: 'user',
-          blocks: [{ kind: 'tool_result', id: item.id, text: r.text, isError: r.isError }],
-        })
+        pushToolPair(out, uuid, { kind: 'tool_use', id: item.id, name: 'Bash', input: { command: item.command ?? '' } }, item)
         break
-      }
       case 'fileChange': {
         const paths = (item.changes ?? []).map((c) => c.path).filter(Boolean)
-        out.push({
-          uuid,
-          role: 'assistant',
-          blocks: [{ kind: 'tool_use', id: item.id, name: 'Edit', input: { file_path: paths[0] ?? '', paths } }],
-        })
-        const r = toolResultFromItem(item)
-        out.push({
-          uuid: `${item.id}-r`,
-          role: 'user',
-          blocks: [{ kind: 'tool_result', id: item.id, text: r.text, isError: r.isError }],
-        })
+        pushToolPair(out, uuid, { kind: 'tool_use', id: item.id, name: 'Edit', input: { file_path: paths[0] ?? '', paths } }, item)
         break
       }
-      case 'mcpToolCall': {
-        out.push({
-          uuid,
-          role: 'assistant',
-          blocks: [{ kind: 'tool_use', id: item.id, name: `${item.server ?? 'mcp'}:${item.tool ?? '?'}`, input: item.arguments }],
-        })
-        const r = toolResultFromItem(item)
-        out.push({
-          uuid: `${item.id}-r`,
-          role: 'user',
-          blocks: [{ kind: 'tool_result', id: item.id, text: r.text, isError: r.isError }],
-        })
+      case 'mcpToolCall':
+        pushToolPair(out, uuid, { kind: 'tool_use', id: item.id, name: `${item.server ?? 'mcp'}:${item.tool ?? '?'}`, input: item.arguments }, item)
         break
-      }
-      case 'webSearch': {
-        out.push({
-          uuid,
-          role: 'assistant',
-          blocks: [{ kind: 'tool_use', id: item.id, name: 'WebSearch', input: { query: item.query ?? '' } }],
-        })
-        const r = toolResultFromItem(item)
-        out.push({
-          uuid: `${item.id}-r`,
-          role: 'user',
-          blocks: [{ kind: 'tool_result', id: item.id, text: r.text, isError: r.isError }],
-        })
+      case 'webSearch':
+        pushToolPair(out, uuid, { kind: 'tool_use', id: item.id, name: 'WebSearch', input: { query: item.query ?? '' } }, item)
         break
-      }
       case 'contextCompaction':
         out.push({ uuid, role: 'system', subtype: 'compact_boundary', blocks: [] })
         break

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,5 +1,5 @@
 // cc-remote 服务端配置
-// 配置文件：项目根目录或 ~/.config/cc-remote/config.json（均可选，全部有默认值）
+// 配置文件：项目根目录 cc-remote.config.json 或 ~/.cc-remote/config.json（均可选，全部有默认值）
 
 import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'

--- a/server/src/handoff.ts
+++ b/server/src/handoff.ts
@@ -2,13 +2,12 @@
 // 已在 handoff-lab 实验验证：两家的"对话内隐藏设计"可经简报无损传递（见 docs/PLAN 附录）。
 
 import { spawn } from 'bun'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { resolveClaudeCommand } from './backends/claude/processManager'
 import { codexRuntime } from './backends/codex/runtime'
 import type { BackendName } from './backends/types'
-import { pumpLines } from './util'
+import { ccDataDir, pumpLines, readJsonFile } from './util'
 
 export type HandoffDetail = 'brief' | 'standard' | 'detailed'
 
@@ -138,43 +137,24 @@ export interface LineageRecord {
   briefUsage?: Record<string, number>
 }
 
-function lineageDir(): string {
-  const dir = join(homedir(), '.cc-remote')
-  mkdirSync(dir, { recursive: true }) // recursive 幂等：已存在不抛错
-  return dir
-}
-
 function lineagePath(): string {
-  return join(lineageDir(), 'lineage.json')
+  return join(ccDataDir(), 'lineage.json')
 }
 
 export function appendLineage(rec: LineageRecord): void {
   const path = lineagePath()
-  let all: LineageRecord[] = []
-  if (existsSync(path)) {
-    try {
-      all = JSON.parse(readFileSync(path, 'utf8')) as LineageRecord[]
-    } catch {
-      all = []
-    }
-  }
+  const all = readJsonFile<LineageRecord[]>(path) ?? []
   all.push(rec)
   writeFileSync(path, JSON.stringify(all, null, 2))
 }
 
 export function lineageFor(key: string): LineageRecord[] {
-  const path = lineagePath()
-  if (!existsSync(path)) return []
-  try {
-    const all = JSON.parse(readFileSync(path, 'utf8')) as LineageRecord[]
-    return all.filter(
-      (r) =>
-        r.fromKey === key ||
-        r.toKey === key ||
-        r.fromResolvedKey === key ||
-        r.toResolvedKey === key,
-    )
-  } catch {
-    return []
-  }
+  const all = readJsonFile<LineageRecord[]>(lineagePath()) ?? []
+  return all.filter(
+    (r) =>
+      r.fromKey === key ||
+      r.toKey === key ||
+      r.fromResolvedKey === key ||
+      r.toResolvedKey === key,
+  )
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -307,6 +307,35 @@ function broadcastError(hub: Hub, message: string): void {
   broadcast(hub, { kind: 'error', message })
 }
 
+/** 两后端会话状态的公共字段（claude/codex 会话句柄结构化同形，契约见 backends/types.ts 末尾） */
+function baseStatusOf(
+  s:
+    | {
+        exited: boolean
+        busy: boolean
+        waiting: boolean
+        sessionState: string
+        sessionId: string | undefined
+        connectedClients: number
+        tokenUsage: unknown
+      }
+    | undefined,
+  hub: Hub | undefined,
+  waiting: boolean,
+): Record<string, unknown> {
+  return {
+    spawned: !!s && !s.exited,
+    busy: (s?.busy ?? false) || waiting,
+    waiting,
+    sessionState: s?.sessionState ?? 'idle',
+    sessionId: s?.sessionId,
+    clients: s?.connectedClients ?? hub?.clients.size ?? 0,
+    usage: s?.tokenUsage,
+    permissionMode: hub?.spawnOpts?.permissionMode,
+    effort: hub?.spawnOpts?.effort,
+  }
+}
+
 /** liveHint：调用方（/api/sessions）刚做过 pid 扫描时传入复用，避免每行各扫一次；
  *  显式 null 表示"已知不在线"（跳过扫描），undefined 才现扫 */
 function statusOf(key: string, liveHint?: { status: string; pid: number } | null): Record<string, unknown> {
@@ -321,24 +350,16 @@ function statusOf(key: string, liveHint?: { status: string; pid: number } | null
     if (ek) live = liveHint === undefined ? liveSessionInfo(ek.sessionId) : (liveHint ?? undefined)
   }
   const waiting = (s?.waiting ?? false) || pending > 0 || live?.status === 'waiting'
-  // 审批等待也算 busy，防止误回收
-  const busy = (s?.busy ?? false) || waiting || live?.status === 'busy'
+  const st = baseStatusOf(s, hub, waiting)
+  if (live?.status === 'busy') st.busy = true // 审批等待与外部进程 busy 都算 busy，防止误回收
   return {
-    spawned: !!s && !s.exited,
-    busy,
-    waiting,
-    sessionState: s?.sessionState ?? 'idle',
-    sessionId: s?.sessionId,
-    clients: s?.connectedClients ?? hub?.clients.size ?? 0,
+    ...st,
     activeTaskCount: s?.activeTaskCount ?? 0,
     activeTasks: s?.backgroundTasks ?? [],
-    usage: s?.tokenUsage,
     slashCommands: s?.slashCommands,
     // spawnOpts.model 是用户显式选择（未 spawn 时的待应用值）；initModel 是进程 init 报告的解析后 ID。
     // 后者让重连 attach 的页面不必等下一轮就能显示模型（StatusPill 再经 modelNames 映射成配置名）
     model: hub?.spawnOpts?.model ?? s?.initModel,
-    permissionMode: hub?.spawnOpts?.permissionMode,
-    effort: hub?.spawnOpts?.effort,
     tailing: !!hub?.tailer,
     liveStatus: live?.status,
     goal: hub?.goal ?? null,
@@ -353,21 +374,12 @@ function pushStatus(hub: Hub, extra?: Record<string, unknown>): void {
 function codexStatusOf(key: string): Record<string, unknown> {
   const s = codexRuntime.get(key)
   const hub = hubs.get(key)
-  const pending = hub?.pendingApprovals.size ?? 0
-  const waiting = (s?.waiting ?? false) || pending > 0
+  const waiting = (s?.waiting ?? false) || (hub?.pendingApprovals.size ?? 0) > 0
   return {
-    spawned: !!s && !s.exited,
-    busy: (s?.busy ?? false) || waiting,
-    waiting,
-    sessionState: s?.sessionState ?? 'idle',
-    sessionId: s?.sessionId,
-    clients: s?.connectedClients ?? hub?.clients.size ?? 0,
+    ...baseStatusOf(s, hub, waiting),
     activeTaskCount: 0,
     activeTasks: [],
-    usage: s?.tokenUsage,
     model: hub?.spawnOpts?.model,
-    permissionMode: hub?.spawnOpts?.permissionMode,
-    effort: hub?.spawnOpts?.effort,
     tailing: false,
     goal: s?.goal ?? null,
   }
@@ -593,7 +605,7 @@ function ensureSpawned(
   // resumeSessionAt 是一次性 spawn 参数（命令行 args 已在 spawn() 内同步生成）。
   // 无论本次成败都不能留在 hub.spawnOpts 里，否则之后空闲回收后的普通 respawn
   // 会带着它再次截断同一条消息，静默丢弃回滚之后的新对话。
-  if (hub.spawnOpts) delete hub.spawnOpts.resumeSessionAt
+  delete hub.spawnOpts.resumeSessionAt
   pushStatus(hub)
 }
 
@@ -605,6 +617,13 @@ function ensureClaudeSession(hub: Hub): ReturnType<typeof processManager.get> {
     s = processManager.get(hub.key)
   }
   return s && !s.exited ? s : undefined
+}
+
+/** 回滚进行中拒绝新操作：返回 true 表示已拒绝（错误已广播） */
+function rewindBusy(hub: Hub, message = '已有回滚操作正在进行'): boolean {
+  if (!hub.rewindPending) return false
+  broadcastError(hub, message)
+  return true
 }
 
 function handleClientMessage(hub: Hub, raw: string): void {
@@ -645,10 +664,7 @@ function handleClientMessage(hub: Hub, raw: string): void {
       break
     }
     case 'user': {
-      if (hub.rewindPending) {
-        broadcastError(hub, '正在恢复文件，请等待回滚完成后再发送消息')
-        return
-      }
+      if (rewindBusy(hub, '正在恢复文件，请等待回滚完成后再发送消息')) return
       const sendMode = data.sendMode === 'steer' || data.sendMode === 'queue' ? data.sendMode : undefined
       // 图片附件：服务端统一校验（类型/大小），claude 并 content blocks，codex 落盘走 localImage
       const attachments = (
@@ -848,10 +864,7 @@ function handleClientMessage(hub: Hub, raw: string): void {
           .catch((e) => broadcastError(hub, `分叉失败: ${errorMessage(e)}`))
         return
       }
-      if (hub.rewindPending) {
-        broadcastError(hub, '已有回滚操作正在进行')
-        return
-      }
+      if (rewindBusy(hub)) return
       rewindConversation(hub, at, 'conversation')
       break
     }
@@ -862,10 +875,7 @@ function handleClientMessage(hub: Hub, raw: string): void {
         broadcastError(hub, 'Codex 没有文件检查点，不支持文件回滚（可用 git 管理代码历史）')
         return
       }
-      if (hub.rewindPending) {
-        broadcastError(hub, '已有回滚操作正在进行')
-        return
-      }
+      if (rewindBusy(hub)) return
       const s = ensureClaudeSession(hub)
       if (!s) return
 
@@ -976,7 +986,8 @@ function handleClientMessage(hub: Hub, raw: string): void {
  */
 function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision): boolean {
   if (!hub.pendingApprovals.delete(requestId)) return false
-  const s = isCodexKey(hub.key) ? codexRuntime.get(hub.key) : processManager.get(hub.key)
+  const codex = isCodexKey(hub.key)
+  const s = codex ? codexRuntime.get(hub.key) : processManager.get(hub.key)
   if (s && !s.exited) {
     try {
       s.sendApproval(requestId, decision)
@@ -987,7 +998,7 @@ function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision
     // 会话已退出/未就绪：决定无处投递（上游请求将自行超时），本地照常解析并告知用户
     broadcastError(hub, '会话未在运行，审批未能送达（该请求会在上游自行超时）')
   }
-  if (!isCodexKey(hub.key)) s?.notifyExternalGate()
+  if (!codex) s?.notifyExternalGate()
   broadcast(hub, { kind: 'approval_resolved', requestId })
   publishInbox({ type: 'approval_resolved', key: hub.key, requestId })
   pushStatus(hub)
@@ -1647,17 +1658,10 @@ function createServer(): ReturnType<typeof Bun.serve<WSData>> {
         // 不变量：任何后端的会话句柄存活期间，其 Hub 必须存活——
         // 否则重连时复用旧会话，其回调会把事件广播进已删除的 Hub（消息黑洞）。
         // 用 hub.key 而非 ws.data.key：重键后进程注册在新 key 下
-        const alive = isCodexKey(hub.key)
-          ? (() => {
-              const s = codexRuntime.get(hub.key)
-              s?.detachClient()
-              return !!s && !s.exited
-            })()
-          : (() => {
-              const s = processManager.get(hub.key)
-              s?.detachClient()
-              return !!s
-            })()
+        const codex = isCodexKey(hub.key)
+        const s = codex ? codexRuntime.get(hub.key) : processManager.get(hub.key)
+        s?.detachClient()
+        const alive = codex ? !!s && !s.exited : !!s
         if (hub.clients.size === 0) {
           stopTailer(hub)
           if (!alive) hubs.delete(hub.key)

--- a/server/src/portTakeover.ts
+++ b/server/src/portTakeover.ts
@@ -116,6 +116,16 @@ export async function describePid(pid: number): Promise<PidDesc | null> {
 
 export type TakeoverResult = 'noop' | 'freed' | 'refused' | 'unsupported'
 
+/** 在 deadlineMs 内轮询等待端口释放；释放返回 true */
+async function waitForPortFree(port: number, deadlineMs: number): Promise<boolean> {
+  const deadline = Date.now() + deadlineMs
+  while (Date.now() < deadline) {
+    if ((await listListenPids(port))?.length === 0) return true
+    await Bun.sleep(50)
+  }
+  return false
+}
+
 /**
  * 解除 port 上"自己人"残留进程的占用。
  * - 无占用 / 已禁用 → noop
@@ -157,22 +167,14 @@ export async function takeoverStaleListeners(
       process.kill(pid, 'SIGTERM')
     } catch {}
   }
-  const gracefulDeadline = Date.now() + 2000
-  while (Date.now() < gracefulDeadline) {
-    if ((await listListenPids(port))?.length === 0) return 'freed'
-    await Bun.sleep(50)
-  }
+  if (await waitForPortFree(port, 2000)) return 'freed'
   for (const pid of own) {
     try {
       process.kill(pid, 'SIGKILL')
       console.warn(`[port-takeover] pid=${pid} 未退出，已 SIGKILL`)
     } catch {}
   }
-  const forceDeadline = Date.now() + 1000
-  while (Date.now() < forceDeadline) {
-    if ((await listListenPids(port))?.length === 0) return 'freed'
-    await Bun.sleep(50)
-  }
+  if (await waitForPortFree(port, 1000)) return 'freed'
   console.error(`[port-takeover] :${port} SIGKILL 后仍被占用，接管失败`)
   return 'refused'
 }

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -10,7 +10,7 @@
 // 能力模型：直接审批 URL 只经端到端加密的推送（或受信的 webhook 渠道）投递到设备，
 // 「持有有效 secret + requestId 处于 pending」即充分条件，不依赖页面登录态。
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import {
   createCipheriv,
   createHmac,
@@ -21,10 +21,10 @@ import {
   generateKeyPairSync,
   randomBytes,
 } from 'node:crypto'
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { isLoopbackHostname } from './auth'
 import { config, type PushWebhookConfig } from './config'
+import { ccDataDir } from './util'
 
 export interface PushSubscriptionRow {
   endpoint: string
@@ -51,12 +51,6 @@ export interface PushPayload {
   tag?: string
 }
 
-function dataDir(): string {
-  const d = join(homedir(), '.cc-remote')
-  mkdirSync(d, { recursive: true }) // recursive 幂等：已存在不抛错
-  return d
-}
-
 const b64url = (b: Buffer) => b.toString('base64url')
 const hmac = (key: Buffer, data: Buffer) => createHmac('sha256', key).update(data).digest()
 /** HKDF-Expand 单块（输出 ≤32 字节，本协议全部派生都满足） */
@@ -69,7 +63,7 @@ let vapid: VapidKeys | undefined
 
 function loadVapid(): VapidKeys {
   if (!vapid) {
-    const path = join(dataDir(), 'vapid.json')
+    const path = join(ccDataDir(), 'vapid.json')
     if (existsSync(path)) {
       vapid = JSON.parse(readFileSync(path, 'utf8')) as VapidKeys
     } else {
@@ -106,15 +100,14 @@ function vapidJwt(audience: string): string {
       JSON.stringify({ aud: audience, exp: now + 12 * 3600, sub: 'mailto:cc-remote@localhost' }),
     ),
   )
+  const pubRaw = Buffer.from(keys.publicKey, 'base64url')
   const priv = createPrivateKey({
     key: {
       kty: 'EC',
       crv: 'P-256',
       d: keys.privateKey,
-      ...((): { x: string; y: string } => {
-        const raw = Buffer.from(keys.publicKey, 'base64url')
-        return { x: b64url(raw.subarray(1, 33)), y: b64url(raw.subarray(33, 65)) }
-      })(),
+      x: b64url(pubRaw.subarray(1, 33)),
+      y: b64url(pubRaw.subarray(33, 65)),
     },
     format: 'jwk',
   })
@@ -173,7 +166,7 @@ function encryptPayload(plaintext: Buffer, sub: PushSubscriptionRow): Buffer {
 let subs: PushSubscriptionRow[] | undefined
 
 function subsPath(): string {
-  return join(dataDir(), 'push-subscriptions.json')
+  return join(ccDataDir(), 'push-subscriptions.json')
 }
 
 function loadSubs(): PushSubscriptionRow[] {

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -1,5 +1,25 @@
 // 服务端通用小助手：错误文案归一化、NDJSON 行泵、平台版本闸。
 
+import { mkdirSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** cc-remote 运行数据根目录（~/.cc-remote/，约定见 AGENTS.md）；recursive mkdir 幂等 */
+export function ccDataDir(): string {
+  const dir = join(homedir(), '.cc-remote')
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+/** 读 JSON 文件；不存在或解析失败返回 undefined（调用方决定回退值） */
+export function readJsonFile<T>(path: string): T | undefined {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T
+  } catch {
+    return undefined
+  }
+}
+
 /** unknown 错误 → 单行文案（broadcast/json 响应用；console.* 请直接传原对象保留堆栈） */
 export function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e)

--- a/web/src/components/ApprovalCard.tsx
+++ b/web/src/components/ApprovalCard.tsx
@@ -52,6 +52,27 @@ export function ApprovalCard(props: {
   )
 }
 
+/** 选项按钮：预设选项与「其他」共用的单/多选条目 */
+function OptionButton(props: { pressed: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      aria-pressed={props.pressed}
+      className={`w-full rounded border px-2.5 py-2 text-left transition-colors ${
+        props.pressed
+          ? 'border-accent bg-accent/15 text-ink'
+          : 'border-line bg-surface/50 text-muted hover:border-accent/50 hover:bg-surface2'
+      }`}
+      onClick={props.onClick}
+    >
+      <span className="flex gap-2">
+        <span className="font-mono text-xs text-accent-soft">{props.pressed ? '●' : '○'}</span>
+        {props.children}
+      </span>
+    </button>
+  )
+}
+
 function AskUserQuestionCard(props: { input: AskUserQuestionInput; onDecision: (d: ApprovalDecision) => void }) {
   const { input, onDecision } = props
   const [selections, setSelections] = useState<AskUserQuestionSelections>(() =>
@@ -93,45 +114,24 @@ function AskUserQuestionCard(props: { input: AskUserQuestionInput; onDecision: (
               </div>
               <p className="text-sm font-medium text-ink">{question.question}</p>
               <div className="mt-2 space-y-1.5">
-                {question.options.map((option) => {
-                  const isSelected = selected.includes(option.label)
-                  return (
-                    <button
-                      key={option.label}
-                      type="button"
-                      aria-pressed={isSelected}
-                      className={`w-full rounded border px-2.5 py-2 text-left transition-colors ${
-                        isSelected
-                          ? 'border-accent bg-accent/15 text-ink'
-                          : 'border-line bg-surface/50 text-muted hover:border-accent/50 hover:bg-surface2'
-                      }`}
-                      onClick={() => toggleOption(question.question, option.label, question.multiSelect)}
-                    >
-                      <span className="flex gap-2">
-                        <span className="font-mono text-xs text-accent-soft">{isSelected ? '●' : '○'}</span>
-                        <span>
-                          <span className="block text-sm font-medium">{option.label}</span>
-                          <span className="block text-xs leading-relaxed text-faint">{option.description}</span>
-                        </span>
-                      </span>
-                    </button>
-                  )
-                })}
-                <button
-                  type="button"
-                  aria-pressed={otherSelected}
-                  className={`w-full rounded border px-2.5 py-2 text-left transition-colors ${
-                    otherSelected
-                      ? 'border-accent bg-accent/15 text-ink'
-                      : 'border-line bg-surface/50 text-muted hover:border-accent/50 hover:bg-surface2'
-                  }`}
+                {question.options.map((option) => (
+                  <OptionButton
+                    key={option.label}
+                    pressed={selected.includes(option.label)}
+                    onClick={() => toggleOption(question.question, option.label, question.multiSelect)}
+                  >
+                    <span>
+                      <span className="block text-sm font-medium">{option.label}</span>
+                      <span className="block text-xs leading-relaxed text-faint">{option.description}</span>
+                    </span>
+                  </OptionButton>
+                ))}
+                <OptionButton
+                  pressed={otherSelected}
                   onClick={() => toggleOption(question.question, '__other__', question.multiSelect)}
                 >
-                  <span className="flex gap-2">
-                    <span className="font-mono text-xs text-accent-soft">{otherSelected ? '●' : '○'}</span>
-                    <span className="text-sm font-medium">其他</span>
-                  </span>
-                </button>
+                  <span className="text-sm font-medium">其他</span>
+                </OptionButton>
                 {otherSelected && (
                   <textarea
                     autoFocus

--- a/web/src/components/Dialogs.tsx
+++ b/web/src/components/Dialogs.tsx
@@ -1,6 +1,37 @@
 import { useEffect, useRef, useState } from 'react'
 import { PopupPanel } from './PopupPanel'
 
+/** 弹窗底部按钮行：取消 + 确认（PromptDialog/ConfirmDialog 共用） */
+function DialogButtons(props: {
+  confirmLabel?: string
+  cancelLabel?: string
+  danger?: boolean
+  className?: string
+  onConfirm: () => void
+  onClose: () => void
+}) {
+  return (
+    <div className={`flex justify-end gap-2 ${props.className ?? ''}`}>
+      <button
+        type="button"
+        className="rounded px-2 py-1 text-xs text-muted transition-colors hover:text-ink"
+        onClick={props.onClose}
+      >
+        {props.cancelLabel ?? '取消'}
+      </button>
+      <button
+        type="button"
+        className={`rounded px-2 py-1 text-xs transition-colors ${
+          props.danger ? 'text-danger hover:text-danger/80' : 'text-accent-soft hover:text-accent'
+        }`}
+        onClick={props.onConfirm}
+      >
+        {props.confirmLabel ?? '确定'}
+      </button>
+    </div>
+  )
+}
+
 /** 文本输入弹窗：替代浏览器 prompt() */
 export function PromptDialog(props: {
   open: boolean
@@ -47,22 +78,13 @@ export function PromptDialog(props: {
           className="w-full rounded border border-line bg-bg px-2 py-1.5 text-xs text-ink outline-none transition-colors focus:border-accent/60"
           placeholder={props.placeholder}
         />
-        <div className="mt-2 flex justify-end gap-2">
-          <button
-            type="button"
-            className="rounded px-2 py-1 text-xs text-muted transition-colors hover:text-ink"
-            onClick={props.onClose}
-          >
-            {props.cancelLabel ?? '取消'}
-          </button>
-          <button
-            type="button"
-            className="rounded px-2 py-1 text-xs text-accent-soft transition-colors hover:text-accent"
-            onClick={() => props.onConfirm(value)}
-          >
-            {props.confirmLabel ?? '确定'}
-          </button>
-        </div>
+        <DialogButtons
+          className="mt-2"
+          confirmLabel={props.confirmLabel}
+          cancelLabel={props.cancelLabel}
+          onConfirm={() => props.onConfirm(value)}
+          onClose={props.onClose}
+        />
       </div>
     </PopupPanel>
   )
@@ -92,24 +114,13 @@ export function ConfirmDialog(props: {
       <div className="px-3 py-2">
         <div className="mb-1 text-xs font-medium text-ink">{props.title}</div>
         <div className="mb-3 whitespace-pre-wrap text-[11px] leading-relaxed text-muted">{props.message}</div>
-        <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            className="rounded px-2 py-1 text-xs text-muted transition-colors hover:text-ink"
-            onClick={props.onClose}
-          >
-            {props.cancelLabel ?? '取消'}
-          </button>
-          <button
-            type="button"
-            className={`rounded px-2 py-1 text-xs transition-colors ${
-              props.danger ? 'text-danger hover:text-danger/80' : 'text-accent-soft hover:text-accent'
-            }`}
-            onClick={props.onConfirm}
-          >
-            {props.confirmLabel ?? '确定'}
-          </button>
-        </div>
+        <DialogButtons
+          confirmLabel={props.confirmLabel}
+          cancelLabel={props.cancelLabel}
+          danger={props.danger}
+          onConfirm={props.onConfirm}
+          onClose={props.onClose}
+        />
       </div>
     </PopupPanel>
   )

--- a/web/src/components/MessageView.tsx
+++ b/web/src/components/MessageView.tsx
@@ -63,6 +63,18 @@ function UserText(props: { text: string }) {
   )
 }
 
+/** 图片附件：侧问卡片 / user 气泡 / assistant 块三处展示共用 */
+function ImageAttachment(props: { src?: string }) {
+  return (
+    <img
+      src={props.src}
+      alt="图片附件"
+      loading="lazy"
+      className="my-1.5 max-h-64 max-w-full rounded-md border border-line object-contain"
+    />
+  )
+}
+
 /** 抄本式消息条目：左栏角色符号 + 内容区；compact 表示与上一条同角色（连续块，收紧间距、省略符号） */
 export function MessageView(props: { msg: ChatMsg; compact?: boolean }) {
   const { msg, compact } = props
@@ -83,16 +95,7 @@ export function MessageView(props: { msg: ChatMsg; compact?: boolean }) {
           {msg.blocks.map((b, i) => {
             if (b.kind === 'text') return <Markdown key={i} text={b.text} />
             if (b.kind === 'thinking') return <Thinking key={i} text={b.text} streaming={msg.btwPending} />
-            if (b.kind === 'image')
-              return (
-                <img
-                  key={i}
-                  src={b.src}
-                  alt="图片附件"
-                  loading="lazy"
-                  className="my-1.5 max-h-64 max-w-full rounded-md border border-line object-contain"
-                />
-              )
+            if (b.kind === 'image') return <ImageAttachment key={i} src={b.src} />
             return <ToolCard key={b.id} tool={b} />
           })}
         </div>
@@ -138,16 +141,7 @@ export function MessageView(props: { msg: ChatMsg; compact?: boolean }) {
         </span>
         <div className="min-w-0 flex-1 rounded-md border border-accent/30 bg-accent/15 px-3 py-2">
           {msg.blocks.map((b, i) => {
-            if (b.kind === 'image')
-              return (
-                <img
-                  key={i}
-                  src={b.src}
-                  alt="图片附件"
-                  loading="lazy"
-                  className="my-1.5 max-h-64 max-w-full rounded-md border border-line object-contain"
-                />
-              )
+            if (b.kind === 'image') return <ImageAttachment key={i} src={b.src} />
             if (b.kind === 'text') return <UserText key={i} text={b.text} />
             if (b.kind === 'thinking') return <Thinking key={i} text={b.text} />
             return <ToolCard key={b.id} tool={b} />
@@ -171,12 +165,7 @@ export function MessageView(props: { msg: ChatMsg; compact?: boolean }) {
             </span>
             <div className="min-w-0 flex-1">
               {b.kind === 'image' ? (
-                <img
-                  src={b.src}
-                  alt="图片附件"
-                  loading="lazy"
-                  className="my-1.5 max-h-64 max-w-full rounded-md border border-line object-contain"
-                />
+                <ImageAttachment src={b.src} />
               ) : b.kind === 'text' ? (
                 <Markdown text={b.text} />
               ) : b.kind === 'thinking' ? (

--- a/web/src/components/RewindPicker.tsx
+++ b/web/src/components/RewindPicker.tsx
@@ -10,20 +10,20 @@ export interface RewindTarget {
   timestamp?: string
 }
 
-function formatTime(timestamp?: string): string | undefined {
-  if (!timestamp) return undefined
-  const date = new Date(timestamp)
-  if (Number.isNaN(date.getTime())) return undefined
-  // 模块级共享实例，避免每行渲染重复构造 Intl.DateTimeFormat
-  return timeFormatter.format(date)
-}
-
+// 模块级共享实例，避免每行渲染重复构造 Intl.DateTimeFormat
 const timeFormatter = new Intl.DateTimeFormat('zh-CN', {
   month: 'numeric',
   day: 'numeric',
   hour: '2-digit',
   minute: '2-digit',
 })
+
+function formatTime(timestamp?: string): string | undefined {
+  if (!timestamp) return undefined
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return undefined
+  return timeFormatter.format(date)
+}
 
 export function RewindPicker(props: {
   targets: RewindTarget[]

--- a/web/src/components/StatusPill.tsx
+++ b/web/src/components/StatusPill.tsx
@@ -42,7 +42,7 @@ const MODE_META: Record<string, { dot: string; label: string; short: string; des
 }
 
 /** effort 元信息兜底：非 claude 五档时按索引循环 glyph、中性色 */
-const EFFORT_GLYPHS = ['○', '◐', '⬤', '◉', '◈'] as const
+const EFFORT_GLYPH_LIST = Object.values(EFFORT_GLYPH)
 const effortMetaOf = (level: string) =>
   (EFFORT_META as Record<string, (typeof EFFORT_META)[Effort]>)[level] ?? {
     color: 'text-ok',
@@ -51,7 +51,7 @@ const effortMetaOf = (level: string) =>
     desc: '',
   }
 const effortGlyphOf = (level: string, idx: number) =>
-  (EFFORT_GLYPH as Record<string, string>)[level] ?? EFFORT_GLYPHS[idx % EFFORT_GLYPHS.length]
+  (EFFORT_GLYPH as Record<string, string>)[level] ?? EFFORT_GLYPH_LIST[idx % EFFORT_GLYPH_LIST.length]
 
 /** 毛玻璃主面板：半透明底 + blur-md。须 portal 到 body，否则会被带 backdrop-filter 的顶栏截成 backdrop root。
  *  背景特效层见 index.css 的 .cc-panel-fx（CRT 扫描线 / 点阵 / 指针磷光），子面板复用同一层 */
@@ -141,6 +141,7 @@ export function StatusPill(props: {
   const levels = props.effortLevels ?? EFFORT_LEVELS
   const effort: string = props.effort && levels.includes(props.effort) ? props.effort : (levels[Math.min(2, levels.length - 1)] ?? 'high')
   const effortMeta = effortMetaOf(effort)
+  const modelInfo = resolveModel(props.model)
 
   const panel =
     open &&
@@ -198,9 +199,9 @@ export function StatusPill(props: {
           <span className="w-10 font-mono text-[10px] uppercase tracking-widest text-faint">model</span>
           <span
             className="min-w-0 flex-1 truncate font-mono text-xs text-ink"
-            title={resolveModel(props.model).title}
+            title={modelInfo.title}
           >
-            [{resolveModel(props.model).label}]
+            [{modelInfo.label}]
           </span>
           <span className="text-[10px] text-faint">{sub === 'model' ? '▴' : '▾'}</span>
         </button>
@@ -253,8 +254,8 @@ export function StatusPill(props: {
       >
         <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${mode.dot}`} />
         <span className="shrink-0">{mode.short}</span>
-        <span className="shrink-0 text-faint" title={resolveModel(props.model).title}>
-          [{resolveModel(props.model).label}]
+        <span className="shrink-0 text-faint" title={modelInfo.title}>
+          [{modelInfo.label}]
         </span>
         <span className={`shrink-0 ${effortMeta.color}`}>{effortMeta.label}</span>
         <span className="shrink-0 text-faint">{open ? '▴' : '▾'}</span>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -23,6 +23,15 @@ async function apiError(r: Response): Promise<Error> {
   return new Error(body?.error || `HTTP ${r.status}`)
 }
 
+/** POST JSON 小封装：统一 method/headers/序列化（错误检查由调用方按需补） */
+async function postJson(path: string, body: unknown): Promise<Response> {
+  return apiFetch(path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
 export interface SessionInfo {
   sessionId: string
   cwd?: string
@@ -48,6 +57,22 @@ export interface SessionInfo {
     model?: string
     permissionMode?: string
     effort?: string
+  }
+}
+
+/**
+ * 构造本地导航用的会话条目（fork / handoff / moved / 新建共用缺省值）。
+ * 刚导航过去的会话尚无权威状态，占位字段随后由 WS status 覆盖。
+ */
+export function makeSessionInfo(
+  p: Pick<SessionInfo, 'key' | 'slug' | 'sessionId' | 'backend'> & Partial<SessionInfo>,
+): SessionInfo {
+  return {
+    mtime: Date.now(),
+    sizeBytes: 0,
+    status: 'idle',
+    managed: { spawned: false, busy: false, clients: 0 },
+    ...p,
   }
 }
 
@@ -103,11 +128,7 @@ export async function fetchCodexHistory(threadId: string): Promise<HistoryRespon
 }
 
 export async function createSession(cwd: string, backend?: 'claude' | 'codex'): Promise<{ key: string; slug: string }> {
-  const r = await apiFetch('/api/sessions', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ cwd, backend }),
-  })
+  const r = await postJson('/api/sessions', { cwd, backend })
   return r.json()
 }
 
@@ -154,30 +175,18 @@ export async function fetchLineage(key: string): Promise<LineageResponse> {
 
 /** 改名：claude 离线会话追加 custom-title；codex 走 thread/name/set */
 export async function renameSession(key: string, title: string): Promise<void> {
-  const r = await apiFetch('/api/sessions/rename', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ key, title }),
-  })
+  const r = await postJson('/api/sessions/rename', { key, title })
   if (!r.ok) throw await apiError(r)
 }
 
 /** 归档（回收站语义，无物理删除）：claude 移入 ~/.cc-remote/trash；codex 走官方 thread/archive */
 export async function archiveSession(key: string): Promise<void> {
-  const r = await apiFetch('/api/sessions/archive', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ key }),
-  })
+  const r = await postJson('/api/sessions/archive', { key })
   if (!r.ok) throw await apiError(r)
 }
 
 export async function restoreSession(key: string): Promise<void> {
-  const r = await apiFetch('/api/sessions/restore', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ key }),
-  })
+  const r = await postJson('/api/sessions/restore', { key })
   if (!r.ok) throw await apiError(r)
 }
 
@@ -222,11 +231,7 @@ export async function startHandoff(
   toBackend: 'claude' | 'codex',
   detail: 'brief' | 'standard' | 'detailed' = 'standard',
 ): Promise<void> {
-  const r = await apiFetch('/api/handoff', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ fromKey, toBackend, detail }),
-  })
+  const r = await postJson('/api/handoff', { fromKey, toBackend, detail })
   if (!r.ok) throw await apiError(r)
 }
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, startHandoff, type CodexModelInfo, type HistoryMessage, type HistoryResponse, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
+import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type HistoryMessage, type HistoryResponse, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
 import { SessionSocket, type CliMsg, type ServerEvent, type SessionState } from '../lib/ws'
 import { StatusPill, GLASS_BAR } from '../components/StatusPill'
 import { ApprovalCard } from '../components/ApprovalCard'
@@ -173,7 +173,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const moreBtnRef = useRef<HTMLButtonElement>(null)
   const querySeq = useRef(0)
   const sockRef = useRef<SessionSocket | undefined>(undefined)
-  const bottomRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const [atBottom, setAtBottom] = useState(true)
@@ -216,7 +215,14 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     setDetailOpen(false)
     setLineage(undefined)
     fetchLineage(session.key)
-      .then((r) => setLineage(r.records.length > 0 ? r : undefined))
+      // 记录按时间排序一次到位（渲染期不再重复排序）
+      .then((r) =>
+        setLineage(
+          r.records.length > 0
+            ? { ...r, records: [...r.records].sort((a, b) => a.at.localeCompare(b.at)) }
+            : undefined,
+        ),
+      )
       .catch(() => {})
   }, [session.key])
 
@@ -623,34 +629,31 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               pushSystem(
                 `⎇ 已创建分支${ev.name ? `「${ev.name}」` : ''}：新会话携带当前全部历史，原会话保持不动`,
               )
-              props.onNavigate?.({
-                key: ev.targetKey,
-                slug: session.slug,
-                sessionId: ev.branchOf,
-                cwd: session.cwd,
-                backend: 'claude',
-                mtime: Date.now(),
-                sizeBytes: 0,
-                status: 'idle',
-                managed: { spawned: false, busy: false, clients: 0 },
-              })
+              props.onNavigate?.(
+                makeSessionInfo({
+                  key: ev.targetKey,
+                  slug: session.slug,
+                  sessionId: ev.branchOf,
+                  cwd: session.cwd,
+                  backend: 'claude',
+                }),
+              )
               break
             }
             // codex 分叉回滚完成：原线程不动，跳到携带截断历史的新线程
             pushSystem('⎇ 已分叉：新会话携带所选消息之前的历史，原会话保持不动')
             setShowRewind(false)
-            props.onNavigate?.({
-              key: ev.targetKey,
-              slug: 'codex',
-              // codex 分叉路径服务端始终携带 targetSessionId（branchOf 不存在时）
-              sessionId: ev.targetSessionId ?? '',
-              cwd: session.cwd,
-              backend: 'codex',
-              mtime: Date.now(),
-              sizeBytes: 0,
-              status: 'idle',
-              managed: { spawned: true, busy: false, clients: 0 },
-            })
+            props.onNavigate?.(
+              makeSessionInfo({
+                key: ev.targetKey,
+                slug: 'codex',
+                // codex 分叉路径服务端始终携带 targetSessionId（branchOf 不存在时）
+                sessionId: ev.targetSessionId ?? '',
+                cwd: session.cwd,
+                backend: 'codex',
+                managed: { spawned: true, busy: false, clients: 0 },
+              }),
+            )
             break
           }
           case 'handoff_pending':
@@ -665,17 +668,17 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               systemKind: 'info',
               blocks: [{ kind: 'text', text: `⇄ 接力简报（已播种给 ${ev.toBackend === 'codex' ? 'Codex' : 'Claude'} 新会话）：\n\n${ev.brief}` }],
             })
-            props.onNavigate?.({
-              key: ev.targetKey,
-              slug: ev.toBackend === 'codex' ? 'codex' : session.slug,
-              sessionId: 'new',
-              cwd: session.cwd,
-              backend: ev.toBackend,
-              mtime: Date.now(),
-              sizeBytes: 0,
-              status: 'busy',
-              managed: { spawned: true, busy: true, clients: 0 },
-            })
+            props.onNavigate?.(
+              makeSessionInfo({
+                key: ev.targetKey,
+                slug: ev.toBackend === 'codex' ? 'codex' : session.slug,
+                sessionId: 'new',
+                cwd: session.cwd,
+                backend: ev.toBackend,
+                status: 'busy',
+                managed: { spawned: true, busy: true, clients: 0 },
+              }),
+            )
             break
           }
           case 'handoff_error':
@@ -743,17 +746,16 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             // /clear 对话重置：进程已换新 sessionId 续跑，Hub 重键完毕——跳到新会话页
             //（旧 transcript 在磁盘原样保留，列表页可见）
             const parts = ev.targetKey.split('|')
-            props.onNavigate?.({
-              key: ev.targetKey,
-              slug: parts[1] ?? session.slug,
-              sessionId: ev.targetSessionId ?? 'new',
-              cwd: session.cwd,
-              backend: 'claude',
-              mtime: Date.now(),
-              sizeBytes: 0,
-              status: 'idle',
-              managed: { spawned: true, busy: false, clients: 0 },
-            })
+            props.onNavigate?.(
+              makeSessionInfo({
+                key: ev.targetKey,
+                slug: parts[1] ?? session.slug,
+                sessionId: ev.targetSessionId ?? 'new',
+                cwd: session.cwd,
+                backend: 'claude',
+                managed: { spawned: true, busy: false, clients: 0 },
+              }),
+            )
             break
           }
           case 'tail_reset': {
@@ -874,21 +876,17 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     `data:${img.mediaType};base64,${img.dataBase64}`
 
   // ---------- goal 设定/清除：claude 走 /goal 斜杠命令（本地命令，不进模型上下文），codex 走 thread/goal RPC ----------
-  const setGoal = (condition: string) => {
+  const sendGoal = (condition?: string) => {
     if (isCodex) {
-      sockRef.current?.send({ kind: 'control', subtype: 'set_goal', extra: { objective: condition } })
+      sockRef.current?.send(
+        condition
+          ? { kind: 'control', subtype: 'set_goal', extra: { objective: condition } }
+          : { kind: 'control', subtype: 'clear_goal' },
+      )
     } else {
-      sockRef.current?.send({ kind: 'user', text: `/goal ${condition}` })
+      sockRef.current?.send({ kind: 'user', text: condition ? `/goal ${condition}` : '/goal clear' })
     }
-    pushSystem(`◎ 已设定目标：${condition}`)
-  }
-  const clearGoal = () => {
-    if (isCodex) {
-      sockRef.current?.send({ kind: 'control', subtype: 'clear_goal' })
-    } else {
-      sockRef.current?.send({ kind: 'user', text: '/goal clear' })
-    }
-    pushSystem('◎ 已清除目标')
+    pushSystem(condition ? `◎ 已设定目标：${condition}` : '◎ 已清除目标')
   }
 
   // ---------- StatusPill 共享处理器（claude/codex 两个胶囊的 mode/effort 同构；model 因本地回显差异分开） ----------
@@ -904,7 +902,8 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const send = () => {
     const text = input.trim()
     if ((!text && pendingImages.length === 0) || !sockRef.current) return
-    if (text === '/rewind') {
+    // /rewind 及其官方别名 /checkpoint /undo
+    if (text === '/rewind' || text === '/checkpoint' || text === '/undo') {
       setShowRewind(true)
       setInput('')
       return
@@ -931,12 +930,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       setInput('')
       return
     }
-    // /rewind 的官方别名
-    if (text === '/checkpoint' || text === '/undo') {
-      setShowRewind(true)
-      setInput('')
-      return
-    }
     // codex 的斜杠命令不会被 app-server 解释（原样进模型上下文），有对应物的必须前端拦截
     if (isCodex && text === '/compact') {
       sockRef.current.send({ kind: 'control', subtype: 'compact' })
@@ -957,8 +950,8 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     if (isCodex && /^\/goal(\s|$)/.test(text)) {
       const arg = text.slice(5).trim()
       if (!arg) pushSystem(state.goal ? `◎ 当前目标：${state.goal.condition}` : '用法：/goal <条件>，/goal clear 清除')
-      else if (/^(clear|stop|off|reset|none|cancel)$/i.test(arg)) clearGoal()
-      else setGoal(arg)
+      else if (/^(clear|stop|off|reset|none|cancel)$/i.test(arg)) sendGoal()
+      else sendGoal(arg)
       setInput('')
       return
     }
@@ -987,17 +980,9 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       const cwd = session.cwd
       if (cwd) {
         void createSession(cwd, 'codex').then(({ key }) =>
-          props.onNavigate?.({
-            key,
-            slug: 'codex',
-            sessionId: 'new',
-            cwd,
-            backend: 'codex',
-            mtime: Date.now(),
-            sizeBytes: 0,
-            status: 'offline',
-            managed: { spawned: false, busy: false, clients: 0 },
-          }),
+          props.onNavigate?.(
+            makeSessionInfo({ key, slug: 'codex', sessionId: 'new', cwd, backend: 'codex', status: 'offline' }),
+          ),
         )
       } else {
         pushSystem('⚠ 未知当前目录，无法新建线程', 'error')
@@ -1180,7 +1165,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               <ClaudeStar active={busy || Boolean(draft) || Boolean(phase)} size={28} />
             )}
           </div>
-          <div ref={bottomRef} />
         </div>
       </div>
 
@@ -1343,7 +1327,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
                   onChange={(e) => setGoalDraft(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && goalDraft.trim()) {
-                      setGoal(goalDraft.trim())
+                      sendGoal(goalDraft.trim())
                       setGoalOpen(false)
                     }
                   }}
@@ -1353,7 +1337,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
                   disabled={!goalDraft.trim()}
                   onClick={() => {
                     if (!goalDraft.trim()) return
-                    setGoal(goalDraft.trim())
+                    sendGoal(goalDraft.trim())
                     setGoalOpen(false)
                   }}
                 >
@@ -1363,7 +1347,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
                   <button
                     className="shrink-0 rounded border border-danger/60 px-2 py-1 font-mono text-[11px] text-danger"
                     onClick={() => {
-                      clearGoal()
+                      sendGoal()
                       setGoalOpen(false)
                     }}
                   >
@@ -1412,8 +1396,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
           <div className="flex items-center gap-1.5 overflow-x-auto border-t border-line/60 px-3 py-1.5 font-mono text-[10px]">
             <span className="shrink-0 text-faint">⇄ 接力链:</span>
             {lineage.records
-              .slice()
-              .sort((a, b) => a.at.localeCompare(b.at))
               .map((r) => {
                 const fromKey = r.fromResolvedKey ?? r.fromKey
                 const toKey = r.toResolvedKey ?? r.toKey

--- a/web/src/pages/SessionList.tsx
+++ b/web/src/pages/SessionList.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   archiveSession,
   createSession,
   fetchArchived,
   fetchSessions,
+  makeSessionInfo,
   renameSession,
   restoreSession,
   type ArchivedEntry,
@@ -25,6 +26,20 @@ const STATUS_META: Record<SessionInfo['status'], { cls: string; label: string }>
   idle: { cls: 'bg-ok', label: '空闲' },
   waiting: { cls: 'bg-wait', label: '等待输入' },
   offline: { cls: 'bg-faint', label: '离线' },
+}
+
+/** 通知菜单行内容：状态点 + 标题/描述 + 右侧操作文案（外壳 button/只读 div 由调用方定） */
+function NotifyRow(props: { on: boolean; title: string; desc: string; action?: string }) {
+  return (
+    <>
+      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${props.on ? 'bg-ok' : 'bg-faint'}`} />
+      <span className="min-w-0 flex-1">
+        <span className="block font-mono text-[11px] text-ink">{props.title}</span>
+        <span className="block text-[10px] leading-snug text-faint">{props.desc}</span>
+      </span>
+      {props.action && <span className="font-mono text-[10px] text-faint">{props.action}</span>}
+    </>
+  )
 }
 
 function timeAgo(ms: number): string {
@@ -257,28 +272,23 @@ export function SessionList(props: {
       .catch((err) => showToast(String(err)))
   }
 
-  // 按项目目录分组
-  const groups = new Map<string, SessionInfo[]>()
-  for (const s of sessions) {
-    const g = s.cwd ?? s.slug
-    if (!groups.has(g)) groups.set(g, [])
-    groups.get(g)!.push(s)
-  }
+  // 按项目目录分组（cwd 缺失时回退 slug）；分组时顺带记录该组的 git 分支
+  const groups = useMemo(() => {
+    const m = new Map<string, { list: SessionInfo[]; branch?: string }>()
+    for (const s of sessions) {
+      const g = s.cwd ?? s.slug
+      let e = m.get(g)
+      if (!e) m.set(g, (e = { list: [] }))
+      e.list.push(s)
+      e.branch ??= s.gitBranch
+    }
+    return m
+  }, [sessions])
 
   const startNew = async (cwd: string, backend: 'claude' | 'codex') => {
     const { key, slug } = await createSession(cwd, backend)
     setPickerOpen(false)
-    props.onSelect({
-      key,
-      slug,
-      sessionId: 'new',
-      cwd,
-      backend,
-      mtime: Date.now(),
-      sizeBytes: 0,
-      status: 'offline',
-      managed: { spawned: false, busy: false, clients: 0 },
-    })
+    props.onSelect(makeSessionInfo({ key, slug, sessionId: 'new', cwd, backend, status: 'offline' }))
   }
 
   return (
@@ -321,12 +331,12 @@ export function SessionList(props: {
                       className="flex w-full items-center gap-2 rounded px-1.5 py-1.5 text-left hover:bg-surface2"
                       onClick={toggleNotify}
                     >
-                      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${notify ? 'bg-ok' : 'bg-faint'}`} />
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-mono text-[11px] text-ink">页内通知</span>
-                        <span className="block text-[10px] leading-snug text-faint">页面在后台时弹桌面通知</span>
-                      </span>
-                      <span className="font-mono text-[10px] text-faint">{notify ? '开' : '关'}</span>
+                      <NotifyRow
+                        on={notify}
+                        title="页内通知"
+                        desc="页面在后台时弹桌面通知"
+                        action={notify ? '开' : '关'}
+                      />
                     </button>
                     {/* Web Push：SW 离线可达，支持锁屏直接审批 */}
                     <button
@@ -334,37 +344,31 @@ export function SessionList(props: {
                       onClick={togglePush}
                       disabled={pushBusy || !pushSupported()}
                     >
-                      <span
-                        className={`h-1.5 w-1.5 shrink-0 rounded-full ${pushEndpoint ? 'bg-ok' : 'bg-faint'}`}
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-mono text-[11px] text-ink">
-                          {pushBusy ? '处理中…' : '推送通知'}
-                        </span>
-                        <span className="block text-[10px] leading-snug text-faint">
-                          {pushSupported()
+                      <NotifyRow
+                        on={!!pushEndpoint}
+                        title={pushBusy ? '处理中…' : '推送通知'}
+                        desc={
+                          pushSupported()
                             ? pushEndpoint
                               ? '已订阅：锁屏可达，通知上可直接审批'
                               : '锁屏/杀掉页面也能收到，通知上可直接审批'
-                            : '当前浏览器不支持（iOS 需先加到主屏幕）'}
-                        </span>
-                      </span>
-                      {pushSupported() && (
-                        <span className="font-mono text-[10px] text-faint">{pushEndpoint ? '退订' : '订阅'}</span>
-                      )}
+                            : '当前浏览器不支持（iOS 需先加到主屏幕）'
+                        }
+                        action={pushSupported() ? (pushEndpoint ? '退订' : '订阅') : undefined}
+                      />
                     </button>
                     {/* webhook 通道：配置文件管理（ntfy/Bark/Server酱），只读展示 */}
                     <div className="flex w-full items-center gap-2 rounded px-1.5 py-1.5">
-                      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${pushWebhooks > 0 ? 'bg-ok' : 'bg-faint'}`} />
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-mono text-[11px] text-ink">Webhook 通道</span>
-                        <span className="block text-[10px] leading-snug text-faint">
-                          {pushWebhooks > 0
+                      <NotifyRow
+                        on={pushWebhooks > 0}
+                        title="Webhook 通道"
+                        desc={
+                          pushWebhooks > 0
                             ? `已配置 ${pushWebhooks} 个（ntfy/Bark/Server酱）`
-                            : '国内 Android 无 FCM 的出路，见 README 配置'}
-                        </span>
-                      </span>
-                      <span className="font-mono text-[10px] text-faint">{pushWebhooks > 0 ? `${pushWebhooks}` : ''}</span>
+                            : '国内 Android 无 FCM 的出路，见 README 配置'
+                        }
+                        action={pushWebhooks > 0 ? `${pushWebhooks}` : undefined}
+                      />
                     </div>
                     {/* 通道自检：一键向全部通道发测试通知 */}
                     <button
@@ -372,12 +376,12 @@ export function SessionList(props: {
                       onClick={sendTestPush}
                       disabled={pushTestBusy}
                     >
-                      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-faint" />
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-mono text-[11px] text-ink">{pushTestBusy ? '发送中…' : '测试通知'}</span>
-                        <span className="block text-[10px] leading-snug text-faint">向全部订阅与 webhook 通道各发一条</span>
-                      </span>
-                      <span className="font-mono text-[10px] text-faint">发送</span>
+                      <NotifyRow
+                        on={false}
+                        title={pushTestBusy ? '发送中…' : '测试通知'}
+                        desc="向全部订阅与 webhook 通道各发一条"
+                        action="发送"
+                      />
                     </button>
                   </div>
                   </>,
@@ -451,8 +455,7 @@ export function SessionList(props: {
             <p className="mt-1 text-xs text-faint">点「+ 新会话」，从文件系统选择项目目录即可开始。</p>
           </div>
         )}
-        {[...groups.entries()].map(([cwd, list]) => {
-          const branch = list.find((s) => s.gitBranch)?.gitBranch
+        {[...groups.entries()].map(([cwd, group]) => {
           const folded = collapsed.has(cwd)
           return (
           <div key={cwd}>
@@ -473,9 +476,9 @@ export function SessionList(props: {
             >
               <span className="w-3 shrink-0 text-muted">{folded ? '▸' : '▾'}</span>
               <span className="truncate">{cwd}</span>
-              {branch && <span className="ml-auto shrink-0 text-muted">⎇ {branch}</span>}
+              {group.branch && <span className="ml-auto shrink-0 text-muted">⎇ {group.branch}</span>}
             </button>
-            {!folded && list.map((s) => {
+            {!folded && group.list.map((s) => {
               const st =
                 STATUS_META[
                   s.managed.waiting ? 'waiting' : s.managed.busy ? 'busy' : s.managed.spawned ? 'idle' : s.status


### PR DESCRIPTION
## 概要

对整个仓库（server/、web/、scripts/ 全部 TS/TSX）按 /simplify 标准做了一轮质量清理：复用、简化、效率、altitude。不改任何行为；`bun test` 全绿（193 pass），`vite build` 通过，`tsc --noEmit` 无新增错误（scripts/gateway.ts 的 4 个错误为 master 既有）。

## 关键改动

### server 顶层
- `util.ts` 新增 `ccDataDir()` / `readJsonFile()`：push/handoff/archive 三处 `~/.cc-remote` 目录创建与 JSON 读取样板改为复用
- `index.ts`：提取 `baseStatusOf()` 消除 `statusOf`/`codexStatusOf` 公共字段重复；`rewindPending` 拒绝守卫三处合并为 `rewindBusy()`；WS close 的双 IIFE 拍平；删除冗余 `if (hub.spawnOpts)`
- `archive.ts` 删除永不命中的 `.meta.json`/`.bak` 过滤；`portTakeover.ts` 提取 `waitForPortFree()` 消除两段轮询重复；`push.ts` 消除 `vapidJwt` 内的 IIFE；`config.ts` 修正过时的配置路径注释

### backends
- codex `translate.ts`：`streamStart`/`assistantFinal`/`pushToolPair` 消除 agentMessage/reasoning 起止流与四轮工具项配对的重复
- codex `runtime.ts`：`paginate()` 统一 model/list 与 thread/list 分页循环；`startTurn()` 统一 steer 回退与正常路径的 turn/start；`mapPermissionMode` 按映射结果合并重复 case
- claude `discovery.ts`：`textOfContent()` 统一三处 content→纯文本提取，删除 no-op else；`processManager.ts`：spawn 的 IIFE 改为直接 try/catch，usage 四字段累加合并

### web
- `lib/api.ts`：`postJson()` 统一 5 处 POST JSON 样板；`makeSessionInfo()` 统一 fork/handoff/moved/新建共 6 处会话条目缺省构造
- 组件提取：MessageView `ImageAttachment`（三处相同 img）、ApprovalCard `OptionButton`、Dialogs `DialogButtons`、SessionList `NotifyRow`
- StatusPill：`EFFORT_GLYPHS` 派生自 `EFFORT_GLYPH`（消除字面量重复）、`resolveModel` 单次求值
- Chat：删除从未读取的 `bottomRef`；`/rewind` 与别名 `/checkpoint` `/undo` 合并；`setGoal`/`clearGoal` 合并为 `sendGoal`；接力链排序移到 fetch 时一次完成（原每次渲染 sort）
- SessionList：groups 分组改 `useMemo` 并顺带预取分组 git 分支

### scripts
- 新增 `server/scripts/e2e-lib.ts`（`makeNote`/`exitWithSummary`/`connect`），消除 5 个 e2e 脚本逐字复制的 `note()` 与两处 WS 连接封装
- gateway.ts：删除无效三元、header 过滤循环收敛为 `copyHeaders`、`str()` 不再重复 trim
- e2e-slash 嵌套三元化简；e2e-codex 删除 `proc.stderr` 死 guard；e2e-handoff 关键词正则提为模块级常量；lab-run 注释修正硬编码路径

## 有意未做

- 超大函数的整体拆分（`handleClientMessage`/`handleApi`/`handleCli`/`SessionList` 等）：属于结构性重构，diff 大且回归风险高，不适合混入本轮清理
- `blocks.ts:100` 的 `?? ''`：核实后并非死分支（`JSON.stringify(undefined)` 返回 undefined），保留
- 三处分段按钮样式各异，提取共享组件属于强行抽象，保留现状