### PR TITLE
code review: 全仓库审查修复（auth/push/rpc/标题回收/gateway/archive）

### DIFF
--- a/scripts/gateway.ts
+++ b/scripts/gateway.ts
@@ -267,7 +267,14 @@ server ${prodUp ? '<span class="ok">在线</span>' : '<span class="bad">离线</
       const dest = `${target.replace(/^http/, 'ws')}${url.pathname}${url.search}`
       // 子协议必须随 data 带进 open()：Vite 6 的 HMR 只认 vite-hmr / vite-ping 子协议，
       // 缺了它后端握手永远挂起，Bun WS 客户端 120s 超时断连 → 前端整页刷新（本 bug 根因）。
-      const protocols = req.headers.get('sec-websocket-protocol') ?? undefined
+      // 多个子协议按 RFC 以逗号分隔，必须拆成数组后传，否则会被视为一个组合协议名而握手失败。
+      const rawProtocols = req.headers.get('sec-websocket-protocol')
+      const protocols = rawProtocols
+        ? rawProtocols
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined
       if (srv.upgrade(req, { data: { dest, protocols, queue: [] } })) return undefined
       return new Response('WebSocket upgrade failed', { status: 400 })
     }

--- a/server/src/archive.ts
+++ b/server/src/archive.ts
@@ -14,13 +14,24 @@ function trashRoot(): string {
   return dir
 }
 
