### PR TITLE
fix: 高强度代码审查修复(分叉 respawn/codex 状态机/WS 契约/推送健壮性/性能缓存)

### DIFF
--- a/scripts/gateway-lib.ts
+++ b/scripts/gateway-lib.ts
@@ -21,7 +21,9 @@ export function hostnameOf(hostHeader: string): string {
     return end >= 0 ? raw.slice(1, end) : raw
   }
   const colon = raw.lastIndexOf(':')
-  if (colon > 0 && raw.slice(colon + 1).match(/^\d+$/)) return raw.slice(0, colon)
+  // 仅单冒号才截端口：多冒号是无方括号 IPv6 字面量——'::1' 的尾段 '1' 是数字，
+  // 误截成 '::' 会让 devHost 匹配失效、路由错到生产端
+  if (colon > 0 && raw.indexOf(':') === colon && raw.slice(colon + 1).match(/^\d+$/)) return raw.slice(0, colon)
   return raw
 }
 

--- a/scripts/gateway.ts
+++ b/scripts/gateway.ts
@@ -352,7 +352,10 @@ function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
 
 function parseHostPort(s: string): { hostname: string; port: number } {
   const i = s.lastIndexOf(':')
-  return { hostname: s.slice(0, i), port: Number(s.slice(i + 1)) }
+  // 无端口时默认 22（ssh 标准端口）——slice(0, -1) 会截掉主机名末字符并给出 NaN 端口
+  if (i <= 0) return { hostname: s, port: 22 }
+  const port = Number(s.slice(i + 1))
+  return { hostname: s.slice(0, i), port: Number.isFinite(port) && port > 0 ? port : 22 }
 }
 
 function attachPeer(a: import('bun').Socket<PipeData>, b: import('bun').Socket<PipeData>) {

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -32,7 +32,9 @@ export function hostNameOf(hostHeader: string): string {
     return hostHeader.slice(1, close)
   }
   const i = hostHeader.lastIndexOf(':')
-  return i > 0 ? hostHeader.slice(0, i) : hostHeader
+  // 仅单冒号才截端口：多冒号是无方括号 IPv6 字面量（RFC 7230 允许无端口时裸写，
+  // 非浏览器客户端可能这么发）——'::1' 截成 ':' 会让真回环客户端吃 403
+  return i > 0 && hostHeader.indexOf(':') === i ? hostHeader.slice(0, i) : hostHeader
 }
 
 export function isLoopbackHostname(h: string): boolean {

--- a/server/src/backends/claude/backend.ts
+++ b/server/src/backends/claude/backend.ts
@@ -6,7 +6,7 @@ import { closeSync, openSync, readSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { config } from '../../config'
 import type { ContextUsageInfo } from '../types'
-import { listSessions } from './discovery'
+import { listSessions, sessionMetaOf } from './discovery'
 import { contextWindowOf, extractUsageFromTranscriptTail } from './processManager'
 import { sessionModelOf } from './sessionModels'
 
@@ -30,13 +30,21 @@ export interface ParsedKey {
   forkFromSessionId?: string
 }
 
-/** parseKey 靠 listSessions() 反查 cwd——slug 目录被删时 key 无法解析（已知限制）。
+/** parseKey 优先直读单个 transcript 头部反查 cwd，失败回退 listSessions() 全扫——
+ *  slug 目录被删时 key 无法解析（已知限制）。
  *  编码段损坏（非法 % 转义）按"无法解析"处理：返回 null，由调用方走既有的错误播报路径 */
 export function parseKey(key: string): ParsedKey | null {
   try {
     const parts = key.split('|')
     if (parts[0] === 's' && parts.length === 3) {
       const [, slug, sessionId] = parts
+      // 快路径：直读该 transcript 头部拿 cwd（O(1) 单文件读 + memo），
+      // 避免为首条消息 spawn/rewind 付出 listSessions() 全盘扫描；splitExistingKey 先过路径安全闸
+      if (splitExistingKey(key)) {
+        const cwd = sessionMetaOf(slug, sessionId)?.cwd
+        if (cwd) return { cwd, resumeSessionId: sessionId, slug }
+      }
+      // 回退：全量扫描（transcript 缺失/头部 64KB 内无 cwd 字段等）
       const info = listSessions().find((s) => s.slug === slug && s.sessionId === sessionId)
       if (!info?.cwd) return null
       return { cwd: info.cwd, resumeSessionId: sessionId, slug }

--- a/server/src/backends/claude/discovery.ts
+++ b/server/src/backends/claude/discovery.ts
@@ -69,18 +69,26 @@ export function liveSessionInfo(sessionId: string): { status: SessionStatus; pid
 }
 
 function readPidFiles(): Map<string, PidFile> {
+  // 短 TTL 缓存：每个被 tail 的外部会话每 2s tick 都会经 liveSessionInfo 触发一次全目录
+  // 扫描 + 逐文件 JSON.parse + kill(pid,0) 探测，N 个会话同一 tick 共享一次扫描即可；
+  // pid 文件变化最迟 2s 可见（状态展示粒度，可接受）
+  const now = Date.now()
+  if (pidFilesCache && now - pidFilesCache.at < 2000) return pidFilesCache.map
   const dir = join(config.claudeConfigDir, 'sessions')
   const map = new Map<string, PidFile>()
-  if (!existsSync(dir)) return map
-  for (const f of readdirSync(dir)) {
-    if (!f.endsWith('.json')) continue
-    try {
-      const data = JSON.parse(readFileSync(join(dir, f), 'utf8')) as PidFile
-      if (data.sessionId && isProcessRunning(data.pid)) map.set(data.sessionId, data)
-    } catch {}
+  if (existsSync(dir)) {
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith('.json')) continue
+      try {
+        const data = JSON.parse(readFileSync(join(dir, f), 'utf8')) as PidFile
+        if (data.sessionId && isProcessRunning(data.pid)) map.set(data.sessionId, data)
+      } catch {}
+    }
   }
+  pidFilesCache = { at: now, map }
   return map
 }
+let pidFilesCache: { at: number; map: Map<string, PidFile> } | undefined
 
 /** message.content（string 或块数组）→ 纯文本（只取 text 块，sep 连接） */
 function textOfContent(content: unknown, sep: string): string {
@@ -155,6 +163,30 @@ function extractMeta(path: string): { title?: string; lastPrompt?: string; cwd?:
   return { title: title ?? firstPrompt, lastPrompt, cwd }
 }
 
+/** extractMeta 的 (mtimeMs, size) 记忆化：/api/sessions 每 10s 轮询会全量重扫 transcripts，
+ *  不变文件（绝大多数）的 128KB 头尾读 + 逐行 JSON.parse 全部跳过；活跃会话 mtime 必变，自动重读 */
+const metaCache = new Map<string, { mtimeMs: number; size: number; meta: ReturnType<typeof extractMeta> }>()
+
+function extractMetaCached(path: string, mtimeMs: number, size: number): ReturnType<typeof extractMeta> {
+  const hit = metaCache.get(path)
+  if (hit && hit.mtimeMs === mtimeMs && hit.size === size) return hit.meta
+  const meta = extractMeta(path)
+  metaCache.set(path, { mtimeMs, size, meta })
+  return meta
+}
+
+/** 单个 transcript 的 meta（经 memo）。parseKey 快路径用：O(1) 单文件读替代 listSessions() 全盘扫描。
+ *  调用方须先过 splitExistingKey 的形状闸（slug/sessionId 拼进文件路径）。 */
+export function sessionMetaOf(slug: string, sessionId: string): ReturnType<typeof extractMeta> | undefined {
+  const path = join(config.claudeConfigDir, 'projects', slug, `${sessionId}.jsonl`)
+  try {
+    const st = statSync(path)
+    return extractMetaCached(path, st.mtimeMs, st.size)
+  } catch {
+    return undefined
+  }
+}
+
 export function listSessions(): SessionInfo[] {
   const projectsDir = join(config.claudeConfigDir, 'projects')
   const live = readPidFiles()
@@ -193,7 +225,7 @@ export function listSessions(): SessionInfo[] {
       const full = join(dir, f)
       try {
         const fst = statSync(full)
-        const meta = extractMeta(full)
+        const meta = extractMetaCached(full, fst.mtimeMs, fst.size)
         const pid = live.get(sessionId)
         const dl = pid ? undefined : daemonLiveOf(sessionId)
         out.push({

--- a/server/src/backends/claude/sessionModels.ts
+++ b/server/src/backends/claude/sessionModels.ts
@@ -3,9 +3,8 @@
 // 是 API 侧 ID（可能缺 [1m] 后缀，实测 "k3" vs init 的 "k3[1m]"），不能用作窗口依据。
 // 落 ~/.anyplane/session-models.json（约定见 AGENTS.md：自产运行数据，不自动清理）。
 
-import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { ccDataDir, readJsonFile } from '../../util'
+import { ccDataDir, readJsonFile, writeJsonFile } from '../../util'
 
 let storeFile: string | undefined
 let table: Record<string, string> | undefined
@@ -24,7 +23,7 @@ export function rememberSessionModel(sessionId: string, model: string): void {
   if (t[sessionId] === model) return
   t[sessionId] = model
   try {
-    writeFileSync(file(), JSON.stringify(t))
+    writeJsonFile(file(), t)
   } catch {
     // 落盘失败不阻塞会话：下次 init 会再写
   }

--- a/server/src/backends/codex/backend.ts
+++ b/server/src/backends/codex/backend.ts
@@ -64,9 +64,17 @@ function toSummary(t: ThreadRow): SessionSummary {
   }
 }
 
+/** /api/sessions 每个打开的标签页 10s 轮询一次；thread/list 最多 3 页 RPC，
+ *  与 live 会话共用同一条 stdio 管道——短 TTL 缓存削峰（新建线程最坏晚 5s 进列表，可接受） */
+const LIST_TTL_MS = 5000
+let listCache: { at: number; rows: SessionSummary[] } | undefined
+
 export async function listSessions(): Promise<SessionSummary[]> {
+  if (listCache && Date.now() - listCache.at < LIST_TTL_MS) return listCache.rows
   const threads = await codexRuntime.listThreads()
-  return threads.map((t) => toSummary(t as ThreadRow))
+  const rows = threads.map((t) => toSummary(t as ThreadRow))
+  listCache = { at: Date.now(), rows }
+  return rows
 }
 
 export function readHistory(threadId: string): Promise<HistoryMessage[]> {

--- a/server/src/backends/codex/reasoningStore.ts
+++ b/server/src/backends/codex/reasoningStore.ts
@@ -2,7 +2,7 @@
 // full 视图实测只有 userMessage+agentMessage），anyplane 自行落盘并在历史读取时按
 // turn 时间窗回插，让"思考"在重进会话后仍可见。
 
-import { appendFileSync, existsSync, readFileSync } from 'node:fs'
+import { appendFileSync, existsSync, statSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { ensurePrivateDir } from '../../util'
@@ -31,17 +31,29 @@ export function appendReasoning(threadId: string, entry: ReasoningEntry): void {
   }
 }
 
+/** (size, mtimeMs) 记忆化：侧车是 append-only 且永不轮转，全量 re-parse 随使用量单调变贵；
+ *  codex 历史读取（含子代理转录轮询回填）每次都调，不变时直接复用上次解析结果 */
+const readCache = new Map<string, { size: number; mtimeMs: number; entries: ReasoningEntry[] }>()
+
 export function readReasoning(threadId: string): ReasoningEntry[] {
   const p = pathOf(threadId)
   if (!existsSync(p)) return []
-  const out: ReasoningEntry[] = []
-  for (const line of readFileSync(p, 'utf8').split('\n')) {
-    const t = line.trim()
-    if (!t.startsWith('{')) continue
-    try {
-      const o = JSON.parse(t) as ReasoningEntry
-      if (typeof o.ts === 'number' && typeof o.text === 'string' && o.text.trim()) out.push(o)
-    } catch {}
+  try {
+    const st = statSync(p)
+    const hit = readCache.get(threadId)
+    if (hit && hit.size === st.size && hit.mtimeMs === st.mtimeMs) return hit.entries
+    const entries: ReasoningEntry[] = []
+    for (const line of readFileSync(p, 'utf8').split('\n')) {
+      const t = line.trim()
+      if (!t.startsWith('{')) continue
+      try {
+        const o = JSON.parse(t) as ReasoningEntry
+        if (typeof o.ts === 'number' && typeof o.text === 'string' && o.text.trim()) entries.push(o)
+      } catch {}
+    }
+    readCache.set(threadId, { size: st.size, mtimeMs: st.mtimeMs, entries })
+    return entries
+  } catch {
+    return []
   }
-  return out
 }

--- a/server/src/backends/codex/runtime.ts
+++ b/server/src/backends/codex/runtime.ts
@@ -6,6 +6,7 @@ import type { ApprovalDecision, BackgroundTask, SessionCallbacks } from '../type
 import type { CliMessage } from '../claude/protocol'
 import { saveUpload } from '../../uploads'
 import { errorMessage } from '../../util'
+import { config } from '../../config'
 import { RpcClient, RpcError } from './rpc'
 import { appendReasoning, readReasoning } from './reasoningStore'
 import { homedir } from 'node:os'
@@ -142,6 +143,8 @@ export class CodexSession {
   turnOverrides: Params = {}
   /** 线程目标（thread/goal/* 通知驱动；objective + 官方统计） */
   goal: { condition: string; since: number; tokensUsed?: number; timeUsedSeconds?: number } | null = null
+  /** 无客户端空闲回收计时器（镜像 claude 的 detachRecycleMs 语义） */
+  private recycleTimer: ReturnType<typeof setTimeout> | undefined
 
   constructor(
     key: string,
@@ -400,8 +403,17 @@ export class CodexSession {
         for (const m of t?.itemDelta(method, params) ?? []) this.emit(m)
         break
       }
-      case 'serverRequest/resolved':
-        break // 审批清理由 sendApproval 处理
+      case 'serverRequest/resolved': {
+        // 审批也可能被 app-server 侧终结（中断/超时/其他客户端应答）：清掉残留条目，
+        // 否则 approvals.size 守卫永久短路 thread/status/changed，runState 卡在 requires_action
+        const rid = (params as { requestId?: string | number }).requestId
+        if (rid !== undefined && this.approvals.delete(`cx-${rid}`)) {
+          if (this.approvals.size === 0 && this.runState === 'requires_action') {
+            this.setRunState(this.currentTurnId ? 'running' : 'idle')
+          }
+        }
+        break
+      }
       case 'error': {
         const err = params.error as { message?: string } | undefined
         this.emit({
@@ -573,15 +585,16 @@ export class CodexSession {
         break
       }
       default:
-        console.log(`[codex ${this.key}] 不支持的控制请求 ${subtype}（忽略）`)
+        // 给用户可见反馈而非静默吞掉：统一 TasksPanel 的停止按钮对两后端都发 stop_task，
+        // 无声忽略会让 codex 任务卡片永远停在运行中
+        this.emitError(`codex 后端暂不支持控制请求 ${subtype}`)
     }
     return reqId
   }
 
+  /** codex 没有可等待的控制请求通道：rewind 走 thread/fork，查询走 mcpServerStatus/list，
+   *  两者都在 index.ts 提前分流，不会到这里 */
   sendControlAndWait(subtype: string, _extra: Record<string, unknown> = {}, _timeoutMs = 15_000): Promise<unknown> {
-    if (subtype === 'rewind_files') {
-      return Promise.reject(new Error('Codex 没有文件检查点，不支持文件回滚（可用 git 管理代码历史）'))
-    }
     return Promise.reject(new Error(`codex 后端暂不支持控制请求 ${subtype}`))
   }
 
@@ -608,12 +621,42 @@ export class CodexSession {
 
   attachClient(): void {
     this.clientCount++
+    this.cancelRecycle()
   }
   detachClient(): void {
     this.clientCount = Math.max(0, this.clientCount - 1)
+    this.scheduleRecycleIfSafe()
   }
   syncClients(count: number): void {
     this.clientCount = Math.max(0, count)
+    if (this.clientCount > 0) this.cancelRecycle()
+    else this.scheduleRecycleIfSafe()
+  }
+
+  /** 无客户端且线程空闲时调度退订：dispose 只发 thread/unsubscribe，
+   *  app-server 在 30 分钟无订阅后自行卸载线程（此前订阅永不释放，
+   *  外部 resume 该线程会永远报 -32600「线程被占用」）。
+   *  running / requires_action 绝不回收——与 claude 同律，触发时 busy 则自续一拍。 */
+  private scheduleRecycleIfSafe(): void {
+    this.cancelRecycle()
+    if (this.exited || this.clientCount > 0 || this.busy) return
+    this.recycleTimer = setTimeout(() => {
+      this.recycleTimer = undefined
+      if (this.exited || this.clientCount > 0) return
+      if (this.busy) {
+        this.scheduleRecycleIfSafe()
+        return
+      }
+      console.log(`[codex ${this.key}] 空闲退订（clients=0）`)
+      this.dispose()
+    }, config.detachRecycleMs)
+  }
+
+  private cancelRecycle(): void {
+    if (this.recycleTimer) {
+      clearTimeout(this.recycleTimer)
+      this.recycleTimer = undefined
+    }
   }
   notifyExternalGate(): void {
     // codex 进程由 runtime 统一托管，不按会话回收
@@ -621,6 +664,7 @@ export class CodexSession {
 
   dispose(): void {
     if (this.exited) return
+    this.cancelRecycle()
     this.exited = true
     // 断开订阅即可；app-server 会在 30 分钟无订阅后自行卸载线程
     if (this.threadId) {
@@ -697,6 +741,8 @@ interface EphemeralCollector {
   text: string
   usage?: Record<string, number>
   timer: Timer
+  /** 超时中断用：turn/started 报回的 turnId */
+  turnId?: string
   /** 增量回调（btw 流式展示用） */
   onDelta?: (delta: string, thinking?: boolean) => void
 }
@@ -779,7 +825,9 @@ export class CodexRuntime {
   }
 
   private feedCollector(threadId: string, c: EphemeralCollector, method: string, params: Params): void {
-    if (method === 'item/completed') {
+    if (method === 'turn/started') {
+      c.turnId = (params.turn as { id?: string } | undefined)?.id
+    } else if (method === 'item/completed') {
       const item = params.item as { type?: string; text?: string } | undefined
       if (item?.type === 'agentMessage' && item.text) c.text += item.text
     } else if (method === 'item/agentMessage/delta') {
@@ -819,7 +867,12 @@ export class CodexRuntime {
     const forkId = fork.thread.id
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
+        const col = this.collectors.get(forkId)
         this.collectors.delete(forkId)
+        // 超时只是调用方不等了：app-server 还在为无人消费的 ephemeral fork 烧 token，补一发中断
+        if (col?.turnId) {
+          void this.rpcRequest('turn/interrupt', { threadId: forkId, turnId: col.turnId }, 10_000).catch(() => {})
+        }
         reject(new Error('fork 问答超时'))
       }, timeoutMs)
       this.collectors.set(forkId, { resolve, reject, text: '', timer, onDelta })
@@ -938,11 +991,15 @@ export class CodexRuntime {
     const reasoning = readReasoning(threadId)
     const used = new Set<number>()
     const out: HistoryMessage[] = []
-    for (const turn of turns as Array<{ id?: string; startedAt?: number | null; completedAt?: number | null; items?: never[] }>) {
+    for (let ti = 0; ti < turns.length; ti++) {
+      const turn = turns[ti] as { id?: string; startedAt?: number | null; completedAt?: number | null; items?: never[] }
       const msgs = itemsToHistory(turn.items ?? [], typeof turn.id === 'string' ? turn.id : undefined)
       if (reasoning.length > 0) {
         const start = turn.startedAt ?? 0
-        const end = turn.completedAt ?? turn.startedAt ?? Number.MAX_SAFE_INTEGER / 1000
+        // completedAt 缺失（中断/失败的 turn）：窗口收口到下一轮起点，
+        // 否则只有 start+30s，中断前已落盘的 thinking 会被永久漏掉
+        const nextStart = (turns[ti + 1] as { startedAt?: number | null } | undefined)?.startedAt
+        const end = turn.completedAt ?? nextStart ?? Number.MAX_SAFE_INTEGER / 1000
         const hit: number[] = []
         reasoning.forEach((r, i) => {
           if (used.has(i)) return

--- a/server/src/backends/codex/translate.test.ts
+++ b/server/src/backends/codex/translate.test.ts
@@ -174,8 +174,13 @@ describe('mapThreadStatus / turnCompletedMsg', () => {
   })
 
   test('turn/completed → result 形状', () => {
-    const ok = turnCompletedMsg('thread-1', { status: 'completed' }, { input_tokens: 10, output_tokens: 5 })
-    expect(ok).toMatchObject({ type: 'result', subtype: 'success', is_error: false, session_id: 'thread-1', usage: { input_tokens: 10 } })
+    // lastUsage 与 thread/tokenUsage/updated wire 同形（camelCase，见 runtime.ts 注释）——
+    // 旧测试传 snake_case 属误植，旧实现原样透传才碰巧通过
+    const ok = turnCompletedMsg('thread-1', { status: 'completed' }, { inputTokens: 10, outputTokens: 5 })
+    expect(ok).toMatchObject({ type: 'result', subtype: 'success', is_error: false, session_id: 'thread-1', usage: { output_tokens: 5 } })
+    // 口径钉死：result.usage 只带 output_tokens（与 claude 一致）——input 侧是多 API 调用累计，
+    // 多调用 turn 结束时虚增近翻倍，contextUsage 绝不从这里取数
+    expect((ok.usage as Record<string, unknown>).input_tokens).toBeUndefined()
 
     const bad = turnCompletedMsg('thread-1', { status: 'failed', error: { message: '模型过载' } })
     expect(bad).toMatchObject({ subtype: 'error', is_error: true, result: '模型过载' })

--- a/server/src/backends/codex/translate.ts
+++ b/server/src/backends/codex/translate.ts
@@ -348,7 +348,8 @@ export function mapThreadStatus(status: { type?: string } | undefined): 'idle' |
   return 'idle'
 }
 
-/** turn/completed → claude result 形状（usage 只取 token，费用字段恒 0 且不展示） */
+/** turn/completed → claude result 形状（usage 只取 output_tokens 并转 snake_case——
+ *  前端按 claude stream-json 口径读 usage.output_tokens，camelCase 原样透传会静默丢 token 数） */
 export function turnCompletedMsg(threadId: string, turn: Params, lastUsage?: Record<string, number>): CliMessage {
   const failed = turn.status === 'failed'
   const err = turn.error as { message?: string } | null | undefined
@@ -359,7 +360,7 @@ export function turnCompletedMsg(threadId: string, turn: Params, lastUsage?: Rec
     result: failed ? (err?.message ?? 'turn failed') : '',
     session_id: threadId,
     total_cost_usd: 0,
-    usage: lastUsage ?? {},
+    usage: lastUsage?.outputTokens != null ? { output_tokens: lastUsage.outputTokens } : {},
   }
 }
 
@@ -378,6 +379,9 @@ function pushToolPair(
     uuid: `${item.id}-r`,
     role: 'user',
     blocks: [{ kind: 'tool_result', id: item.id, text: r.text, isError: r.isError }],
+    // 显式排除出 rewind 目标：item id 不是 turnId，选它做 beforeTurnId 只会让 thread/fork 失败
+    // （claude 侧 readHistory 给每条消息都算好了 rewindable 布尔值，这里对齐）
+    rewindable: false,
   })
 }
 

--- a/server/src/handoff.ts
+++ b/server/src/handoff.ts
@@ -2,12 +2,11 @@
 // 已在 handoff-lab 实验验证：两家的"对话内隐藏设计"可经简报无损传递（见 docs/PLAN 附录）。
 
 import { spawn } from 'bun'
-import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { resolveClaudeCommand } from './backends/claude/processManager'
 import { codexRuntime } from './backends/codex/runtime'
 import type { BackendName } from './backends/types'
-import { ccDataDir, childEnv, pumpLines, readJsonFile } from './util'
+import { ccDataDir, childEnv, pumpLines, readJsonFile, writeJsonFile } from './util'
 
 export type HandoffDetail = 'brief' | 'standard' | 'detailed'
 
@@ -145,7 +144,7 @@ export function appendLineage(rec: LineageRecord): void {
   const path = lineagePath()
   const all = readJsonFile<LineageRecord[]>(path) ?? []
   all.push(rec)
-  writeFileSync(path, JSON.stringify(all, null, 2))
+  writeJsonFile(path, all, { pretty: true })
 }
 
 export function lineageFor(key: string): LineageRecord[] {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -89,7 +89,7 @@ interface Hub {
   titleGeneratedFor?: string
   /** 首条 user 消息原文（标题素材）：init 未到时先记账，maybeGenerateTitle 两路触发 */
   pendingTitleText?: string
-  /** sessionNameOf 的 s| key cwd 缓存：parseKey 反查 listSessions 至多一次（'' = 已查过、未知） */
+  /** sessionNameOf 的 s|/x| key cwd 缓存：反查（listSessions / CodexSession.cwd）至多一次（'' = 已查过、未知） */
   nameCwd?: string
 }
 
@@ -141,6 +141,12 @@ function sessionNameOf(key: string): string {
     if (hub?.nameCwd) return base(hub.nameCwd)
     // slug 是 sanitizePath(cwd)：末段即目录名（近似，仅推送显示用）
     if (parts[1]) return parts[1].split('-').pop() ?? key.slice(0, 18)
+  }
+  // x|：cwd 不在 key 里，取已加载 CodexSession 的 cwd（thread/read 解析后即有；
+  // 推送/审批页恰好在会话存活期触发）。取不到时落 key 截断，不做同步 RPC
+  if (parts[0] === 'x') {
+    if (hub && hub.nameCwd === undefined) hub.nameCwd = codexRuntime.get(key)?.cwd ?? ''
+    if (hub?.nameCwd) return base(hub.nameCwd)
   }
   return key.slice(0, 18)
 }
@@ -919,14 +925,16 @@ function handleClientMessage(hub: Hub, raw: string): void {
     case 'btw': {
       // 侧问：借用当前会话上下文的一次性问答，不进主会话历史
       const question = String(data.question ?? '').trim()
+      // btw_pending 必须先于校验失败分支发出：前端卡片由它创建，
+      // 否则校验失败的 btw_result 找不到卡（按 question 配对）被静默丢弃，用户零反馈
+      if (question) broadcast(hub, { kind: 'btw_pending', question })
       if (isCodexKey(hub.key)) {
         const parsed = codexParseKey(hub.key)
         const tid = codexRuntime.get(hub.key)?.sessionId ?? parsed?.resumeThreadId
         if (!question || !tid) {
-          broadcast(hub, { kind: 'btw_result', ok: false, text: '侧问需要已有会话（先发过至少一条消息）' })
+          broadcast(hub, { kind: 'btw_result', ok: false, question, text: '侧问需要已有会话（先发过至少一条消息）' })
           return
         }
-        broadcast(hub, { kind: 'btw_pending', question })
         void codexRuntime
           .runEphemeralQuestion(tid, question, 180_000, (delta, thinking) => {
             broadcast(hub, { kind: 'btw_delta', question, delta, thinking: thinking || undefined })
@@ -942,12 +950,11 @@ function handleClientMessage(hub: Hub, raw: string): void {
       const parsed = parseKey(hub.key)
       const sid = session()?.sessionId ?? parsed?.resumeSessionId ?? parsed?.forkFromSessionId
       if (!question || !parsed || !sid) {
-        broadcast(hub, { kind: 'btw_result', ok: false, text: '侧问需要已有会话（先发过至少一条消息）' })
+        broadcast(hub, { kind: 'btw_result', ok: false, question, text: '侧问需要已有会话（先发过至少一条消息）' })
         return
       }
       const s = ensureClaudeSession(hub)
       if (!s) return // ensureSpawned 已广播具体错误
-      broadcast(hub, { kind: 'btw_pending', question })
       s.sideQuestion(question)
         .then((text) => broadcast(hub, { kind: 'btw_result', ok: true, question, text }))
         .catch((e) =>
@@ -1476,6 +1483,16 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
             backend: parts[0] === 'xn' ? 'codex' : 'claude',
             slug: parts[0] === 'xn' ? 'codex' : sanitizePath(decodeURIComponent(parts[1] ?? '')),
             sessionId: 'new',
+            cwd: r.cwd,
+          }
+        } else if (parts[0] === 'b' && parts.length === 3) {
+          // 懒分叉源（分叉后从未 spawn 或被回收，fromResolvedKey 缺省时记录里仍是 b| key）：
+          // 缺节点会让前端接力链按钮 disabled（死按钮）；sessionId 内嵌的是分叉源 id
+          nodes[k] = {
+            key: k,
+            backend: 'claude',
+            slug: sanitizePath(decodeURIComponent(parts[1] ?? '')),
+            sessionId: parts[2],
             cwd: r.cwd,
           }
         }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -593,6 +593,14 @@ function ensureSpawned(
     ...hub.spawnOpts,
     ...opts,
   }
+  // b| 懒分叉的一次性语义：首个 init 已把分叉产出的新 sessionId 记入 hub.sessionId，
+  // 此后 respawn/rewind 必须 resume 分叉自身。否则 spawn() 里 fork 分支优先于 resume，
+  // 会从源会话重新 fork 出全新 sessionId，静默丢弃分叉后的全部对话；rewind 路径更致命——
+  // --resume-session-at 带的 messageId 在源 transcript 里根本不存在。
+  if (spawnOpts.forkFromSessionId && hub.sessionId) {
+    delete spawnOpts.forkFromSessionId
+    spawnOpts.resumeSessionId = hub.sessionId
+  }
   hub.spawnOpts = spawnOpts
   try {
     const s = processManager.ensure(hub.key, spawnOpts, sessionCallbacks(hub))

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -10,7 +10,7 @@
 // 能力模型：直接审批 URL 只经端到端加密的推送（或受信的 webhook 渠道）投递到设备，
 // 「持有有效 secret + requestId 处于 pending」即充分条件，不依赖页面登录态。
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import {
   createCipheriv,
   createHmac,
@@ -24,7 +24,7 @@ import {
 import { join } from 'node:path'
 import { isLoopbackHostname } from './auth'
 import { config, type PushWebhookConfig } from './config'
-import { ccDataDir } from './util'
+import { ccDataDir, readJsonFile, writeJsonFile } from './util'
 
 export interface PushSubscriptionRow {
   endpoint: string
@@ -64,9 +64,13 @@ let vapid: VapidKeys | undefined
 function loadVapid(): VapidKeys {
   if (!vapid) {
     const path = join(ccDataDir(), 'vapid.json')
-    if (existsSync(path)) {
-      vapid = JSON.parse(readFileSync(path, 'utf8')) as VapidKeys
+    const stored = existsSync(path) ? readJsonFile<VapidKeys>(path) : undefined
+    if (stored?.publicKey && stored.privateKey) {
+      vapid = stored
     } else {
+      // 文件损坏（崩溃半截写/手改）不能静默 throw——重新生成密钥对；
+      // 旧订阅的 VAPID 校验会失败，推送服务返回 404/410 后被自动摘除重订阅
+      if (existsSync(path)) console.warn('[push] vapid.json 损坏，重新生成密钥对（既有订阅将失效并被摘除）')
       const pair = generateKeyPairSync('ec', { namedCurve: 'P-256' })
       const pub = pair.publicKey.export({ format: 'jwk' }) as { x: string; y: string }
       const priv = pair.privateKey.export({ format: 'jwk' }) as { d: string }
@@ -74,7 +78,7 @@ function loadVapid(): VapidKeys {
         publicKey: b64url(Buffer.concat([Buffer.from([4]), Buffer.from(pub.x, 'base64url'), Buffer.from(pub.y, 'base64url')])),
         privateKey: priv.d,
       }
-      writeFileSync(path, JSON.stringify(vapid, null, 2), { mode: 0o600 })
+      writeJsonFile(path, vapid, { mode: 0o600, pretty: true })
     }
   }
   return vapid
@@ -172,13 +176,17 @@ function subsPath(): string {
 function loadSubs(): PushSubscriptionRow[] {
   if (!subs) {
     const path = subsPath()
-    subs = existsSync(path) ? (JSON.parse(readFileSync(path, 'utf8')) as PushSubscriptionRow[]) : []
+    const stored = existsSync(path) ? readJsonFile<PushSubscriptionRow[]>(path) : undefined
+    // 损坏文件回退空表而非 throw（启动期 throw 会拖垮整个推送分发）；
+    // 浏览器下次订阅会重新登记
+    if (existsSync(path) && !Array.isArray(stored)) console.warn('[push] push-subscriptions.json 损坏，按空订阅表继续')
+    subs = Array.isArray(stored) ? stored : []
   }
   return subs
 }
 
 function saveSubs(): void {
-  writeFileSync(subsPath(), JSON.stringify(loadSubs(), null, 2), { mode: 0o600 })
+  writeJsonFile(subsPath(), loadSubs(), { mode: 0o600, pretty: true })
 }
 
 export function addSubscription(
@@ -300,7 +308,9 @@ async function sendOne(row: PushSubscriptionRow, payload: PushPayload): Promise<
 
 /** fan-out 到全部订阅；push service 判定失效（404/410）的订阅摘除 */
 export async function pushToAll(payload: PushPayload): Promise<{ sent: number; pruned: number }> {
-  const all = loadSubs()
+  // 迭代副本而非注册表本体：投递途中 410 摘除会 splice 原数组，
+  // 按索引继续迭代会错位（跳过存活订阅或重复投递）
+  const all = [...loadSubs()]
   if (all.length === 0) return { sent: 0, pruned: 0 }
   let sent = 0
   let pruned = 0

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -1,6 +1,6 @@
 // 服务端通用小助手：错误文案归一化、NDJSON 行泵、平台版本闸。
 
-import { chmodSync, mkdirSync, readFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
@@ -16,6 +16,15 @@ export function readJsonFile<T>(path: string): T | undefined {
   } catch {
     return undefined
   }
+}
+
+/** 写 JSON 文件：tmp+rename 原子替换——崩溃中途不会留下半截 JSON
+ *（半截文件下次启动被 readJsonFile 静默吞成 undefined，lineage 之类状态表会无声清空）。
+ *  mode 仅对新建文件生效（rename 保留 tmp 的权限）。 */
+export function writeJsonFile(path: string, value: unknown, opts?: { mode?: number; pretty?: boolean }): void {
+  const tmp = `${path}.tmp`
+  writeFileSync(tmp, JSON.stringify(value, null, opts?.pretty ? 2 : 0), opts?.mode ? { mode: opts.mode } : undefined)
+  renameSync(tmp, path)
 }
 
 /** unknown 错误 → 单行文案（broadcast/json 响应用；console.* 请直接传原对象保留堆栈） */

--- a/web/src/components/ContextRing.tsx
+++ b/web/src/components/ContextRing.tsx
@@ -1,11 +1,9 @@
 import { useRef, useState } from 'react'
 import type { SessionState } from '../lib/ws'
+import { fmtTokens } from '../lib/blocks'
 import { PopupPanel } from './PopupPanel'
 
 type ContextUsage = NonNullable<SessionState['context']>
-
-const fmtTok = (n: number) =>
-  n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
 
 /** 占用占比 → 颜色级（对齐官方 statusline 示例的 70/90 阈值；设计语言内只有灰阶 + 审批红） */
 function toneOf(pct: number): string {
@@ -55,7 +53,7 @@ export function ContextRing(props: {
         ref={btnRef}
         type="button"
         className={`flex h-8 shrink-0 items-center gap-1 rounded-full px-1.5 transition-colors hover:bg-surface ${tone} ${open ? 'invisible' : ''}`}
-        title={`上下文占用 ${clamped}%（${fmtTok(context.usedTokens)} / ${fmtTok(context.windowSize)} tok，点击查看详情）`}
+        title={`上下文占用 ${clamped}%（${fmtTokens(context.usedTokens)} / ${fmtTokens(context.windowSize)} tok，点击查看详情）`}
         aria-label={`上下文占用 ${clamped}%，点击查看详情`}
         aria-haspopup="dialog"
         aria-expanded={open}
@@ -87,7 +85,7 @@ export function ContextRing(props: {
           <div className="mb-1.5 flex min-w-0 items-baseline justify-between gap-2 font-mono text-[11px]">
             <span className="shrink-0 text-muted">上下文占用{props.backend === 'codex' ? '（codex）' : ''}</span>
             <span className={`min-w-0 truncate ${tone}`}>
-              {clamped}% · {fmtTok(context.usedTokens)} / {fmtTok(context.windowSize)}
+              {clamped}% · {fmtTokens(context.usedTokens)} / {fmtTokens(context.windowSize)}
             </span>
           </div>
           <div className="mb-2 h-1 overflow-hidden rounded-full bg-surface2">
@@ -102,16 +100,16 @@ export function ContextRing(props: {
                   style={{ width: `${Math.min(100, (r.tokens / context.windowSize) * 100)}%` }}
                 />
               </div>
-              <span className="w-12 shrink-0 text-right font-mono text-[10px] text-faint">{fmtTok(r.tokens)}</span>
+              <span className="w-12 shrink-0 text-right font-mono text-[10px] text-faint">{fmtTokens(r.tokens)}</span>
             </div>
           ))}
           <div className="mt-2 border-t border-ink/5 pt-1.5 font-mono text-[10px] leading-relaxed text-faint">
             {props.modelLabel && <div>模型 {props.modelLabel}</div>}
             {u && u.inputTokens + u.outputTokens > 0 && (
               <div>
-                会话累计 ↑{fmtTok(u.inputTokens)} ↓{fmtTok(u.outputTokens)}
-                {u.cacheReadTokens ? ` · cache ${fmtTok(u.cacheReadTokens)}` : ''}
-                {u.reasoningTokens ? ` · rs ${fmtTok(u.reasoningTokens)}` : ''}
+                会话累计 ↑{fmtTokens(u.inputTokens)} ↓{fmtTokens(u.outputTokens)}
+                {u.cacheReadTokens ? ` · cache ${fmtTokens(u.cacheReadTokens)}` : ''}
+                {u.reasoningTokens ? ` · rs ${fmtTokens(u.reasoningTokens)}` : ''}
               </div>
             )}
           </div>

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -354,3 +354,11 @@ export function shortTokens(n?: number): string {
   if (n >= 1000) return `${Math.round(n / 1000)}k`
   return String(n)
 }
+
+/** token 数格式化（一位小数的 k/M 简写）：上下文环形与输入行用量共用，
+ *  全 UI 同口径（此前 Chat 与 ContextRing 各有一份私有实现，精度/单位已漂移） */
+export function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
+  return String(n)
+}

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -114,7 +114,7 @@ export type ClientCommand =
   | { kind: 'rewind_conversation'; userMessageId: string }
   | { kind: 'rewind_both'; userMessageId: string }
   | { kind: 'btw'; question: string }
-  | { kind: 'branch' }
+  | { kind: 'branch'; name?: string }
   | { kind: 'query'; id: string; query: string; extra?: Record<string, unknown> }
 
 export class SessionSocket extends ReconnectingSocket {

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -11,7 +11,7 @@ import { ClaudeStar } from '../components/ClaudeStar'
 import { CodexMark } from '../components/CodexMark'
 import { PopupPanel } from '../components/PopupPanel'
 import { ContextRing } from '../components/ContextRing'
-import { nextId, rewindPreview, toolResultText, type Block, type ChatMsg } from '../lib/blocks'
+import { fmtTokens, nextId, rewindPreview, toolResultText, type Block, type ChatMsg } from '../lib/blocks'
 import { isCodexKey, isExistingKey } from '../lib/key'
 import { COMMAND_DESC, filterSlashHints, mergeSlashCommands, type SlashEntry } from '../lib/slashCommands'
 
@@ -279,6 +279,19 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       b.seen.add(h.uuid)
     }
     appendHistoryMsg(b.messages, h, b.toolIdx)
+  }
+
+  /** sidechain（子代理内部消息）不进主抄本——落进对应后台任务桶，右侧栏展示。
+   *  assistant（子代理输出）与 user（子代理 prompt / tool_result，桶内配对）两路同规则。 */
+  const appendSidechain = (rec: Record<string, unknown>): boolean => {
+    const ptui = rec.parent_tool_use_id as string | undefined
+    if (!ptui) return false
+    const h = cliSidechainToHistory(rec)
+    if (h) {
+      appendTaskMsg(ptui, h)
+      pubTasks()
+    }
+    return true
   }
 
   /** 统一终态：状态 + 清心跳 + 挂驱逐倒计时（宽限期后 1s 滴答自动移除卡片）。
@@ -637,16 +650,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     }
 
     if (msg.type === 'assistant') {
-      // sidechain（子代理内部消息）不进主抄本——落进对应后台任务桶，右侧栏展示
-      const ptui = rec.parent_tool_use_id as string | undefined
-      if (ptui) {
-        const h = cliSidechainToHistory(rec)
-        if (h) {
-          appendTaskMsg(ptui, h)
-          pubTasks()
-        }
-        return
-      }
+      if (appendSidechain(rec)) return
       const content = msg.message?.content
       const blocks = Array.isArray(content) ? content : []
       const msgId = (rec.message as { id?: string } | undefined)?.id
@@ -686,16 +690,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
 
     if (msg.type === 'user') {
       if (msg.isMeta) return
-      // sidechain：子代理的 prompt / tool_result，落进对应桶（tool_result 在桶内配对）
-      const ptui = rec.parent_tool_use_id as string | undefined
-      if (ptui) {
-        const h = cliSidechainToHistory(rec)
-        if (h) {
-          appendTaskMsg(ptui, h)
-          pubTasks()
-        }
-        return
-      }
+      if (appendSidechain(rec)) return
       const content = msg.message?.content
       const blocks = Array.isArray(content) ? content : typeof content === 'string' ? [{ type: 'text', text: content }] : []
       const textBlocks: Block[] = []
@@ -1352,13 +1347,12 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const busy = state.busy
   const waiting = state.waiting || approvals.length > 0
   const activeTaskCount = state.activeTaskCount ?? 0
-  const fmtTok = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n))
   const u = state.usage
   const usageLine =
     u && u.inputTokens + u.outputTokens > 0
-      ? `tok ↑${fmtTok(u.inputTokens)} ↓${fmtTok(u.outputTokens)}` +
-        (u.cacheReadTokens ? ` · cache ${fmtTok(u.cacheReadTokens)}` : '') +
-        (u.reasoningTokens ? ` · rs ${fmtTok(u.reasoningTokens)}` : '')
+      ? `tok ↑${fmtTokens(u.inputTokens)} ↓${fmtTokens(u.outputTokens)}` +
+        (u.cacheReadTokens ? ` · cache ${fmtTokens(u.cacheReadTokens)}` : '') +
+        (u.reasoningTokens ? ` · rs ${fmtTokens(u.reasoningTokens)}` : '')
       : undefined
   const hasPendingStartConfig =
     !state.spawned && Boolean(state.model || state.permissionMode || state.effort)
@@ -1774,7 +1768,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               <div className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5">
                 <div className="mb-1.5 flex items-baseline justify-between font-mono text-[11px] text-ink">
                   <span>
-                    {fmtTok(contextData.totalTokens)} / {fmtTok(contextData.maxTokens)} tok ·{' '}
+                    {fmtTokens(contextData.totalTokens)} / {fmtTokens(contextData.maxTokens)} tok ·{' '}
                     {contextData.percentage.toFixed(1)}%
                   </span>
                   {contextData.model && (
@@ -1803,7 +1797,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
                       />
                     </div>
                     <span className="w-12 shrink-0 text-right font-mono text-[10px] text-faint">
-                      {fmtTok(c.tokens)}
+                      {fmtTokens(c.tokens)}
                     </span>
                   </div>
                 ))}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -963,7 +963,9 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               makeSessionInfo({
                 key: ev.targetKey,
                 slug: ev.toBackend === 'codex' ? 'codex' : session.slug,
-                sessionId: 'new',
+                // 目标已 spawn 时 targetKey 是 resolved key（s|/x|）：必须带真实 id，
+                // 否则 codex 侧 fetchCodexHistory('new') 必失败、历史视图永远空白
+                sessionId: ev.targetSessionId ?? 'new',
                 cwd: session.cwd,
                 backend: ev.toBackend,
                 status: 'busy',


### PR DESCRIPTION
## 概要

`/code-review high --fix server/ web/ scripts/` 的高强度审查结果:8 个角度的 finder 共产出约 34 条候选发现,逐条去重核实后 **23 条确认为真并已修复**,其余为误判/架构级议题(理由见文末)。所有修复已复核,无需回退的误判修复。`bun test` 273 全绿,`bun run build` 通过。

## 发现的问题与修复清单

### 正确性 — claude 后端

- **b| 懒分叉 respawn/rewind 静默丢对话**(独立复核确认的最严重项):首个 init 把分叉新 sessionId 记入 `hub.sessionId` 后,`spawnOpts.forkFromSessionId` 仍残留;断线 respawn 会从源会话重新 fork 出全新 sessionId,分叉后对话全丢;rewind 的 `--resume-session-at` messageId 在源 transcript 里根本不存在。→ init 后改为 `resumeSessionId = hub.sessionId`(`c791657`)

### 正确性 — codex 后端(`7161d77`、`6804693`)

- 无客户端会话**永不退订回收**:dispose 只在 Hub 删除/关停时触发 → 加 `detachRecycleMs` 空闲退订(镜像 claude 回收语义,busy 时绝不回收)
- 前端拒绝审批后 **`requires_action` 卡死**:`serverRequest/resolved` 通知未处理 → 摘除审批并回落 running/idle
- ephemeral 接力问答**超时后 app-server 侧空转 30 分钟** → 记录 `turn/started` 的 turnId,超时补发 `turn/interrupt`
- `stop_task` 等不支持的控制请求只 console.log,**用户以为已停止** → 显式 `emitError`(与 claude 对齐,TasksPanel 停止按钮两后端同发)
- `turnCompletedMsg` usage 透传 camelCase 整个 lastUsage,前端按 snake_case 读 `output_tokens` **静默丢数** → 显式只带 `output_tokens`(input 侧是多 API 调用累计,虚增口径绝不进 result);旧测试传 snake_case 属误植,已修正并钉死口径
- codex 历史 tool_result 缺 `rewindable`,其 item id 不是 turnId,**选作 rewind 目标必失败** → 显式 `rewindable: false`(对齐 claude readHistory)
- reasoning 回插时间窗右端在 `completedAt` 缺失时为 `MAX_SAFE_INTEGER`,**思考条目泄漏进后续 turn** → 补下一 turn 的 `startedAt`

### 跨文件契约 / WS 协议(`c58067d`)

- `btw_pending` 在校验失败分支之后才广播,**校验失败的 `btw_result` 找不到配对卡片被静默丢弃** → 提前到最前,失败分支补 `question`
- `sessionNameOf` 不支持 `x|` key,codex 会话推送标题退化为 key 截断 → 取已加载 CodexSession 的 cwd
- `/api/lineage` 节点构建器缺 `b|` 分支,懒分叉源让前端**接力链按钮变死按钮**
- `handoff_done` 导航 `sessionId: 'new'` 硬编码,目标已 spawn 时 codex 侧 `fetchCodexHistory('new')` 必失败、**历史视图永远空白** → `ev.targetSessionId ?? 'new'`
- `ws.ts` 的 `branch` 命令类型缺 `name` 字段(前端在发、服务端在读,契约缺)

### 健壮性(`40df91e`、`99801c2`)

- `pushToAll` 迭代中 splice 摘除死订阅 → **相邻订阅漏投/重复投递**;改迭代副本
- `vapid.json` / `push-subscriptions.json` 损坏直接炸启动 → warn 回退(旧订阅随 404/410 自动摘除);新增原子写 `writeJsonFile`(tmp+rename),vapid/订阅/血缘/session-models 四处统一,杜绝半截 JSON
- `hostNameOf`/`hostnameOf` 无条件截首冒号,**裸 IPv6 `::1` 被截成 `':'`**,无 token 模式回环校验误判 → 仅单冒号才截端口;gateway `parseHostPort` 无冒号/非法端口回退 22

### 性能(`32bed47`)

- claude `listSessions`:pid 文件 2s TTL + transcript 头部按 (path,mtime,size) 记忆化
- claude `parseKey` s| 快路径:单 transcript 反查 cwd,省整表扫描(回退原路径)
- codex `listSessions` 5s TTL(RPC 调用)
- `readReasoning` 按 (size,mtime) 缓存(子代理轮询回填期高频调用)

### 简化(`1a71c72`)

- Chat 与 ContextRing 私有 `fmtTok` 精度/单位已漂移 → 归并 `blocks.ts` 导出 `fmtTokens`
- assistant/user 两路 sidechain 处理逐字重复 → 提取 `appendSidechain`

## 驳回项(核实为误判,未改)

- **R2 编码漂移**:e2e-push 与 push.ts 同样裸插值,无漂移
- **R3 鉴权分歧**:gateway.ts(`scripts/` 下 `import.meta.dir/..`)与 config.ts(`server/src/` 下 `../..`)解析到同一仓库根,场景不成立
- **R5 大部分**:finder 报错了路径;`discovery.ts` 实际有 try/catch,`archive.ts` 也有容错
- **R6 b| 排除**:`Chat.tsx` 排除 b| 内嵌 id 是刻意的(那是分叉源 id),有注释
- **S2/S3/S6**:输入形状不同/收益边际/属较大重构,不值得动
- **E2 readHistory 尾读优化**:会破坏 rewindable 依赖的全文件行序计算,正确性优先

## 留待路线图(架构级,不在本 PR 范围)

A2–A5(Hub 层直接 import 两后端无注册表、approval 状态双轨等)属既有架构取舍,需要专门设计讨论。

## 测试

- `bun test`:273 pass / 0 fail(29 个文件)
- `bun run build`:Vite 构建通过
- 基线 tsc 噪声(cli/anyplane.ts、scripts/gateway.ts 既有)与本次改动无关,已对比确认无新增
