### PR TITLE
test: 补 tailer / rpc / reconnectingSocket 三个模块的单元测试（+修复 rpc -32001 重试 bug）

### DIFF
--- a/server/src/backends/claude/tailer.test.ts
+++ b/server/src/backends/claude/tailer.test.ts
@@ -1,0 +1,239 @@
+// TranscriptTailer 的行泵语义：偏移续读、半行/多字节跨块缓冲、截断自停、rewindable 标记。
+// 用真实临时文件驱动（fs.watch + 2s 轮询兜底），不碰真实 CLI。
+
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test'
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { HistoryMessage } from './discovery'
+import { TranscriptTailer } from './tailer'
+
+let dir = ''
+let fileSeq = 0
+const tailers: TranscriptTailer[] = []
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'cc-remote-tailer-'))
+})
+
+afterEach(() => {
+  // pollTimer 是活跃 setInterval，不 stop 会挂住测试进程
+  for (const t of tailers.splice(0)) t.stop()
+})
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function freshFile(): string {
+  return join(dir, `t${fileSeq++}.jsonl`)
+}
+
+function userLine(uuid: string, text: string): string {
+  return JSON.stringify({ type: 'user', uuid, message: { role: 'user', content: text } })
+}
+
+function assistantLine(uuid: string, text: string): string {
+  return JSON.stringify({ type: 'assistant', uuid, message: { role: 'assistant', content: [{ type: 'text', text }] } })
+}
+
+interface Collected {
+  msgs: HistoryMessage[]
+  resets: number
+  ticks: number
+}
+
+function makeTailer(path: string, offset?: number): { tailer: TranscriptTailer; c: Collected } {
+  const c: Collected = { msgs: [], resets: 0, ticks: 0 }
+  const tailer = new TranscriptTailer(path, offset, {
+    onMessage: (m) => c.msgs.push(m),
+    onReset: () => c.resets++,
+    onTick: () => c.ticks++,
+  })
+  tailers.push(tailer)
+  return { tailer, c }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function waitFor(cond: () => boolean, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error('waitFor 超时')
+    await sleep(20)
+  }
+}
+
+/** 找出一个落在多字节 UTF-8 序列中间的切点（lead byte 之后） */
+function multiByteCut(buf: Buffer): number {
+  for (let i = 0; i < buf.length; i++) {
+    const b = buf[i]
+    if (b !== undefined && b >= 0xc0 && b < 0xf8) return i + 1
+  }
+  throw new Error('测试行里没有多字节字符')
+}
+
+describe('TranscriptTailer 偏移与回放', () => {
+  test('未指定偏移时不回放既有内容，只推送新追加的完整消息', async () => {
+    const path = freshFile()
+    writeFileSync(path, userLine('u-old', '历史消息') + '\n')
+    const { tailer, c } = makeTailer(path) // 与「加载历史后订阅」约定一致：从文件尾开始
+    tailer.start()
+    expect(c.msgs).toHaveLength(0)
+
+    appendFileSync(path, userLine('u-new', '新提问') + '\n')
+    await waitFor(() => c.msgs.length === 1)
+    expect(c.msgs[0]?.uuid).toBe('u-new')
+  })
+
+  test('startOffset=0 时 start() 的初始 flush 同步回放既有完整行', () => {
+    const path = freshFile()
+    writeFileSync(path, [userLine('u-1', '第一条'), assistantLine('a-1', '回答')].join('\n') + '\n')
+    const { tailer, c } = makeTailer(path, 0)
+    tailer.start()
+    expect(c.msgs.map((m) => m.uuid)).toEqual(['u-1', 'a-1'])
+    expect(c.msgs[0]?.role).toBe('user')
+    expect(c.msgs[1]?.role).toBe('assistant')
+  })
+
+  test('构造时文件不存在也能跟上：轮询兜底建立读取', async () => {
+    const path = freshFile() // 故意不创建（pid 会话刚起步的场景）
+    const { tailer, c } = makeTailer(path)
+    tailer.start()
+    appendFileSync(path, userLine('u-born', '文件后建') + '\n')
+    await waitFor(() => c.msgs.length === 1, 5000) // watch 未建立，靠 2s 轮询发现
+    expect(c.msgs[0]?.blocks[0]?.text).toBe('文件后建')
+  })
+})
+
+describe('TranscriptTailer 行解析', () => {
+  test('rewindable 标记：普通 user 与 assistant 可回滚，tool_result user 不可', async () => {
+    const path = freshFile()
+    writeFileSync(path, '')
+    const { tailer, c } = makeTailer(path)
+    tailer.start()
+    appendFileSync(
+      path,
+      [
+        userLine('u-text', '普通提问'),
+        JSON.stringify({
+          type: 'user',
+          uuid: 'u-tr',
+          message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'ok' }] },
+        }),
+        assistantLine('a-1', '回答'),
+      ].join('\n') + '\n',
+    )
+    await waitFor(() => c.msgs.length === 3)
+    const byUuid = new Map(c.msgs.map((m) => [m.uuid, m]))
+    expect(byUuid.get('u-text')?.rewindable).toBe(true)
+    // 官方同款语义：tool_result 消息没有文件检查点
+    expect(byUuid.get('u-tr')?.rewindable).toBe(false)
+    expect(byUuid.get('a-1')?.rewindable).toBe(true)
+  })
+
+  test('无换行结尾的半行先缓冲，补齐换行后按完整行解析', async () => {
+    const path = freshFile()
+    writeFileSync(path, '')
+    const { tailer, c } = makeTailer(path)
+    tailer.start()
+    const line = userLine('u-half', '半行缓冲')
+    const cut = Math.floor(line.length / 2)
+    appendFileSync(path, line.slice(0, cut)) // 无 \n：不足以成行
+    await waitFor(() => c.ticks > 1) // 追加已触发一次 flush（初始 flush 是第 1 次 tick）
+    expect(c.msgs).toHaveLength(0)
+
+    appendFileSync(path, line.slice(cut) + '\n')
+    await waitFor(() => c.msgs.length === 1)
+    expect(c.msgs[0]?.blocks[0]?.text).toBe('半行缓冲')
+  })
+
+  test('多字节 UTF-8 字符跨两次写入切开时不产生乱码', async () => {
+    const path = freshFile()
+    writeFileSync(path, '')
+    const { tailer, c } = makeTailer(path)
+    tailer.start()
+    const text = '交接简报：中文内容'
+    const buf = Buffer.from(userLine('u-utf8', text) + '\n', 'utf8')
+    const cut = multiByteCut(buf) // 切点落在某个汉字的字节序列中间
+    appendFileSync(path, buf.subarray(0, cut))
+    await waitFor(() => c.ticks > 1)
+    expect(c.msgs).toHaveLength(0)
+
+    appendFileSync(path, buf.subarray(cut))
+    await waitFor(() => c.msgs.length === 1)
+    // 0x0A 不出现在多字节序列里，按字节切分后拼接应还原原文（无 U+FFFD 替换字符）
+    expect(c.msgs[0]?.blocks[0]?.text).toBe(text)
+  })
+
+  test('非 JSON 行与损坏 JSON 行被跳过，不影响后续正常行', async () => {
+    const path = freshFile()
+    writeFileSync(path, '')
+    const { tailer, c } = makeTailer(path)
+    tailer.start()
+    appendFileSync(
+      path,
+      ['plain noise not json', '{broken json', userLine('u-ok-1', '正常一'), userLine('u-ok-2', '正常二')].join('\n') +
+        '\n',
+    )
+    await waitFor(() => c.msgs.length === 2)
+    expect(c.msgs.map((m) => m.uuid)).toEqual(['u-ok-1', 'u-ok-2'])
+  })
+
+  test('sidechain/isMeta/非抄本类型行不推送，compact_boundary 推送为系统消息', async () => {
+    const path = freshFile()
+    writeFileSync(path, '')
+    const { tailer, c } = makeTailer(path)
+    tailer.start()
+    appendFileSync(
+      path,
+      [
+        JSON.stringify({ type: 'user', uuid: 'u-side', isSidechain: true, message: { role: 'user', content: '子代理内部' } }),
+        JSON.stringify({ type: 'user', uuid: 'u-meta', isMeta: true, message: { role: 'user', content: '元消息' } }),
+        JSON.stringify({ type: 'progress', uuid: 'p-1', data: {} }),
+        JSON.stringify({
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'cb-1',
+          compactMetadata: { trigger: 'auto', preTokens: 1000 },
+        }),
+      ].join('\n') + '\n',
+    )
+    await waitFor(() => c.msgs.length === 1)
+    expect(c.msgs[0]?.uuid).toBe('cb-1')
+    expect(c.msgs[0]?.role).toBe('system')
+    expect(c.msgs[0]?.subtype).toBe('compact_boundary')
+    expect(c.msgs[0]?.rewindable).toBe(true) // 非 user 角色恒 true
+  })
+})
+
+describe('TranscriptTailer 截断与停止', () => {
+  test('文件被截断/重建时 onReset 触发且自停，之后的内容不再推送', async () => {
+    const path = freshFile()
+    writeFileSync(path, '')
+    const { tailer, c } = makeTailer(path)
+    tailer.start()
+    appendFileSync(path, userLine('u-1', '截断前') + '\n')
+    await waitFor(() => c.msgs.length === 1)
+
+    writeFileSync(path, '') // 外部 rewind / /clear：文件归零，偏移失效
+    await waitFor(() => c.resets === 1)
+
+    appendFileSync(path, userLine('u-2', '截断后') + '\n')
+    await sleep(150) // 覆盖 watch debounce 窗口；tailer 已停，不应再有动静
+    expect(c.msgs).toHaveLength(1)
+    expect(c.resets).toBe(1)
+  })
+
+  test('stop() 后追加内容不再触发任何回调', async () => {
+    const path = freshFile()
+    writeFileSync(path, '')
+    const { tailer, c } = makeTailer(path)
+    tailer.start()
+    tailer.stop()
+    appendFileSync(path, userLine('u-late', '停止后') + '\n')
+    await sleep(150)
+    expect(c.msgs).toHaveLength(0)
+    expect(c.ticks).toBe(1) // 仅 start() 的初始 flush
+  })
+})

