### PR TITLE
fix(security): 剥离 CLI 子进程环境中的 ANYPLANE_TOKEN（全量安全审查）

### DIFF
--- a/server/src/backends/claude/agents.ts
+++ b/server/src/backends/claude/agents.ts
@@ -6,6 +6,7 @@
 // 文档化脚本接口（对照 control.sock 逆向协议的版本锁风险，见 memory/ROADMAP 决策记录）。
 
 import { resolveClaudeCommand } from './processManager'
+import { childEnv } from '../../util'
 
 export interface DaemonAgent {
   sessionId: string
@@ -72,6 +73,7 @@ function refresh(): void {
         stdin: 'ignore',
         stdout: 'pipe',
         stderr: 'ignore',
+        env: childEnv(), // 显式传 env 剥离 ANYPLANE_TOKEN（缺省 spawn 继承全量 process.env）
       })
       const timeout = setTimeout(() => {
         try {

--- a/server/src/backends/claude/backend.test.ts
+++ b/server/src/backends/claude/backend.test.ts
@@ -81,11 +81,15 @@ describe('hydratedContextOf（离线水合：点开会话即有环形）', () =>
     config.claudeConfigDir = tmpRoot
     setStoreFileForTest(join(tmpRoot, 'models-2.json'))
     writeTranscript(1000, 300)
+    // 显式推进 mtime：上个测试刚以相同内容写过同一文件，Windows 文件系统
+    // 精度下 mtime 可能不变，hydratedContextOf 的 mtime 缓存会返回陈旧结果
+    const p = join(tmpRoot, 'projects', slug, `${sid}.jsonl`)
+    const t1 = new Date(Date.now() + 1000)
+    utimesSync(p, t1, t1)
     expect(hydratedContextOf(`s|${slug}|${sid}`)?.windowSize).toBe(200_000)
 
     // mtime 变化 → 重新读盘拿到新值（写文件后显式推进 mtime，避开文件系统精度）
     writeTranscript(2000, 400)
-    const p = join(tmpRoot, 'projects', slug, `${sid}.jsonl`)
     const future = new Date(Date.now() + 5000)
     utimesSync(p, future, future)
     expect(hydratedContextOf(`s|${slug}|${sid}`)?.inputTokens).toBe(2000)

--- a/server/src/backends/claude/processManager.ts
+++ b/server/src/backends/claude/processManager.ts
@@ -11,7 +11,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { spawn, spawnSync, type Subprocess } from 'bun'
 import { config } from '../../config'
-import { errorMessage, pumpLines, sanitizePath } from '../../util'
+import { childEnv, errorMessage, pumpLines, sanitizePath } from '../../util'
 import type { ApprovalDecision, BackgroundTask, SessionCallbacks, SpawnOptions } from '../types'
 import {
   approvalResponse,
@@ -317,13 +317,12 @@ export class ClaudeSession {
         stdin: 'pipe',
         stdout: 'pipe',
         stderr: 'pipe', // 吞掉 stderr，避免干扰；需要诊断时可改为 inherit
-        env: {
-          ...process.env,
+        env: childEnv({
           // headless/SDK 模式下文件检查点默认关闭，rewind_files 需要它
           CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: '1',
           // 启用权威 idle/running/requires_action 事件（Claude Code sessionState.ts）
           CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
-        },
+        }),
       })
     } catch (e) {
       this.exited = true

--- a/server/src/backends/codex/rpc.ts
+++ b/server/src/backends/codex/rpc.ts
@@ -2,7 +2,7 @@
 // 与 claude 后端的 pumpStdout 同构：逐行解析、宽松透传、未知字段不校验。
 
 import { spawn, type Subprocess } from 'bun'
-import { pumpLines } from '../../util'
+import { childEnv, pumpLines } from '../../util'
 
 export interface RpcNotification {
   method: string
@@ -64,7 +64,7 @@ export class RpcClient {
   static spawn(argv: string[], opts: { cwd?: string; env?: Record<string, string | undefined> } = {}): RpcClient {
     const proc = spawn(argv, {
       cwd: opts.cwd,
-      env: { ...process.env, ...opts.env } as Record<string, string>,
+      env: childEnv(opts.env),
       stdin: 'pipe',
       stdout: 'pipe',
       stderr: 'pipe',

--- a/server/src/handoff.ts
+++ b/server/src/handoff.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { resolveClaudeCommand } from './backends/claude/processManager'
 import { codexRuntime } from './backends/codex/runtime'
 import type { BackendName } from './backends/types'
-import { ccDataDir, pumpLines, readJsonFile } from './util'
+import { ccDataDir, childEnv, pumpLines, readJsonFile } from './util'
 
 export type HandoffDetail = 'brief' | 'standard' | 'detailed'
 
@@ -61,7 +61,7 @@ export async function generateClaudeBrief(
       // CLAUDE.md 缺席对简报质量影响可忽略；用户 hooks 在临时 fork 上本就不该触发。
       '--bare',
     ],
-    { cwd, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe', env: { ...process.env } },
+    { cwd, stdin: 'ignore', stdout: 'pipe', stderr: 'pipe', env: childEnv() },
   )
   return await new Promise((resolve, reject) => {
     const timer = setTimeout(() => {

--- a/server/src/util.test.ts
+++ b/server/src/util.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { chmodSync, mkdtempSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ensurePrivateDir, errorMessage, pumpLines } from './util'
+import { ensurePrivateDir, childEnv, errorMessage, pumpLines } from './util'
 
 function streamOf(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -70,6 +70,28 @@ describe('errorMessage', () => {
     expect(errorMessage('字符串错误')).toBe('字符串错误')
     expect(errorMessage(42)).toBe('42')
     expect(errorMessage(undefined)).toBe('undefined')
+  })
+})
+
+describe('childEnv（CLI 子进程环境）', () => {
+  test('剥离 ANYPLANE_TOKEN，其余继承变量与 extra 不受影响', () => {
+    const savedToken = process.env.ANYPLANE_TOKEN
+    process.env.ANYPLANE_TOKEN = 'secret-token'
+    process.env.ANYPLANE_TEST_MARKER = 'm'
+    try {
+      const env = childEnv({ CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: '1' })
+      expect(env.ANYPLANE_TOKEN).toBeUndefined()
+      expect(env.ANYPLANE_TEST_MARKER).toBe('m') // 其余继承不受影响
+      expect(env.CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING).toBe('1') // extra 叠加生效
+    } finally {
+      if (savedToken === undefined) delete process.env.ANYPLANE_TOKEN
+      else process.env.ANYPLANE_TOKEN = savedToken
+      delete process.env.ANYPLANE_TEST_MARKER
+    }
+  })
+
+  test('extra 显式注入 ANYPLANE_TOKEN 也会被剥除', () => {
+    expect(childEnv({ ANYPLANE_TOKEN: 'x' }).ANYPLANE_TOKEN).toBeUndefined()
   })
 })
 

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -23,6 +23,19 @@ export function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e)
 }
 
+/**
+ * 传给 CLI 子进程（claude/codex app-server）的环境：process.env 叠加 extra，
+ * 并剥离 anyplane 自身的服务端凭据 ANYPLANE_TOKEN——它是 /api 与 /ws 的唯一防线，
+ * 不能经 CLI → hooks/MCP server/Bash 工具这条子进程链扩散
+ *（会话内任意命令 `env` 即可读到它，进 transcript 或被外泄后即等于交出远程 API）。
+ * extra 显式注入 ANYPLANE_TOKEN 同样剥除。ANYPLANE_HOST/PORT 等非凭据不处理。
+ */
+export function childEnv(extra?: Record<string, string | undefined>): Record<string, string> {
+  const env = { ...process.env, ...extra } as Record<string, string>
+  delete env.ANYPLANE_TOKEN
+  return env
+}
+
 /** 与官方 CLI 的 projects 目录 slug 规则一致：非字母数字 → '-'（截断/hash 情形极罕见，不实现）。
  *  放在叶子层：transcript 相关模块（discovery/processManager/tailer）共用，避免依赖成环。 */
 export function sanitizePath(p: string): string {


### PR DESCRIPTION
## 范围

按任务要求对全仓库做安全审查（当前分支为新开分支、无 diff，故以 `server/`、`web/`、`scripts/` 下全部 TypeScript/TSX 源码为审查对象），重点覆盖注入、认证与授权绕过、CORS/跨源防护、密钥与 token 泄露、SSRF、路径穿越、不安全默认值、WebSocket 鉴权缺口。AGENTS.md / docs/ 记载的既有安全设计（Origin/Host 一致性校验、审批能力 URL、推送订阅 endpoint 白名单、authToken 防线等）视为刻意防线，未做改动。

## 发现（含 file:line 证据）

### Vuln 1（MEDIUM，已修复）：ANYPLANE_TOKEN 经 process.env 泄漏进 CLI 子进程环境

- **凭据定位**：`ANYPLANE_TOKEN` 是 `authToken` 的来源之一（`server/src/config.ts:96`），配置后它是 `/api` 与 `/ws` 的唯一防线（`server/src/auth.ts:11-17`）。
- **泄漏路径**：四个 spawn 点把完整 `process.env` 交给 claude / codex app-server 子进程——
  - `server/src/backends/claude/processManager.ts`（修复前 `env: { ...process.env, CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING: '1', ... }` 直接展开）
  - `server/src/handoff.ts:64`（简报 fork 的一次性问答进程）
  - `server/src/backends/codex/rpc.ts:67`（app-server 常驻进程）
  - `server/src/backends/claude/agents.ts:71`（不显式传 env，Bun.spawn 缺省继承全量 `process.env`）
- **利用场景**：token 模式把服务暴露到局域网/公网后，会话内的 prompt injection 或恶意 MCP server 只需执行 `env` 即可读到 `ANYPLANE_TOKEN` 并外泄。持 token 者可远程调用全部 `/api` 与 `/ws`（读全部会话、任意目录起会话、远程裁决审批弹窗）——把一次本地注入放大为持久的远程 API 凭据。

### 其余审查结论（干净 / 刻意设计，未改动）

- `auth.ts` 两道跨源防护（hostAllowed / originAllowed / jsonContentTypeRequired）与非回环绑定强制 token 的启动闸：设计严密。
- `push.ts`：能力 URL secret 熵 192bit、订阅 endpoint 白名单（先判回环再判 `*`）、投递 `redirect: 'manual'`、webhook 配置即信任（文档化）。
- 路径穿越：`index.ts` 静态托管与 `/api/history` 依赖 WHATWG URL 归一化消解 `..`/`%2e%2e`/反斜杠点段（已用 Bun 实测 10 个恶意样本）；`uploads.ts` 严格正则 `[0-9a-f]{16}\.(jpg|png|gif|webp)`；`backend.ts` `splitExistingKey` 双段字符闸。
- `web/`：React 默认转义，唯一 `dangerouslySetInnerHTML`（AnyPlaneMark）仅渲染构建期静态 SVG；token 存 localStorage，`?token=` 首注入即抹地址栏。
- `scripts/gateway.ts`：反代目标固定回环，无 token 需 `--insecure` 才启动（文档化信任边界）。

## 修复

新增 `server/src/util.ts` 的 `childEnv(extra?)` helper：`process.env` 叠加 `extra` 后删除 `ANYPLANE_TOKEN`（extra 显式注入同样剥除）；上述四个 spawn 点全部改用。`ANYPLANE_HOST`/`PORT` 等非凭据变量不处理。

- `server/src/util.ts` — 新增 `childEnv()`
- `server/src/backends/claude/processManager.ts`、`server/src/handoff.ts`、`server/src/backends/codex/rpc.ts`、`server/src/backends/claude/agents.ts` — 改用 `childEnv`
- `server/src/util.test.ts` — 新增 2 个单元测试

验证：`bun test` 全量 273 pass / 0 fail；真实 spawn 端到端验证子进程读到 `<absent>`；`tsc --noEmit` 仅余 master 上已存在的 pre-existing 错误（`cli/anyplane.ts`、`scripts/gateway.ts`，与本改动无关）。

## 残留风险（供人工判断，本次未改）

1. **`b|` key 的 forkFromSessionId 未做 UUID 形状校验**（`processManager.ts` hydrateContextUsage 的路径拼接、`backend.ts:47-49`）：WS 客户端在本产品设计模型中即 owner（任意目录起会话 = 任意命令执行是文档化能力），伪造 key 最多读到任意 `.jsonl` 的 token 统计数字，无越权增益；可作纵深加固。
2. **`validSecret` / `isAuthorized` 使用非恒定时间字符串比较**（`push.ts`、`auth.ts:11-17`）：对 192bit 随机密钥的远程时序攻击不现实，理论项。
3. **gateway openssl、portTakeover 的 ss/lsof 等受信系统工具子进程仍继承完整 env**：可信二进制且不再派生子进程，无扩散面。
4. **文档化设计项**：`/api/fs/list` 暴露本机目录结构（README/AGENTS.md 已声明与「任意目录起会话」同级风险）；无 token 回环模式 = 完全信任本机；webhook 渠道方可读通知全文（非端到端加密，配置即信任）。