-/** rename 的跨文件系统兜底：CLAUDE_CONFIG_DIR 可指到与 ~/.cc-remote 不同的挂载点（EXDEV） */
+/** rename 的跨文件系统兜底：CLAUDE_CONFIG_DIR 可指到与 ~/.cc-remote 不同的挂载点（EXDEV）。
+ *  非原子：cpSync 成功后、rmSync 前崩溃会留下双份；调用方/用户需手动清理回收站。
+ */
 function move(src: string, dest: string): void {
   try {
     renameSync(src, dest)
   } catch (e) {
     if ((e as NodeJS.ErrnoException)?.code !== 'EXDEV') throw e
     cpSync(src, dest, { recursive: true })
+    // 简单一致性校验（仅文件）：复制失败通常已抛错；这里避免 rmSync 掉尚未成功复制的源
+    if (
+      existsSync(src) &&
+      existsSync(dest) &&
+      statSync(src).isFile() &&
+      statSync(src).size !== statSync(dest).size
+    ) {
+      throw new Error(`EXDEV 复制大小不一致: ${src} -> ${dest}`)
+    }
     rmSync(src, { recursive: true, force: true })
   }
 }

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -24,7 +24,12 @@ export function isAuthorized(req: Request, url: URL): boolean {
 
 /** Host 头去端口（兼容 [::1]:7480 形态） */
 export function hostNameOf(hostHeader: string): string {
-  if (hostHeader.startsWith('[')) return hostHeader.slice(1, hostHeader.indexOf(']'))
+  if (hostHeader.startsWith('[')) {
+    const close = hostHeader.indexOf(']')
+    // 缺少闭合方括号的 IPv6 Host 头按无效处理，避免 slice(1, -1) 截断后误判为回环
+    if (close === -1) return hostHeader
+    return hostHeader.slice(1, close)
+  }
   const i = hostHeader.lastIndexOf(':')
   return i > 0 ? hostHeader.slice(0, i) : hostHeader
 }
@@ -32,7 +37,12 @@ export function hostNameOf(hostHeader: string): string {
 export function isLoopbackHostname(h: string): boolean {
   // WHATWG URL 的 IPv6 hostname 保留方括号（http://[::1]:9001 → "[::1]"）
   const n = h.startsWith('[') && h.endsWith(']') ? h.slice(1, -1) : h
-  return n === 'localhost' || n === '::1' || n.startsWith('127.')
+  if (n === 'localhost' || n === '::1') return true
+  // 127.0.0.0/8 必须是合法 IPv4 地址，避免 127.evil.com 这类 DNS 名绕过
+  return /^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.test(n) && n.split('.').slice(1).every((octet) => {
+    const v = Number(octet)
+    return v >= 0 && v <= 255
+  })
 }
 
 /** Origin 与 Host 同 host，或同为回环（dev 模式 Vite :5173 代理到 server :7480 的端口差） */

--- a/server/src/backends/claude/agents.ts
+++ b/server/src/backends/claude/agents.ts
@@ -24,6 +24,8 @@ export interface DaemonAgent {
 /** 后台 agent 是否还在 daemon 手里跑（其余终态都不是"活着") */
 export function backgroundAlive(state?: string): boolean {
   if (!state) return false
+  // 官方 CLI 可能新增终态；未显式列入的终态会被乐观地视为 alive，
+  // 因此当列表中出现无法结束的 background agent 时，应先扩展此集合。
   return !['done', 'error', 'failed', 'killed', 'stopped', 'cancelled'].includes(state)
 }
 

--- a/server/src/backends/claude/processManager.ts
+++ b/server/src/backends/claude/processManager.ts
@@ -330,7 +330,7 @@ export class ClaudeSession {
     const resp = (await this.sendControlAndWait(
       'generate_session_title',
       { description: description.slice(0, 500), persist: true },
-      60_000,
+      15_000,
     )) as { title?: string | null } | undefined
     return resp?.title ?? null
   }

--- a/server/src/backends/codex/rpc.test.ts
+++ b/server/src/backends/codex/rpc.test.ts
@@ -1,0 +1,94 @@
+// -32001 过载退避重试的回归测试：重试请求必须重新注册 pending 并重新武装超时，
+// 否则重试应答被静默丢弃、Promise 永久悬挂（修复前行为）。
+import { describe, expect, test } from 'bun:test'
+import { RpcClient } from './rpc'
+
+/** mock app-server：对同一 id 的第 1 次请求应答 -32001，第 2 次应答成功 */
+function spawnFlakyServer(): RpcClient {
+  const script = `
+const decoder = new TextDecoder()
+let buf = ''
+const seen = new Map()
+process.stdin.on('data', (chunk) => {
+  buf += decoder.decode(chunk)
+  let i
+  while ((i = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, i)
+    buf = buf.slice(i + 1)
+    if (!line.trim()) continue
+    const msg = JSON.parse(line)
+    const n = (seen.get(msg.id) ?? 0) + 1
+    seen.set(msg.id, n)
+    if (n === 1) {
+      process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32001, message: 'overloaded' } }) + '\\n')
+    } else {
+      process.stdout.write(JSON.stringify({ id: msg.id, result: { ok: true, attempt: n } }) + '\\n')
+    }
+  }
+})
+`
+  const bun = process.execPath // 当前 bun 可执行文件
+  return RpcClient.spawn([bun, '-e', script])
+}
+
+describe('RpcClient -32001 过载退避', () => {
+  test('重试后应答能送达调用方（而非静默丢弃导致永久悬挂）', async () => {
+    const client = spawnFlakyServer()
+    try {
+      const result = (await client.request('thread/start', {}, { timeoutMs: 5_000 })) as {
+        ok: boolean
+        attempt: number
+      }
+      expect(result.ok).toBe(true)
+      expect(result.attempt).toBe(2) // 首次 -32001，重试成功
+    } finally {
+      client.kill()
+    }
+  }, 15_000)
+
+  test('持续过载：重试次数耗尽后以最后一次 -32001 拒绝', async () => {
+    const script = `
+const decoder = new TextDecoder()
+let buf = ''
+process.stdin.on('data', (chunk) => {
+  buf += decoder.decode(chunk)
+  let i
+  while ((i = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, i)
+    buf = buf.slice(i + 1)
+    if (!line.trim()) continue
+    const msg = JSON.parse(line)
+    process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32001, message: 'overloaded' } }) + '\\n')
+  }
+})
+`
+    const client = RpcClient.spawn([process.execPath, '-e', script])
+    try {
+      await expect(client.request('turn/start', {}, { timeoutMs: 5_000, maxRetries: 2 })).rejects.toThrow('-32001')
+    } finally {
+      client.kill()
+    }
+  }, 15_000)
+
+  test('重试等待期间进程退出：请求被拒绝而非悬挂', async () => {
+    // 首次应答 -32001 后立即退出
+    const script = `
+const decoder = new TextDecoder()
+let buf = ''
+process.stdin.on('data', (chunk) => {
+  buf += decoder.decode(chunk)
+  let i
+  while ((i = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, i)
+    buf = buf.slice(i + 1)
+    if (!line.trim()) continue
+    const msg = JSON.parse(line)
+    process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32001, message: 'overloaded' } }) + '\\n')
+    setTimeout(() => process.exit(1), 50)
+  }
+})
+`
+    const client = RpcClient.spawn([process.execPath, '-e', script])
+    await expect(client.request('turn/start', {}, { timeoutMs: 5_000, maxRetries: 4 })).rejects.toThrow()
+  }, 15_000)
+})

--- a/server/src/backends/codex/rpc.ts
+++ b/server/src/backends/codex/rpc.ts
@@ -116,12 +116,21 @@ export class RpcClient {
           entry.retries++
           const delay = Math.min(200 * 2 ** entry.retries + Math.random() * 100, 3000)
           setTimeout(() => {
-            if (this.dead) return
+            // 进程已死时必须 reject：entry 此刻不在 pending 里，exited 的清理扫不到它
+            if (this.dead) {
+              reject(new Error('codex app-server 已退出'))
+              return
+            }
             try {
               this.write({ id, method, params: entry.params })
             } catch (err) {
               reject(err instanceof Error ? err : new Error(String(err)))
+              return
             }
+            // 重试发送成功后必须重新注册 + 重新武装超时——handleLine 的应答路径按 id
+            // 查 pending（首次应答时已 delete），缺席会把重试应答静默丢弃、Promise 永久悬挂
+            this.pending.set(id, entry)
+            arm()
           }, delay)
           return
         }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -383,10 +383,10 @@ function maybeGenerateTitle(hub: Hub): void {
   const sid = hub.sessionId
   const text = hub.pendingTitleText
   if (!sid || !text || hub.titleGeneratedFor === sid) return
-  hub.titleGeneratedFor = sid
-  hub.pendingTitleText = undefined
   const s = processManager.get(hub.key)
   if (!s) return
+  hub.titleGeneratedFor = sid
+  hub.pendingTitleText = undefined
   void s
     .generateSessionTitle(text)
     .then((title) => {

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -261,7 +261,21 @@ export function subscriptionCount(): number {
 export function validSecret(secret: string): boolean {
   if (!secret) return false
   if (loadSubs().some((r) => r.secret === secret)) return true
-  return (config.pushWebhooks ?? []).some((wh) => webhookSecret(wh) === secret)
+  let keys: VapidKeys
+  try {
+    keys = loadVapid()
+  } catch {
+    // vapid 私钥无法加载时（权限/损坏），webhook secret 派生不可信，整体拒绝
+    return false
+  }
+  return (config.pushWebhooks ?? []).some((wh) => webhookSecretWithKey(wh, keys) === secret)
+}
+
+/** 从指定 vapid 私钥派生的 per-webhook 能力密钥（测试/预计算用） */
+function webhookSecretWithKey(wh: PushWebhookConfig, keys: VapidKeys): string {
+  return hmac(Buffer.from(keys.privateKey, 'base64url'), Buffer.from(`webhook:${webhookId(wh)}`))
+    .subarray(0, 18)
+    .toString('base64url')
 }
 
 // ---------- 投递 ----------
@@ -331,11 +345,14 @@ export async function pushToAll(payload: PushPayload): Promise<{ sent: number; p
 //   Bark/Server酱 —— 无原生按钮，链接落 GET /api/approval-page 确认页（按钮再 POST），
 //                    不做直出 GET 审批链接：链接被预览/抓取即误触。
 
-/** 渠道标识：唯一定位一条配置的字符串（secret 派生输入，也用于日志） */
+/** 渠道标识：唯一定位一条配置的字符串（secret 派生输入，也用于日志）
+ *  ntfy server 必须规范化（去掉末尾斜杠），否则 https://ntfy.sh/ 与 https://ntfy.sh
+ *  会派生不同 secret，导致改配置后旧审批 URL 失效。
+ */
 function webhookId(wh: PushWebhookConfig): string {
   switch (wh.type) {
     case 'ntfy':
-      return `ntfy:${wh.server ?? 'https://ntfy.sh'}/${wh.topic}`
+      return `ntfy:${(wh.server ?? 'https://ntfy.sh').replace(/\/+$/, '')}/${wh.topic}`
     case 'bark':
       return `bark:${wh.url}`
     case 'sct':
@@ -345,9 +362,7 @@ function webhookId(wh: PushWebhookConfig): string {
 
 /** 从 vapid 私钥派生的 per-webhook 能力密钥（18 字节 → 24 字符，与订阅 secret 同长） */
 function webhookSecret(wh: PushWebhookConfig): string {
-  return hmac(Buffer.from(loadVapid().privateKey, 'base64url'), Buffer.from(`webhook:${webhookId(wh)}`))
-    .subarray(0, 18)
-    .toString('base64url')
+  return webhookSecretWithKey(wh, loadVapid())
 }
 
 export function webhookCount(): number {
@@ -451,6 +466,20 @@ async function sendSct(wh: { type: 'sct'; sendkey: string }, payload: PushPayloa
   return resp.status
 }
 
+/** 单 webhook 投递；未知类型返回 undefined，由调用方记日志 */
+async function sendWebhook(wh: PushWebhookConfig, payload: PushPayload): Promise<number | undefined> {
+  switch (wh.type) {
+    case 'ntfy':
+      return sendNtfy(wh, payload)
+    case 'bark':
+      return sendBark(wh, payload)
+    case 'sct':
+      return sendSct(wh, payload)
+    default:
+      return undefined
+  }
+}
+
 /** fan-out 到全部 webhook 通道；单通道失败只记日志，不影响其他通道与 Web Push */
 export async function pushWebhooksToAll(payload: PushPayload): Promise<{ sent: number }> {
   const hooks = config.pushWebhooks ?? []
@@ -458,12 +487,11 @@ export async function pushWebhooksToAll(payload: PushPayload): Promise<{ sent: n
   await Promise.allSettled(
     hooks.map(async (wh) => {
       try {
-        const status =
-          wh.type === 'ntfy'
-            ? await sendNtfy(wh, payload)
-            : wh.type === 'bark'
-              ? await sendBark(wh, payload)
-              : await sendSct(wh, payload)
+        const status = await sendWebhook(wh, payload)
+        if (status === undefined) {
+          console.warn(`[push] webhook ${webhookId(wh)} 类型未知，跳过`)
+          return
+        }
         if (status >= 200 && status < 300) {
           sent++
         } else {


### PR DESCRIPTION
## 概要

对 cc-remote 全仓库（server/、web/、scripts/ 全部 TS/TSX）运行 /code-review high --fix 后的修复集合，外加一处人工独立确认的高严重度 bug 修复。全量 `bun test` 196 pass / 0 fail（含新增 3 个回归测试）。

## 修复的问题

### 安全
- **`auth.ts`**：`isLoopbackHostname` 的 `startsWith('127.')` 会把 `127.evil.com` 这类攻击者可控 DNS 名误判为回环，无 token 模式的跨源防护（CSWSH/CSRF 防线）与推送 endpoint 白名单的本地 mock 豁免同时失效。改为要求合法 127.0.0.0/8 IPv4。同时 `hostNameOf` 拒绝缺闭合 `]` 的畸形 IPv6 Host 头（原会截断成 `127.0.0.` 误判回环）。

### 正确性
- **`codex/rpc.ts`（人工独立确认，--fix 未覆盖）**：-32001 过载退避重试路径三重缺陷叠加——重试后未重新注册 pending（应答被静默丢弃）、未重新武装超时（无兜底）、重试等待期进程退出不 reject。**任一触发 -32001 的请求（turn/start 等）会永久挂起**。附 rpc.test.ts 三个回归测试；修复前第一个测试直接挂死 bun test，反向验证了 bug。
- **`push.ts`**：① `validSecret` 在 vapid.json 不可读/损坏时 500 崩溃 → 改为整体拒绝（403）；② ntfy `webhookId` 用未规范化的 server URL 派生 secret，末尾斜杠差异导致改配置后旧审批 URL 全失效 → 与 `sendNtfy` 对齐做规范化；③ 嵌套三元把未知 webhook 类型（如笔误 wecom）路由给 sendSct 打向 `/undefined.send` → switch 分派 + 显式跳过记日志。
- **`index.ts`**：`maybeGenerateTitle` 先确认进程句柄存活再标记 `titleGeneratedFor`，消除进程间隙退出导致会话永久失去标题的窗口。
- **`processManager.ts`**：`generate_session_title` 控制请求超时 60s→15s——等待中的控制请求撑起 busy 语义，旧版 CLI 忽略该 subtype 时会话 60s 无法空闲回收；超时代价仅是列表回退首条消息摘要。
- **`gateway.ts`**：`Sec-WebSocket-Protocol` 按 RFC 逗号拆分后再传给后端 WebSocket，修复多子协议客户端握手失败。
- **`archive.ts`**：EXDEV 跨盘兜底在 `rmSync` 源文件前校验复制大小一致，避免删掉未复制成功的源。

## 复核后维持不变的 review 建议（误判/有意设计）

- **`portTakeover.ts:126`**：读不到进程信息即判外来并拒绝接管——这是文件头明言的安全红线（宁可启动失败，绝不误杀外来进程），跨平台无可靠兜底，不改。
- **`discovery.ts` / `agents.ts` `backgroundAlive`**：未知终态乐观视为 alive 是有意的防误回收设计（悲观误判会把活的子任务回收掉），仅以注释标注维护约定。
- **`archive.ts` EXDEV 非原子**：cp+rm 之间崩溃留双份的问题只缓解未根除（真正崩溃安全需要事务日志/恢复标记，超出本次范围），已注释说明手动清理路径。

## 疑似但无法确认的问题（未改动）

- `web/src/lib/ws.ts` 的 `onOpen` flush 期间若连接恰好再断，`sendRaw` 失败的消息会从 queue 丢失。窗口极小（open 事件同步处理期间断连），未改。
- `uploads.ts` `saveUpload` 的 existsSync+writeFileSync 存在 TOCTOU 竞争，但 hash 相同即内容相同，最坏结果是并发写同名文件，无实际危害，未改。
- `fsbrowse.ts` `readGitBranch` 对 `refs/heads/feature/foo` 只取最后一段（丢 `feature/` 前缀），仅影响显示，未改。

## 测试

```
bun test  # 196 pass / 0 fail / 24 files（新增 rpc.test.ts 3 例）
```