--- a/server/src/backends/codex/rpc.test.ts
+++ b/server/src/backends/codex/rpc.test.ts
@@ -1,0 +1,156 @@
+// RpcClient 的传输层语义：应答按 id 配对、notification/server request 路由、
+// -32001 过载退避重试、超时、进程退出清理、非 JSON 行容错。
+// 用 bun -e 起一个假 app-server 子进程跑真实 NDJSON stdio 链路，不碰真实 codex。
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { RpcClient, RpcError } from './rpc'
+
+// 假 app-server：逐行读 stdin，按 method 脚本化应答。
+// 无 id 的是客户端 notify；有 id 无 method 的是客户端 respond（忽略）；其余按 method 分发。
+const FAKE_SERVER = `
+const rl = require('node:readline').createInterface({ input: process.stdin })
+let overloadedHits = 0
+rl.on('line', (line) => {
+  let msg
+  try { msg = JSON.parse(line) } catch { return }
+  if (msg.id === undefined) {
+    if (msg.method === 'die') process.exit(3)
+    if (msg.method === 'push') {
+      process.stdout.write(JSON.stringify({ method: 'thread/status/changed', params: { status: 'active' } }) + '\\n')
+      process.stdout.write(JSON.stringify({ id: 'srv-1', method: 'item/approval/request', params: { tool: 'Bash' } }) + '\\n')
+    }
+    return
+  }
+  if (msg.method === undefined) return
+  if (msg.method === 'echo') {
+    process.stdout.write(JSON.stringify({ id: msg.id, result: { got: msg.params } }) + '\\n')
+  } else if (msg.method === 'overloaded-twice') {
+    overloadedHits++
+    if (overloadedHits <= 2) {
+      process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32001, message: 'overloaded' } }) + '\\n')
+    } else {
+      process.stdout.write(JSON.stringify({ id: msg.id, result: { attempts: overloadedHits } }) + '\\n')
+    }
+  } else if (msg.method === 'always-overloaded') {
+    process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32001, message: 'overloaded' } }) + '\\n')
+  } else if (msg.method === 'fail') {
+    process.stdout.write(JSON.stringify({ id: msg.id, error: { code: -32600, message: 'thread busy' } }) + '\\n')
+  } else if (msg.method === 'garbage') {
+    process.stdout.write('this is not json\\n')
+    process.stdout.write(JSON.stringify({ id: msg.id, result: 'after-garbage' }) + '\\n')
+  }
+})
+`
+
+const clients: RpcClient[] = []
+
+afterEach(() => {
+  for (const c of clients.splice(0)) c.kill()
+})
+
+function spawnFake(): RpcClient {
+  const c = RpcClient.spawn([process.execPath, '-e', FAKE_SERVER])
+  clients.push(c)
+  return c
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function waitFor(cond: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error('waitFor 超时')
+    await sleep(20)
+  }
+}
+
+describe('RpcClient 请求-应答', () => {
+  test('result 应答按 id 配对返回', async () => {
+    const rpc = spawnFake()
+    const r = await rpc.request('echo', { hello: 'world' })
+    expect(r).toEqual({ got: { hello: 'world' } })
+  })
+
+  test('并发请求各自配对，互不串扰', async () => {
+    const rpc = spawnFake()
+    const [a, b] = await Promise.all([rpc.request('echo', { n: 1 }), rpc.request('echo', { n: 2 })])
+    expect(a).toEqual({ got: { n: 1 } })
+    expect(b).toEqual({ got: { n: 2 } })
+  })
+
+  test('error 应答 reject 为 RpcError，保留 code 与 message', async () => {
+    const rpc = spawnFake()
+    const err = await rpc.request('fail').catch((e) => e)
+    expect(err).toBeInstanceOf(RpcError)
+    expect((err as RpcError).code).toBe(-32600)
+    expect((err as Error).message).toContain('thread busy')
+  })
+
+  test('stdout 混入非 JSON 行时不影响后续应答解析', async () => {
+    const rpc = spawnFake()
+    const r = await rpc.request('garbage')
+    expect(r).toBe('after-garbage')
+  })
+})
+
+describe('RpcClient -32001 过载退避', () => {
+  test('前两次 -32001 后自动重试，第三次成功', async () => {
+    const rpc = spawnFake()
+    const r = (await rpc.request('overloaded-twice')) as { attempts: number }
+    expect(r.attempts).toBe(3)
+  }, 10000)
+
+  test('超过 maxRetries 后 reject 最后一次 -32001 错误', async () => {
+    const rpc = spawnFake()
+    const err = await rpc.request('always-overloaded', undefined, { maxRetries: 2 }).catch((e) => e)
+    expect(err).toBeInstanceOf(RpcError)
+    expect((err as RpcError).code).toBe(-32001)
+  }, 10000)
+})
+
+describe('RpcClient 超时与进程退出', () => {
+  test('超时：pending 请求在 timeoutMs 后 reject', async () => {
+    const rpc = spawnFake()
+    const err = await rpc.request('slow', undefined, { timeoutMs: 200 }).catch((e) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toContain('超时')
+  })
+
+  test('进程退出：所有 pending 请求 reject，onExit 携带退出码', async () => {
+    const rpc = spawnFake()
+    const exitCode = new Promise<number>((resolve) => {
+      rpc.onExit = resolve
+    })
+    const slowReq = rpc.request('slow', undefined, { timeoutMs: 30_000 }).catch((e) => e)
+    rpc.notify('die')
+    expect(await exitCode).toBe(3)
+    expect(((await slowReq) as Error).message).toContain('已退出')
+    expect(rpc.exited).toBe(true)
+  })
+
+  test('进程退出后：request 立即 reject，notify/respond 同步抛错', async () => {
+    const rpc = spawnFake()
+    rpc.notify('die')
+    await waitFor(() => rpc.exited)
+    const err = await rpc.request('echo').catch((e) => e)
+    expect((err as Error).message).toContain('未运行')
+    expect(() => rpc.notify('push')).toThrow(/未运行/)
+    expect(() => rpc.respond(1, {})).toThrow(/未运行/)
+  })
+})
+
+describe('RpcClient 下行消息路由', () => {
+  test('notification 与 server 发起的 request 分别路由到对应回调', async () => {
+    const rpc = spawnFake()
+    const notifications: Array<{ method: string; params?: unknown }> = []
+    const serverRequests: Array<{ id: number | string; method: string }> = []
+    rpc.onNotification = (n) => notifications.push(n)
+    rpc.onServerRequest = (r) => serverRequests.push(r)
+    rpc.notify('push')
+    await waitFor(() => notifications.length === 1 && serverRequests.length === 1)
+    expect(notifications[0]?.method).toBe('thread/status/changed')
+    expect(serverRequests[0]).toMatchObject({ id: 'srv-1', method: 'item/approval/request' })
+    // 应答 server request 不产生新的 pending，也不应崩溃
+    rpc.respond('srv-1', { approved: true })
+  })
+})

--- a/server/src/backends/codex/rpc.ts
+++ b/server/src/backends/codex/rpc.ts
@@ -115,11 +115,16 @@ export class RpcClient {
         if (e instanceof RpcError && e.code === OVERLOADED_CODE && entry.retries < maxRetries) {
           entry.retries++
           const delay = Math.min(200 * 2 ** entry.retries + Math.random() * 100, 3000)
+          // handleLine 派发应答时已把 entry 移出 pending；重试期间必须放回，
+          // 否则重发的应答无人认领（静默丢弃），进程退出时也漏掉对这个请求的 reject。
+          this.pending.set(id, entry)
           setTimeout(() => {
             if (this.dead) return
             try {
               this.write({ id, method, params: entry.params })
+              arm() // 重发后重新计时，防止服务端吞掉重试导致永久挂起
             } catch (err) {
+              this.pending.delete(id)
               reject(err instanceof Error ? err : new Error(String(err)))
             }
           }, delay)

--- a/web/src/lib/reconnectingSocket.test.ts
+++ b/web/src/lib/reconnectingSocket.test.ts
@@ -1,0 +1,218 @@
+// ReconnectingSocket 的重连状态机：指数退避（1s 起 15s 封顶）、open 复位、
+// close 终止重连、sendRaw 门控、下行 JSON 解析容错。
+// 用 FakeWebSocket + 捕获式 setTimeout 全同步驱动，不做真实等待。
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { ReconnectingSocket, wsUrl } from './reconnectingSocket'
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSED = 3
+  static instances: FakeWebSocket[] = []
+
+  readyState = FakeWebSocket.CONNECTING
+  sent: string[] = []
+  onopen: ((e: unknown) => void) | null = null
+  onclose: ((e: unknown) => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onerror: ((e: unknown) => void) | null = null
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(text: string): void {
+    this.sent.push(text)
+  }
+
+  close(): void {
+    if (this.readyState === FakeWebSocket.CLOSED) return
+    this.readyState = FakeWebSocket.CLOSED
+    this.onclose?.({})
+  }
+
+  // ---- 测试驱动辅助 ----
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN
+    this.onopen?.({})
+  }
+  receive(data: string): void {
+    this.onmessage?.({ data })
+  }
+  error(): void {
+    this.onerror?.({})
+  }
+}
+
+class TestSocket extends ReconnectingSocket {
+  messages: unknown[] = []
+  openStates: boolean[] = []
+  openCount = 0
+
+  protected url(): string {
+    return '/ws/test'
+  }
+  protected onMessage(data: unknown): void {
+    this.messages.push(data)
+  }
+  protected onOpenChange(open: boolean): void {
+    this.openStates.push(open)
+  }
+  protected onOpen(): void {
+    this.openCount++
+  }
+  /** 构造后手动启动：对应子类构造函数末尾调 start() 的约定 */
+  boot(): void {
+    this.start()
+  }
+  trySend(text: string): boolean {
+    return this.sendRaw(text)
+  }
+}
+
+interface ScheduledCall {
+  delay: number
+  fn: () => void
+}
+
+let scheduled: ScheduledCall[] = []
+const realSetTimeout = globalThis.setTimeout
+const realWebSocket = globalThis.WebSocket
+
+beforeEach(() => {
+  scheduled = []
+  FakeWebSocket.instances = []
+  globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+  // 捕获重连定时器：不断言真实时间流，手动 fire
+  globalThis.setTimeout = ((fn: () => void, delay?: number) => {
+    scheduled.push({ delay: delay ?? 0, fn })
+    return 0
+  }) as unknown as typeof setTimeout
+})
+
+afterEach(() => {
+  globalThis.setTimeout = realSetTimeout
+  globalThis.WebSocket = realWebSocket
+})
+
+describe('wsUrl', () => {
+  test('按页面协议映射 ws/wss；localStorage 有 token 时附加编码后的 query', () => {
+    const g = globalThis as Record<string, unknown>
+    const saved = { location: g.location, localStorage: g.localStorage }
+    let storedToken: string | null = null
+    g.localStorage = {
+      getItem: (k: string) => (k === 'cc-remote-token' ? storedToken : null),
+      setItem: (_k: string, v: string) => {
+        storedToken = v
+      },
+      removeItem: () => {},
+      clear: () => {},
+    }
+    try {
+      g.location = { protocol: 'http:', host: 'cc.test', search: '', href: 'http://cc.test/' }
+      expect(wsUrl('/ws/inbox')).toBe('ws://cc.test/ws/inbox')
+      g.location = { protocol: 'https:', host: 'cc.test', search: '', href: 'https://cc.test/' }
+      expect(wsUrl('/ws/inbox')).toBe('wss://cc.test/ws/inbox')
+      storedToken = 'tok 123'
+      expect(wsUrl('/ws/inbox')).toBe('wss://cc.test/ws/inbox?token=tok%20123')
+    } finally {
+      g.location = saved.location
+      g.localStorage = saved.localStorage
+    }
+  })
+})
+
+describe('ReconnectingSocket 连接与消息', () => {
+  test('open 后回调 onOpenChange(true) 与 onOpen 钩子', () => {
+    const s = new TestSocket()
+    s.boot()
+    const ws = FakeWebSocket.instances[0]
+    expect(ws?.url).toBe('/ws/test')
+    ws?.open()
+    expect(s.openStates).toEqual([true])
+    expect(s.openCount).toBe(1)
+  })
+
+  test('下行消息逐条 JSON 解析分发；坏 JSON 静默吞掉', () => {
+    const s = new TestSocket()
+    s.boot()
+    const ws = FakeWebSocket.instances[0]
+    ws?.open()
+    ws?.receive(JSON.stringify({ kind: 'status', state: { busy: true } }))
+    ws?.receive('{broken')
+    ws?.receive(JSON.stringify({ kind: 'error', message: 'x' }))
+    expect(s.messages).toEqual([{ kind: 'status', state: { busy: true } }, { kind: 'error', message: 'x' }])
+  })
+
+  test('sendRaw 仅在 open 时发送：CONNECTING/CLOSED 返回 false 且不发送', () => {
+    const s = new TestSocket()
+    s.boot()
+    const ws = FakeWebSocket.instances[0]
+    expect(s.trySend('a')).toBe(false)
+    expect(ws?.sent).toEqual([])
+    ws?.open()
+    expect(s.trySend('b')).toBe(true)
+    expect(ws?.sent).toEqual(['b'])
+    ws?.close()
+    expect(s.trySend('c')).toBe(false)
+    expect(ws?.sent).toEqual(['b'])
+  })
+})
+
+describe('ReconnectingSocket 断线重连退避', () => {
+  test('退避序列 1s 起每次翻倍，15s 封顶', () => {
+    const s = new TestSocket()
+    s.boot()
+    const expected = [1000, 2000, 4000, 8000, 15000, 15000]
+    for (const delay of expected) {
+      FakeWebSocket.instances.at(-1)?.close() // 连接失败/断线
+      const call = scheduled.shift()
+      expect(call?.delay).toBe(delay)
+      call?.fn() // 定时器到点 → 发起新连接
+    }
+    expect(FakeWebSocket.instances).toHaveLength(expected.length + 1)
+  })
+
+  test('重连成功后退避复位：再次断线从 1s 重新计', () => {
+    const s = new TestSocket()
+    s.boot()
+    FakeWebSocket.instances[0]?.close()
+    const retry = scheduled.shift()
+    expect(retry?.delay).toBe(1000)
+    retry?.fn() // 重连 #2
+    FakeWebSocket.instances[1]?.open() // 成功 → retry 清零
+    FakeWebSocket.instances[1]?.close() // 再次断线
+    expect(scheduled.shift()?.delay).toBe(1000) // 回到起点而非 2000
+  })
+
+  test('onerror 等效断线：触发 close 并排程重连', () => {
+    const s = new TestSocket()
+    s.boot()
+    FakeWebSocket.instances[0]?.error()
+    expect(s.openStates).toEqual([false])
+    expect(scheduled.shift()?.delay).toBe(1000)
+  })
+})
+
+describe('ReconnectingSocket close 终止', () => {
+  test('close() 后断线不再排程重连', () => {
+    const s = new TestSocket()
+    s.boot()
+    const ws = FakeWebSocket.instances[0]
+    s.close()
+    expect(ws?.readyState).toBe(FakeWebSocket.CLOSED)
+    expect(scheduled).toHaveLength(0)
+    expect(s.openStates).toEqual([false])
+  })
+
+  test('close() 前已排程的重连在到点时被 closed 守卫拦下', () => {
+    const s = new TestSocket()
+    s.boot()
+    FakeWebSocket.instances[0]?.close() // 排程 1s
+    expect(scheduled).toHaveLength(1)
+    s.close()
+    scheduled.shift()?.fn() // 定时器到点，但已 closed
+    expect(FakeWebSocket.instances).toHaveLength(1) // 没有发起新连接
+  })
+})


### PR DESCRIPTION
## 概述

针对测试覆盖短板补了 3 个核心纯逻辑模块的单元测试，测试总数 **198 → 227**（+29），全部通过。

## 补测模块

### 1. `server/src/backends/claude/tailer.ts`（10 个用例）
TranscriptTailer 的 transcript 行泵语义，用真实临时文件驱动（fs.watch + 2s 轮询兜底），不碰真实 CLI：
- **偏移续读**：未指定偏移时不回放既有内容（「加载历史后订阅」约定）、`startOffset=0` 时初始 flush 同步回放、构造时文件不存在靠轮询兜底跟上
- **行解析**：rewindable 标记（tool_result user 不可回滚，对齐官方 checkpoint 语义）、无换行半行先缓冲后补齐、**多字节 UTF-8 字符跨两次写入切开不产生乱码**（验证 0x0A 字节切分安全性）、噪声/损坏 JSON 行跳过不影响后续行、sidechain/isMeta/progress 行过滤而 compact_boundary 推送为系统消息
- **截断与停止**：文件归零触发 onReset 且 tailer 自停（之后内容不再推送、reset 不重复触发）、stop() 后不再触发任何回调

### 2. `server/src/backends/codex/rpc.ts`（10 个用例）
RpcClient 的 JSON-RPC stdio 传输层语义，用 `bun -e` 假 app-server 子进程跑真实 NDJSON 链路（与 e2e-codex 的真实 CLI 探针不重复）：
- **请求-应答**：按 id 配对、并发解复用、error 应答保留 RpcError code/message、stdout 混入非 JSON 行容错
- **-32001 过载退避**：重试至成功、超 maxRetries 后 reject
- **超时与退出**：timeoutMs 后 reject、进程退出时 pending 全 reject 且 onExit 携带退出码、退出后 request 立即 reject / notify、respond 同步抛错
- **下行路由**：notification 与 server request（审批）分别进对应回调

### 3. `web/src/lib/reconnectingSocket.ts`（9 个用例）
WS 重连状态机，FakeWebSocket + 捕获式 setTimeout 全同步驱动（7ms 跑完）：
- **wsUrl**：http/https → ws/wss 协议映射、localStorage token 附加 encodeURIComponent 编码的 query
- **连接与消息**：open 回调时序（onOpenChange/onOpen）、下行 JSON 逐条解析、坏 JSON 静默吞掉、sendRaw 仅在 OPEN 时发送
- **退避**：1s 起翻倍至 15s 封顶（精确断言 [1000, 2000, 4000, 8000, 15000, 15000]）、重连成功后复位回 1s、onerror 等效断线
- **close 终止**：close 后断线不再排程、已排程的重连到点时被 closed 守卫拦下

## 顺带修复的 bug（单独 commit）

**`fix(rpc)`: -32001 过载重试应答无人认领导致请求永久挂起**——rpc 测试暴露出：`handleLine` 派发应答时先从 `pending` 摘除 entry 再调 `entry.reject`，而 -32001 重试分支只安排 setTimeout 重发，重发的应答回来后查不到 pending entry 被静默丢弃，且超时定时器已被 clear——Promise 永远 pending，AGENTS.md 记载的「-32001 过载退避」实际完全不生效。修复：重试期间把 entry 放回 pending（进程退出清理也能覆盖），重发成功后重新 arm 超时计时。

## 验证

`bun test`：227 pass / 0 fail（26 个测试文件）。存量 `tsc --noEmit` 有 4 个错误均在 `scripts/gateway.ts`（master 既有），与本次改动无关。