### PR TITLE
security: 全仓库安全审查修复（DNS rebinding 防线、私有目录权限、mock 绑回环）

### DIFF
--- a/scripts/gateway.ts
+++ b/scripts/gateway.ts
@@ -9,10 +9,11 @@
 //          http://cc-remote-dev.devcloud.woa.com/       永远开发（需在 DevCloud 再挂一个域名）
 //   https:// 同源分流（自签证书；平台若在边缘终结 TLS，则只会打到明文 80）
 
-import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { detectProtocol, isOwnGatewayCmd, modeCookie, parseSsListenPids, pickMode, type Mode } from './gateway-lib'
+import { ensurePrivateDir } from '../server/src/util'
 
 type GatewayCfg = {
   httpPort: number
@@ -120,8 +121,8 @@ function certSan(cfg: GatewayCfg): string {
 }
 
 async function ensureCerts(cfg: GatewayCfg): Promise<{ cert: string; key: string }> {
-  const dir = join(homedir(), '.cc-remote', 'certs')
-  mkdirSync(dir, { recursive: true })
+  // TLS 私钥落 ~/.cc-remote/certs：目录收紧 700（ensurePrivateDir）
+  const dir = ensurePrivateDir(join(homedir(), '.cc-remote', 'certs'))
   const certPath = join(dir, 'gateway.crt')
   const keyPath = join(dir, 'gateway.key')
   if (existsSync(certPath) && existsSync(keyPath)) {

--- a/scripts/gateway.ts
+++ b/scripts/gateway.ts
@@ -186,7 +186,7 @@ function htmlPage(title: string, body: string): Response {
   )
 }
 
-function filterReqHeaders(req: Request, proto: string): Headers {
+function filterReqHeaders(req: Request, proto: string, target: string): Headers {
   const out = new Headers()
   req.headers.forEach((v, k) => {
     if (HOP.has(k.toLowerCase())) return
@@ -196,6 +196,11 @@ function filterReqHeaders(req: Request, proto: string): Headers {
   if (host) out.set('x-forwarded-host', host)
   out.set('x-forwarded-proto', proto)
   out.set('x-cc-remote-gateway', '1')
+  // 上游无 token 模式要求 Host 为回环（DNS rebinding 防线）：反代统一改写为上游 authority，
+  // 并剥除浏览器 Origin（公网域名会被上游判成跨源）——网关即信任边界，剥除不削弱防线：
+  // token 模式不查 Origin/Host；无 token 时网关本身需 --insecure 才起得来（已是有意的全暴露）。
+  out.set('host', new URL(target).host)
+  out.delete('origin')
   return out
 }
 
@@ -213,7 +218,7 @@ async function proxyHttp(req: Request, target: string, proto: string, mode: Mode
   const dest = new URL(url.pathname + url.search, target)
   const init: RequestInit = {
     method: req.method,
-    headers: filterReqHeaders(req, proto),
+    headers: filterReqHeaders(req, proto, target),
     redirect: 'manual',
   }
   if (req.method !== 'GET' && req.method !== 'HEAD' && req.body) {

--- a/server/scripts/e2e-push.ts
+++ b/server/scripts/e2e-push.ts
@@ -35,6 +35,7 @@ const captured = new Map<string, Captured>()
 const gonePaths = new Set<string>()
 const mock = Bun.serve({
   port: 18999,
+  hostname: '127.0.0.1', // mock 只服务本机被测服务端，不暴露到局域网
   async fetch(req) {
     const url = new URL(req.url)
     const headers: Record<string, string> = {}

--- a/server/src/archive.ts
+++ b/server/src/archive.ts
@@ -7,11 +7,10 @@ import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, r
 import { homedir } from 'node:os'
 import { basename, join } from 'node:path'
 import { config } from './config'
+import { ensurePrivateDir } from './util'
 
 function trashRoot(): string {
-  const dir = join(homedir(), '.cc-remote', 'trash', 'claude')
-  mkdirSync(dir, { recursive: true }) // recursive 幂等：已存在不抛错
-  return dir
+  return ensurePrivateDir(join(homedir(), '.cc-remote', 'trash', 'claude'))
 }
 
 /** rename 的跨文件系统兜底：CLAUDE_CONFIG_DIR 可指到与 ~/.cc-remote 不同的挂载点（EXDEV） */

--- a/server/src/auth.test.ts
+++ b/server/src/auth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import {
+  hostAllowed,
   hostNameOf,
   isAuthorized,
   isLoopbackHost,
@@ -107,6 +108,32 @@ describe('originAllowed（无 token 模式的 CSWSH 防线）', () => {
 
   test('非法 Origin URL 拒绝', () => {
     expect(originAllowed(withHeaders({ host: '127.0.0.1:7480', origin: 'not a url' }))).toBe(false)
+  })
+})
+
+describe('hostAllowed（无 token 模式的 DNS rebinding 防线）', () => {
+  const withHost = (host?: string) =>
+    new Request('http://127.0.0.1:7480/api/sessions', host ? { headers: { host } } : undefined)
+
+  test('回环 Host 放行（直连/Vite 代理/SSH 转发）', () => {
+    expect(hostAllowed(withHost('127.0.0.1:7480'))).toBe(true)
+    expect(hostAllowed(withHost('localhost:5173'))).toBe(true)
+    expect(hostAllowed(withHost('[::1]:7480'))).toBe(true)
+    expect(hostAllowed(withHost('127.1.2.3:7480'))).toBe(true)
+  })
+
+  test('缺 Host 头放行（HTTP/1.0/非浏览器客户端；浏览器必定携带）', () => {
+    expect(hostAllowed(withHost())).toBe(true)
+  })
+
+  test('rebinding 场景拒绝：攻击者域名 rebind 到 127.0.0.1 后，浏览器 Host 是攻击者域名', () => {
+    // Origin 与 Host 同名同宿主（originAllowed 的"相同放行"分支救不了这个场景），
+    // Host 是浏览器禁改头，攻击者无法谎称回环
+    expect(hostAllowed(withHost('attacker.com:7480'))).toBe(false)
+    expect(hostAllowed(withHost('cc-remote.devcloud.woa.com'))).toBe(false)
+    expect(hostAllowed(withHost('localhost.evil.com:7480'))).toBe(false)
+    // 内网 IP 也不是回环
+    expect(hostAllowed(withHost('192.168.1.10:7480'))).toBe(false)
   })
 })
 

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -18,7 +18,8 @@ export function isAuthorized(req: Request, url: URL): boolean {
 
 // ---------- 跨源防护（无 token 回环部署的浏览器攻击面） ----------
 // WebSocket 不受同源策略约束、text/plain 简单请求不触发 preflight——
-// 默认无 token 时恶意网页可经受害者浏览器直连回环服务（CSWSH/CSRF → RCE）。
+// 默认无 token 时恶意网页可经受害者浏览器直连回环服务（CSWSH/CSRF → RCE）；
+// DNS rebinding 则让攻击者域名解析到 127.0.0.1，把跨源变成"同源"（靠 Host 回环白名单封堵）。
 // 浏览器在 WS 握手与跨源 POST 时必定携带 Origin；非浏览器客户端（e2e 脚本/curl）不带。
 // 配置 authToken 后 token 即防线，以下检查不生效（行为与旧版完全一致）。
 
@@ -33,6 +34,18 @@ export function isLoopbackHostname(h: string): boolean {
   // WHATWG URL 的 IPv6 hostname 保留方括号（http://[::1]:9001 → "[::1]"）
   const n = h.startsWith('[') && h.endsWith(']') ? h.slice(1, -1) : h
   return n === 'localhost' || n === '::1' || n.startsWith('127.')
+}
+
+/** Host 头必须是回环地址（无 token 模式的 DNS rebinding 防线）。
+ *  Origin↔Host 一致性挡不住 rebinding：攻击者域名 rebind 到 127.0.0.1 后，浏览器发出的是
+ *  同源请求，Origin 与 Host 同为攻击者域名，恰好命中 originAllowed 的"相同放行"分支。
+ *  Host 是浏览器禁改头（forbidden header），攻击者页面无法让它谎称回环；
+ *  无 token 时启动闸已保证只绑回环，合法浏览器入口（直连/Vite 代理/SSH 转发）Host 必然回环。
+ *  缺 Host 头放行（HTTP/1.0、非浏览器客户端；浏览器必定携带）。 */
+export function hostAllowed(req: Request): boolean {
+  const host = req.headers.get('host')
+  if (!host) return true
+  return isLoopbackHostname(hostNameOf(host))
 }
 
 /** Origin 与 Host 同 host，或同为回环（dev 模式 Vite :5173 代理到 server :7480 的端口差） */

--- a/server/src/backends/codex/reasoningStore.ts
+++ b/server/src/backends/codex/reasoningStore.ts
@@ -2,9 +2,10 @@
 // full 视图实测只有 userMessage+agentMessage），cc-remote 自行落盘并在历史读取时按
 // turn 时间窗回插，让"思考"在重进会话后仍可见。
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { appendFileSync, existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { ensurePrivateDir } from '../../util'
 
 export interface ReasoningEntry {
   /** Unix ms */
@@ -14,9 +15,7 @@ export interface ReasoningEntry {
 }
 
 function dir(): string {
-  const d = join(homedir(), '.cc-remote', 'reasoning')
-  mkdirSync(d, { recursive: true }) // recursive 幂等：已存在不抛错
-  return d
+  return ensurePrivateDir(join(homedir(), '.cc-remote', 'reasoning'))
 }
 
 function pathOf(threadId: string): string {

--- a/server/src/handoff.ts
+++ b/server/src/handoff.ts
@@ -2,13 +2,13 @@
 // 已在 handoff-lab 实验验证：两家的"对话内隐藏设计"可经简报无损传递（见 docs/PLAN 附录）。
 
 import { spawn } from 'bun'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { resolveClaudeCommand } from './backends/claude/processManager'
 import { codexRuntime } from './backends/codex/runtime'
 import type { BackendName } from './backends/types'
-import { pumpLines } from './util'
+import { ensurePrivateDir, pumpLines } from './util'
 
 export type HandoffDetail = 'brief' | 'standard' | 'detailed'
 
@@ -139,9 +139,7 @@ export interface LineageRecord {
 }
 
 function lineageDir(): string {
-  const dir = join(homedir(), '.cc-remote')
-  mkdirSync(dir, { recursive: true }) // recursive 幂等：已存在不抛错
-  return dir
+  return ensurePrivateDir(join(homedir(), '.cc-remote'))
 }
 
 function lineagePath(): string {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,7 +3,7 @@
 import { appendFileSync, existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
 import { join, resolve } from 'node:path'
-import { isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
+import { hostAllowed, isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
 import { keyFor, keyForBranch, keyForNew, parseKey, splitExistingKey, type ParsedKey } from './backends/claude/backend'
 import { listSessions, liveSessionInfo, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
 import { resolveTierModelNames } from './backends/claude/modelNames'
@@ -1547,7 +1547,12 @@ function createServer(): ReturnType<typeof Bun.serve<WSData>> {
 
       // 跨源防护：仅在无 token 模式生效（此时唯一防线）。approval-action 走能力 URL，
       // SW 回 POST 无页面 Origin 语义，且其鉴权是 per-subscription secret，不在此约束。
+      // hostAllowed 在最前：DNS rebinding 下 Origin 与 Host 同为攻击者域名，
+      // Origin↔Host 一致性天然失效，Host 回环白名单才是不依赖攻击者行为的锚点。
       if (!config.authToken && guarded) {
+        if (!hostAllowed(req)) {
+          return json({ error: 'host not allowed' }, { status: 403 })
+        }
         if (!originAllowed(req)) {
           return json({ error: 'origin not allowed' }, { status: 403 })
         }

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -10,7 +10,7 @@
 // 能力模型：直接审批 URL 只经端到端加密的推送（或受信的 webhook 渠道）投递到设备，
 // 「持有有效 secret + requestId 处于 pending」即充分条件，不依赖页面登录态。
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import {
   createCipheriv,
   createHmac,
@@ -25,6 +25,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { isLoopbackHostname } from './auth'
 import { config, type PushWebhookConfig } from './config'
+import { ensurePrivateDir } from './util'
 
 export interface PushSubscriptionRow {
   endpoint: string
@@ -52,9 +53,7 @@ export interface PushPayload {
 }
 
 function dataDir(): string {
-  const d = join(homedir(), '.cc-remote')
-  mkdirSync(d, { recursive: true }) // recursive 幂等：已存在不抛错
-  return d
+  return ensurePrivateDir(join(homedir(), '.cc-remote'))
 }
 
 const b64url = (b: Buffer) => b.toString('base64url')

--- a/server/src/uploads.ts
+++ b/server/src/uploads.ts
@@ -2,9 +2,10 @@
 // 用户自行管理（不自动清理）；hash 命名去重，同名同内容不会重复占盘。
 
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { ensurePrivateDir } from './util'
 
 export const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'] as const
 /** claude API 硬限制：base64 后 5MB（constants/apiLimits.ts） */
@@ -17,9 +18,7 @@ export interface ImageAttachment {
 }
 
 export function uploadsDir(): string {
-  const dir = join(homedir(), '.cc-remote', 'uploads')
-  mkdirSync(dir, { recursive: true }) // recursive 幂等：已存在不抛错
-  return dir
+  return ensurePrivateDir(join(homedir(), '.cc-remote', 'uploads'))
 }
 
 const EXT_OF: Record<string, string> = {

--- a/server/src/util.test.ts
+++ b/server/src/util.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test'
-import { errorMessage, pumpLines } from './util'
+import { chmodSync, mkdtempSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ensurePrivateDir, errorMessage, pumpLines } from './util'
 
 function streamOf(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -67,5 +70,41 @@ describe('errorMessage', () => {
     expect(errorMessage('字符串错误')).toBe('字符串错误')
     expect(errorMessage(42)).toBe('42')
     expect(errorMessage(undefined)).toBe('undefined')
+  })
+})
+
+describe('ensurePrivateDir（~/.cc-remote 私有目录）', () => {
+  // POSIX 权限语义测试；Windows 的 chmod 语义不同，跳过断言仅保证不抛错
+  test('新建目录与既有宽松目录都收紧为 700', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ccr-util-'))
+    try {
+      const dir = join(root, '.cc-remote', 'uploads')
+      expect(ensurePrivateDir(dir)).toBe(dir)
+      if (process.platform !== 'win32') {
+        // .cc-remote 根与目标层都是 700
+        expect(statSync(join(root, '.cc-remote')).mode & 0o777).toBe(0o700)
+        expect(statSync(dir).mode & 0o777).toBe(0o700)
+      }
+      // 幂等：重复调用不抛错
+      expect(ensurePrivateDir(dir)).toBe(dir)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('路径不含 .cc-remote 段时只收紧目标目录本身', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ccr-util-'))
+    try {
+      if (process.platform !== 'win32') chmodSync(root, 0o755) // mkdtemp 默认 700，先放宽以观察不受影响
+      const dir = join(root, 'plain')
+      expect(ensurePrivateDir(dir)).toBe(dir)
+      if (process.platform !== 'win32') {
+        expect(statSync(dir).mode & 0o777).toBe(0o700)
+        // 父目录不受影响
+        expect(statSync(root).mode & 0o777).toBe(0o755)
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -1,8 +1,34 @@
 // 服务端通用小助手：错误文案归一化、NDJSON 行泵、平台版本闸。
 
+import { chmodSync, mkdirSync } from 'node:fs'
+
 /** unknown 错误 → 单行文案（broadcast/json 响应用；console.* 请直接传原对象保留堆栈） */
 export function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e)
+}
+
+/**
+ * ~/.cc-remote 下的私有数据目录：递归创建并把 .cc-remote 根到目标的每层收紧为 700
+ *（vapid 私钥、推送订阅注册表、接力血缘简报、reasoning 侧车、网关 TLS 私钥都落在这里）。
+ * mkdir 的 mode 只对新建目录生效，旧版本已建出的 755 目录靠 chmod 逐段兜底；
+ * chmod 在 Windows 上语义有限，失败静默（NTFS 另有权限模型）。
+ */
+export function ensurePrivateDir(dir: string): string {
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  const parts = dir.split(/[\\/]/)
+  const base = parts.lastIndexOf('.cc-remote')
+  const targets: string[] = []
+  if (base >= 0) {
+    for (let i = base; i < parts.length; i++) targets.push(parts.slice(0, i + 1).join('/'))
+  } else {
+    targets.push(dir)
+  }
+  for (const p of targets) {
+    try {
+      chmodSync(p, 0o700)
+    } catch {}
+  }
+  return dir
 }
 
 /** Bun <=1.3.14 在 Windows 存在监听 socket 被子进程继承的 bug（oven-sh/bun#36936）；


### PR DESCRIPTION
## 背景

对整个仓库（server/、web/、scripts/ 全部 TS/TSX，非仅 diff）做了一轮安全审查，重点覆盖注入、认证/授权绕过、CORS/跨源防护、密钥泄露、SSRF、路径穿越、不安全默认值、WebSocket 鉴权缺口。既有的刻意安全设计（能力 URL 绕开 authToken、订阅 endpoint 白名单、无 token 时的 Origin/Content-Type 双闸、端口接管双校验等）均识别为防线并予以保留。

## 发现 → 修复

### 1. DNS rebinding 可绕过无 token 模式的全部跨源防线（中高危，已修复）

**证据链**：
- `server/src/auth.ts` `originAllowed`（原 39-52 行）：`o.host === host` 即放行——Origin 与 Host 都来自请求头。
- 攻击场景：受害者浏览 `http://attacker.com:7480/`（攻击者自己的服务器），随后 DNS rebind 把 attacker.com 解析到 127.0.0.1。此后浏览器发出的是**同源请求**：`Host: attacker.com:7480`、`Origin: http://attacker.com:7480`——恰好命中 `o.host === host` 放行分支。WS 无同源策略、同源 POST 免 CORS preflight，恶意页面由此完整驱动 `/api` 与 `/ws`（任意目录起会话 = 任意命令执行）。运行时验证：rebinding 形态下 `originAllowed()` 返回 `true`。
- `server/src/index.ts`（原 1550-1557 行）：无 token 模式只查 Origin 与 Content-Type，不校验 Host 本身。

**修复**：
- `server/src/auth.ts` 新增 `hostAllowed()`：无 token 模式的 guarded 路径要求 Host 为回环（localhost / 127.0.0.0/8 / ::1）。Host 是浏览器禁改头，攻击者无法谎称回环；缺 Host 放行（非浏览器客户端，与 originAllowed 同哲学）。
- `server/src/index.ts` 无 token 分支最前面加 hostAllowed 检查（403）。
- `scripts/gateway.ts` `filterReqHeaders`：反代统一把 Host 改写为上游 authority 并剥除浏览器 Origin——否则无 token + `--insecure` 的网关路径（公网 Host/Origin）会被新校验误伤。网关即信任边界：token 模式本就不查 Origin/Host；`--insecure` 本身是有意的全暴露（无 token 时网关拒绝启动，除非显式 --insecure）。剥除不削弱任何防线。
- 新增 `auth.test.ts` 的 hostAllowed 测试组（回环放行/缺 Host 放行/rebinding 拒绝）。
- 端到端验证：无 token 起服，回环请求 200；`Host: attacker.com`（含 Origin==Host 形态、WS 升级形态）全部 403；既有跨源 403 / text-plain 415 / 合法 JSON POST 行为不变；token 模式下公网 Host + 正确 token 200（行为与旧版一致）。

### 2. ~/.cc-remote 私有数据目录按 755 创建，同机其他用户可读会话敏感内容（低危，已修复）

**证据**：`server/src/push.ts:56`、`uploads.ts:21`、`handoff.ts:143`、`backends/codex/reasoningStore.ts:18`、`archive.ts:13`、`scripts/gateway.ts:124` 均 `mkdirSync(dir, { recursive: true })` 不带 mode。vapid.json / push-subscriptions.json 文件本身是 600，但目录树 755 使同机其他用户可读取：接力血缘简报（lineage.json，含对话摘要）、codex reasoning 侧车、上传图片、回收站 transcript、网关 TLS 私钥（certs/gateway.key）。

**修复**：新增 `util.ensurePrivateDir()`——递归创建并把 `.cc-remote` 根到目标逐层收紧 700（mkdir 的 mode 只对新建生效，既有 755 目录靠 chmod 逐段兜底；Windows chmod 失败静默）。六个建目录点统一接入；`util.test.ts` 补权限测试。实测：新建 700、既有 755 目录被收紧为 700、vapid.json 仍 600。

### 3. e2e-push 的 mock push service 绑 0.0.0.0（轻微，已修复）

**证据**：`server/scripts/e2e-push.ts:36` `Bun.serve({ port: 18999 })` 缺省绑全网卡，测试运行期间 mock 端点（能看到投递载荷）暴露到局域网。**修复**：`hostname: '127.0.0.1'`。

## 确认无问题的主要面（审查记录）

- **路径穿越**：`/api/history/:slug/:sessionId` 与 `/api/uploads/:name` 的参数取自 `url.pathname`——WHATWG URL 解析会消解 `..` 与 `%2e%2e` 段（已运行时验证），`%2f` 不解码；归档/恢复/改名路径另有 `splitExistingKey` 的 `^[a-zA-Z0-9-]+$` 安全闸（backends/claude/backend.ts:53-59）；`resolveUpload` 的 hash 文件名正则严格（uploads.ts:50）。
- **SSRF**：推送订阅注册有 endpoint 白名单 + 投递 `redirect: 'manual'`（push.ts:240-254、278-281）；webhook 通道配置即信任（无浏览器注册面），能力密钥为 HMAC(vapid 私钥, 渠道标识) 派生不落状态。
- **注入**：全部子进程 spawn 均为 argv 数组形式（无 shell 拼接）；审批确认页 HTML 对会话名/工具名/摘要全部转义（index.ts escapeHtml），secret 不写进 HTML；前端无 dangerouslySetInnerHTML，react-markdown v10 无 rehype-raw 且默认 urlTransform 已净化 `javascript:` 链接。
- **能力 URL**：`/api/approval-action` 仅 POST、`/api/approval-page` GET 只渲染（防预览抓取误触）、`validSecret('')` 恒 false、仅对 pending 中的 requestId 有效——按设计，保留。
- **进程清理**：端口接管要求 cmdline+cwd 双命中才杀（portTakeover.ts），Windows 不自动杀。

## 残留风险（疑似/接受，未改动，供人工判断）

1. **token 明文比较**：`isAuthorized`（auth.ts:13-15）与 `validSecret`（push.ts:261-265）用 `===` 比较，理论上有时序侧信道；网络条件下利用难度高，未改。
2. **无认证速率限制**：token 可在线爆破；docs/public-access.md 已要求 ≥32 随机字符，熵足够时不可行。如需要可加失败计数退避。
3. **`GET /api/fs/list?path=` 暴露目录结构**：README/AGENTS 已声明该端点与"任意目录起会话 = 任意命令执行"同级，属已知接受风险（鉴权后）。
4. **WS `attach` 接受客户端 spawn opts**（cwd/resumeSessionId/forkFromSessionId，index.ts:619-633）：已认证客户端本就可经 REST 创建任意目录会话，信任模型内，非提权。
5. **网关 `/__gateway` 状态页无鉴权**：泄露后端存活状态与域名（gateway.ts:247-260），敏感性低。
6. **token 存 localStorage**：XSS 可窃取；本轮未发现 XSS 注入面。
7. **LAN 模式把带 token 的 URL 打印到终端并生成二维码**（index.ts:1715-1732）：刻意的扫码 onboarding 设计。
8. **能力密钥不区分会话**：任一订阅的 secret 可裁决任意 pending 审批（push.ts 能力模型注释已声明"持有有效 secret + pending 即充分条件"），刻意设计。
9. **预存 tsc 报错**：`scripts/gateway.ts` 有 4 个基线已存在的类型错误（Socket 泛型与 startMux 端口），与本次改动无关，未顺手修。

## 测试

`bun test`：198 pass / 0 fail（含新增 hostAllowed 4 用例、ensurePrivateDir 2 用例）。