### PR TITLE
refactor: 全仓库四角度清理（复用/简化/效率/altitude）

### DIFF
--- a/scripts/gateway-lib.ts
+++ b/scripts/gateway-lib.ts
@@ -1,5 +1,13 @@
 /** 80/443 网关的纯函数：协议探测与 dev/prod 分流。不碰网络。 */
 
+import { hostNameOf } from '../server/src/util'
+
+/** Host 去端口的正本在 server/src/util（auth 跨源防护共用同一份，防语义漂移） */
+export const hostnameOf = hostNameOf
+
+/** parseSsListenPids 的正本在 server/src/portTakeover（端口接管共用同一份） */
+export { parseSsListenPids } from '../server/src/portTakeover'
+
 export type Mode = 'dev' | 'prod'
 export type WireProto = 'tls' | 'ssh' | 'http' | 'wait'
 
@@ -12,19 +20,6 @@ export function detectProtocol(buf: Uint8Array): WireProto {
   // SSH-2.0-...
   if (buf[0] === 0x53 && buf[1] === 0x53 && buf[2] === 0x48) return 'ssh'
   return 'http'
-}
-
-export function hostnameOf(hostHeader: string): string {
-  const raw = hostHeader.trim().toLowerCase()
-  if (raw.startsWith('[')) {
-    const end = raw.indexOf(']')
-    return end >= 0 ? raw.slice(1, end) : raw
-  }
-  const colon = raw.lastIndexOf(':')
-  // 仅单冒号才截端口：多冒号是无方括号 IPv6 字面量——'::1' 的尾段 '1' 是数字，
-  // 误截成 '::' 会让 devHost 匹配失效、路由错到生产端
-  if (colon > 0 && raw.indexOf(':') === colon && raw.slice(colon + 1).match(/^\d+$/)) return raw.slice(0, colon)
-  return raw
 }
 
 export function parseCookieMode(cookie: string | null | undefined): Mode | undefined {
@@ -66,17 +61,6 @@ export function modeCookie(mode: Mode, secure: boolean): string {
   const flags = ['Path=/', 'Max-Age=31536000', 'SameSite=Lax']
   if (secure) flags.push('Secure')
   return `${MODE_COOKIE}=${mode}; ${flags.join('; ')}`
-}
-
-/** 从 `ss -tlnp` 文本里抽出占用指定 TCP 端口的 pid（不误伤 :8080 对 :80）。 */
-export function parseSsListenPids(ssOut: string, port: number): number[] {
-  const pids = new Set<number>()
-  const portRe = new RegExp(`(?:[:\\]])${port}(?:\\s|$)`)
-  for (const line of ssOut.split('\n')) {
-    if (!/\bLISTEN\b/.test(line) || !portRe.test(line)) continue
-    for (const m of line.matchAll(/pid=(\d+)/g)) pids.add(Number(m[1]))
-  }
-  return [...pids]
 }
 
 export function isOwnGatewayCmd(cmdline: string): boolean {

--- a/scripts/gateway.ts
+++ b/scripts/gateway.ts
@@ -13,7 +13,8 @@ import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { detectProtocol, isOwnGatewayCmd, modeCookie, parseSsListenPids, pickMode, type Mode } from './gateway-lib'
-import { ensurePrivateDir } from '../server/src/util'
+import { loadAnyplaneConfigFile } from '../server/src/config'
+import { ensurePrivateDir, escapeHtml as htmlEscape } from '../server/src/util'
 
 type GatewayCfg = {
   httpPort: number
@@ -49,22 +50,7 @@ const HOP = new Set([
   'upgrade',
 ])
 
-function loadFileConfig(): { authToken?: string; gateway?: Record<string, unknown> } {
-  const candidates = [
-    join(process.cwd(), 'anyplane.config.json'),
-    join(import.meta.dir, '..', 'anyplane.config.json'),
-    join(homedir(), '.anyplane', 'config.json'),
-  ]
-  for (const p of candidates) {
-    if (!existsSync(p)) continue
-    try {
-      return JSON.parse(readFileSync(p, 'utf8')) as { authToken?: string; gateway?: Record<string, unknown> }
-    } catch (e) {
-      console.error(`[gateway] 解析 ${p} 失败:`, e)
-    }
-  }
-  return {}
-}
+type FileCfg = { authToken?: string; gateway?: Record<string, unknown> }
 
 function num(v: unknown, fallback: number): number {
   const n = typeof v === 'number' ? v : typeof v === 'string' ? Number(v) : NaN
@@ -85,8 +71,7 @@ function parseArgs(argv: string[]): { insecure: boolean; noReplace: boolean } {
   return { insecure: argv.includes('--insecure'), noReplace: argv.includes('--no-replace') }
 }
 
-function loadCfg(): GatewayCfg {
-  const file = loadFileConfig()
+function loadCfg(file: FileCfg): GatewayCfg {
   const g = file.gateway ?? {}
   const args = parseArgs(process.argv.slice(2))
   return {
@@ -101,10 +86,6 @@ function loadCfg(): GatewayCfg {
     insecure: args.insecure || process.env.ANYPLANE_GATEWAY_INSECURE === '1',
     replace: !args.noReplace,
   }
-}
-
-function htmlEscape(s: string): string {
-  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c)
 }
 
 function certSan(cfg: GatewayCfg): string {
@@ -543,8 +524,8 @@ function startMux(
   }
 }
 
-const fileCfg = loadFileConfig()
-const cfg = loadCfg()
+const fileCfg = loadAnyplaneConfigFile() as FileCfg
+const cfg = loadCfg(fileCfg)
 const token = process.env.ANYPLANE_TOKEN || fileCfg.authToken
 
 if (!token && !cfg.insecure) {

--- a/server/src/archive.ts
+++ b/server/src/archive.ts
@@ -98,14 +98,10 @@ export function listTrash(): TrashEntry[] {
       } catch {}
       let sizeBytes = 0
       try {
-        sizeBytes = statSyncSafe(p)
+        sizeBytes = statSync(p).size
       } catch {}
       out.push({ key: `s|${slug}|${sessionId}`, slug, sessionId, trashedAt, sizeBytes })
     }
   }
   return out.sort((a, b) => (b.trashedAt ?? '').localeCompare(a.trashedAt ?? ''))
-}
-
-function statSyncSafe(p: string): number {
-  return statSync(p).size
 }

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -3,6 +3,7 @@
 // 静态前端壳不鉴权（JS 中无敏感数据），数据面与控制面全部受保护。
 
 import { config } from './config'
+import { hostNameOf } from './util'
 
 export function isLoopbackHost(host: string): boolean {
   return host === '127.0.0.1' || host === 'localhost' || host === '::1'
@@ -23,19 +24,7 @@ export function isAuthorized(req: Request, url: URL): boolean {
 // 浏览器在 WS 握手与跨源 POST 时必定携带 Origin；非浏览器客户端（e2e 脚本/curl）不带。
 // 配置 authToken 后 token 即防线，以下检查不生效（行为与旧版完全一致）。
 
-/** Host 头去端口（兼容 [::1]:7480 形态） */
-export function hostNameOf(hostHeader: string): string {
-  if (hostHeader.startsWith('[')) {
-    const close = hostHeader.indexOf(']')
-    // 缺少闭合方括号的 IPv6 Host 头按无效处理，避免 slice(1, -1) 截断后误判为回环
-    if (close === -1) return hostHeader
-    return hostHeader.slice(1, close)
-  }
-  const i = hostHeader.lastIndexOf(':')
-  // 仅单冒号才截端口：多冒号是无方括号 IPv6 字面量（RFC 7230 允许无端口时裸写，
-  // 非浏览器客户端可能这么发）——'::1' 截成 ':' 会让真回环客户端吃 403
-  return i > 0 && hostHeader.indexOf(':') === i ? hostHeader.slice(0, i) : hostHeader
-}
+export { hostNameOf }
 
 export function isLoopbackHostname(h: string): boolean {
   // WHATWG URL 的 IPv6 hostname 保留方括号（http://[::1]:9001 → "[::1]"）

--- a/server/src/backends/claude/backend.ts
+++ b/server/src/backends/claude/backend.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { config } from '../../config'
 import type { ContextUsageInfo } from '../types'
 import { listSessions, sessionMetaOf } from './discovery'
-import { contextWindowOf, extractUsageFromTranscriptTail } from './processManager'
+import { contextUsageOf, contextWindowOf, extractUsageFromTranscriptTail } from './processManager'
 import { sessionModelOf } from './sessionModels'
 
 export function keyFor(slug: string, sessionId: string): string {
@@ -119,13 +119,6 @@ function readTailContext(path: string, size: number, sessionId: string): Context
   }
   const u = extractUsageFromTranscriptTail(text)
   if (!u) return undefined
-  return {
-    usedTokens: u.inputTokens + u.cacheReadTokens + u.cacheWriteTokens,
-    // 离线无 initModel：靠 init 时持久化的 sessionId→model 表；没见过 live 的会话回退默认窗口
-    windowSize: contextWindowOf(sessionModelOf(sessionId)),
-    outputTokens: u.outputTokens,
-    inputTokens: u.inputTokens,
-    cacheReadTokens: u.cacheReadTokens,
-    cacheWriteTokens: u.cacheWriteTokens,
-  }
+  // 离线无 initModel：靠 init 时持久化的 sessionId→model 表；没见过 live 的会话回退默认窗口
+  return contextUsageOf(u, contextWindowOf(sessionModelOf(sessionId)))
 }

--- a/server/src/backends/claude/processManager.ts
+++ b/server/src/backends/claude/processManager.ts
@@ -49,6 +49,32 @@ export interface TranscriptCallUsage {
   cacheWriteTokens: number
 }
 
+/** CLI usage JSON → TranscriptCallUsage（字段名以 stream-json transcript 为准，缺失/非数归 0）。
+ *  实时流（noteContextUsage）与离线回扫（extractUsageFromTranscriptTail）共用同一映射。 */
+export function coerceCallUsage(u: unknown): TranscriptCallUsage | undefined {
+  if (!u || typeof u !== 'object') return undefined
+  const r = u as Record<string, unknown>
+  return {
+    inputTokens: Number(r.input_tokens ?? 0) || 0,
+    outputTokens: Number(r.output_tokens ?? 0) || 0,
+    cacheReadTokens: Number(r.cache_read_input_tokens ?? 0) || 0,
+    cacheWriteTokens: Number(r.cache_creation_input_tokens ?? 0) || 0,
+  }
+}
+
+/** 单次 API 调用 usage → 环形 UI 的上下文占用。usedTokens 口径对齐官方 statusline：
+ *  input+cache，不含 output（output 单独列出）。进程内热路径与离线水合共用。 */
+export function contextUsageOf(u: TranscriptCallUsage, windowSize: number) {
+  return {
+    usedTokens: u.inputTokens + u.cacheReadTokens + u.cacheWriteTokens,
+    windowSize,
+    outputTokens: u.outputTokens,
+    inputTokens: u.inputTokens,
+    cacheReadTokens: u.cacheReadTokens,
+    cacheWriteTokens: u.cacheWriteTokens,
+  }
+}
+
 /** 从 transcript 文本尾部倒序找最后一条主线 assistant 行的 message.usage。
  *  与实时跟踪同口径：sidechain（isSidechain:true）不计；transcript 的 usage 是完成态
  *  （output_tokens 为真实值，不像 stream 快照恒为 0）。找不到返回 undefined。 */
@@ -64,15 +90,8 @@ export function extractUsageFromTranscriptTail(text: string): TranscriptCallUsag
       continue // 尾块首行可能被截断，跳过
     }
     if (msg.type !== 'assistant' || msg.isSidechain === true) continue
-    const u = (msg.message as { usage?: unknown } | undefined)?.usage
-    if (!u || typeof u !== 'object') continue
-    const r = u as Record<string, unknown>
-    return {
-      inputTokens: Number(r.input_tokens ?? 0) || 0,
-      outputTokens: Number(r.output_tokens ?? 0) || 0,
-      cacheReadTokens: Number(r.cache_read_input_tokens ?? 0) || 0,
-      cacheWriteTokens: Number(r.cache_creation_input_tokens ?? 0) || 0,
-    }
+    const u = coerceCallUsage((msg.message as { usage?: unknown } | undefined)?.usage)
+    if (u) return u
   }
   return undefined
 }
@@ -209,26 +228,13 @@ export class ClaudeSession {
     | undefined {
     const u = this.lastCallUsage
     if (!u) return undefined
-    return {
-      usedTokens: u.inputTokens + u.cacheReadTokens + u.cacheWriteTokens,
-      windowSize: contextWindowOf(this.initModel ?? this.opts.model),
-      outputTokens: u.outputTokens,
-      inputTokens: u.inputTokens,
-      cacheReadTokens: u.cacheReadTokens,
-      cacheWriteTokens: u.cacheWriteTokens,
-    }
+    return contextUsageOf(u, contextWindowOf(this.initModel ?? this.opts.model))
   }
 
   /** 记录最近一次 API 调用的 usage（assistant 与 result 同口径）；按值去重，变了才广播 status */
   private noteContextUsage(u: unknown): void {
-    if (!u || typeof u !== 'object') return
-    const r = u as Record<string, unknown>
-    const next = {
-      inputTokens: Number(r.input_tokens ?? 0) || 0,
-      outputTokens: Number(r.output_tokens ?? 0) || 0,
-      cacheReadTokens: Number(r.cache_read_input_tokens ?? 0) || 0,
-      cacheWriteTokens: Number(r.cache_creation_input_tokens ?? 0) || 0,
-    }
+    const next = coerceCallUsage(u)
+    if (!next) return
     const prev = this.lastCallUsage
     if (
       prev &&

--- a/server/src/backends/codex/runtime.ts
+++ b/server/src/backends/codex/runtime.ts
@@ -124,6 +124,18 @@ interface PendingCodexApproval {
   kind: string
 }
 
+/** app-server 的 camelCase usage 记录 → 统一形状（缺失/非数归 0；tokenUsage 与 contextUsage 共用） */
+function mapTokenUsage(u: Record<string, number> | undefined) {
+  const n = (v: unknown) => Number(v ?? 0) || 0
+  return {
+    inputTokens: n(u?.inputTokens),
+    outputTokens: n(u?.outputTokens),
+    cacheReadTokens: n(u?.cachedInputTokens),
+    cacheWriteTokens: n(u?.cacheWriteInputTokens),
+    reasoningTokens: n(u?.reasoningOutputTokens),
+  }
+}
+
 export class CodexSession {
   readonly key: string
   threadId: string | undefined
@@ -196,14 +208,7 @@ export class CodexSession {
     cacheWriteTokens: number
     reasoningTokens: number
   } {
-    const u = this.totalUsage ?? {}
-    return {
-      inputTokens: Number(u.inputTokens ?? 0) || 0,
-      outputTokens: Number(u.outputTokens ?? 0) || 0,
-      cacheReadTokens: Number(u.cachedInputTokens ?? 0) || 0,
-      cacheWriteTokens: Number(u.cacheWriteInputTokens ?? 0) || 0,
-      reasoningTokens: Number(u.reasoningOutputTokens ?? 0) || 0,
-    }
+    return mapTokenUsage(this.totalUsage)
   }
 
   /** 当前上下文窗口占用（codex 口径：last.totalTokens = 最新活跃上下文大小，对应 TUI footer
@@ -226,11 +231,7 @@ export class CodexSession {
     return {
       usedTokens: Number(u.totalTokens ?? 0) || 0,
       windowSize: w,
-      outputTokens: Number(u.outputTokens ?? 0) || 0,
-      inputTokens: Number(u.inputTokens ?? 0) || 0,
-      cacheReadTokens: Number(u.cachedInputTokens ?? 0) || 0,
-      cacheWriteTokens: Number(u.cacheWriteInputTokens ?? 0) || 0,
-      reasoningTokens: Number(u.reasoningOutputTokens ?? 0) || 0,
+      ...mapTokenUsage(u),
     }
   }
 
@@ -989,23 +990,39 @@ export class CodexRuntime {
     }
     const turns = res.thread?.turns ?? []
     const reasoning = readReasoning(threadId)
+    // 侧车 append-only 按时间递增；校验失败（手工编辑等）回退全扫，语义不变
+    const reasoningSorted = reasoning.every((r, i) => i === 0 || reasoning[i - 1].ts <= r.ts)
     const used = new Set<number>()
     const out: HistoryMessage[] = []
     for (let ti = 0; ti < turns.length; ti++) {
-      const turn = turns[ti] as { id?: string; startedAt?: number | null; completedAt?: number | null; items?: never[] }
+      const turn = turns[ti]
       const msgs = itemsToHistory(turn.items ?? [], typeof turn.id === 'string' ? turn.id : undefined)
       if (reasoning.length > 0) {
         const start = turn.startedAt ?? 0
         // completedAt 缺失（中断/失败的 turn）：窗口收口到下一轮起点，
         // 否则只有 start+30s，中断前已落盘的 thinking 会被永久漏掉
-        const nextStart = (turns[ti + 1] as { startedAt?: number | null } | undefined)?.startedAt
+        const nextStart = turns[ti + 1]?.startedAt
         const end = turn.completedAt ?? nextStart ?? Number.MAX_SAFE_INTEGER / 1000
+        const loMs = (start - 1) * 1000
+        const hiMs = end * 1000 + 30_000
         const hit: number[] = []
-        reasoning.forEach((r, i) => {
-          if (used.has(i)) return
-          const ts = r.ts / 1000
-          if (ts >= start - 1 && ts <= end + 30) hit.push(i)
-        })
+        if (reasoningSorted) {
+          // 时间窗二分定位起点后线性到终点：O(log n + 命中数)，免每 turn 全扫侧车
+          let lo = 0
+          let hi = reasoning.length
+          while (lo < hi) {
+            const mid = (lo + hi) >> 1
+            if (reasoning[mid].ts < loMs) lo = mid + 1
+            else hi = mid
+          }
+          for (let i = lo; i < reasoning.length && reasoning[i].ts <= hiMs; i++) {
+            if (!used.has(i)) hit.push(i)
+          }
+        } else {
+          reasoning.forEach((r, i) => {
+            if (!used.has(i) && r.ts >= loMs && r.ts <= hiMs) hit.push(i)
+          })
+        }
         if (hit.length > 0) {
           const thinkingMsgs = hit.map((i) => ({
             uuid: `rs-${reasoning[i].ts}-${i}`,

--- a/server/src/backends/codex/translate.ts
+++ b/server/src/backends/codex/translate.ts
@@ -223,7 +223,8 @@ function systemText(text: string): CliMessage {
 
 /** collab 子代理状态（pendingInit/running/interrupted/completed/errored/shutdown/notFound）
  *  → claude task_notification 三态；非终态返回 null 不发通知 */
-function collabTerminalStatus(status?: string): 'completed' | 'failed' | 'stopped' | null {  switch (status) {
+function collabTerminalStatus(status?: string): 'completed' | 'failed' | 'stopped' | null {
+  switch (status) {
     case 'completed':
       return 'completed'
     case 'interrupted':

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -68,7 +68,9 @@ const DEFAULTS: ServerConfig = {
   claudeConfigDir: join(homedir(), '.claude'),
 }
 
-function loadFileConfig(): Partial<ServerConfig> {
+/** 读取 anyplane 配置文件：cwd → 项目根 → ~/.anyplane/config.json，首个存在者优先。
+ *  服务端与 scripts/gateway 共用同一候选集，保证两处读到的配置一致。 */
+export function loadAnyplaneConfigFile(): Record<string, unknown> {
   // server 从 workspace 的 server/ 目录启动时，仍应支持 README 中约定的项目根配置文件。
   const projectRootConfig = join(import.meta.dir, '..', '..', 'anyplane.config.json')
   const candidates = [
@@ -79,7 +81,7 @@ function loadFileConfig(): Partial<ServerConfig> {
   for (const p of candidates) {
     if (existsSync(p)) {
       try {
-        return JSON.parse(readFileSync(p, 'utf8'))
+        return JSON.parse(readFileSync(p, 'utf8')) as Record<string, unknown>
       } catch (e) {
         console.error(`[config] 解析 ${p} 失败:`, e)
       }
@@ -90,7 +92,7 @@ function loadFileConfig(): Partial<ServerConfig> {
 
 export const config: ServerConfig = {
   ...DEFAULTS,
-  ...loadFileConfig(),
+  ...(loadAnyplaneConfigFile() as Partial<ServerConfig>),
   ...(process.env.ANYPLANE_PORT ? { port: Number(process.env.ANYPLANE_PORT) } : {}),
   ...(process.env.ANYPLANE_HOST ? { host: process.env.ANYPLANE_HOST } : {}),
   ...(process.env.ANYPLANE_TOKEN ? { authToken: process.env.ANYPLANE_TOKEN } : {}),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,7 +37,7 @@ import {
   seedMessage,
   type HandoffDetail,
 } from './handoff'
-import { errorMessage, hasWindowsSocketFix } from './util'
+import { errorMessage, escapeHtml, hasWindowsSocketFix } from './util'
 
 // ---------- sessionKey ----------
 // 编码规则与解析见 backends/claude/backend.ts（s|slug|sid / n|cwd）
@@ -151,18 +151,20 @@ function sessionNameOf(key: string): string {
   return key.slice(0, 18)
 }
 
-/** 审批输入摘要：Bash 给命令、Edit/Write 给路径，其余给 JSON 截断 */
+/** 审批输入摘要（推送通知/审批页）：按工具挑裁决所需的关键字段，其余给 JSON 截断。
+ *  与 web 端 toolSummary 同族但取舍不同——审批场景 Bash 必须给 command 本体
+ *  （description 是作者给的说明文字，不能作为裁决依据；web 卡片下方另有详情区才可用它打头）。 */
 function summarizeInput(toolName: string, input: unknown): string {
   const obj = (input ?? {}) as Record<string, unknown>
   if (toolName === 'Bash') return String(obj.command ?? '').slice(0, 400)
+  if (toolName === 'Glob' || toolName === 'Grep') return String(obj.pattern ?? '')
+  if (toolName === 'WebSearch') return String(obj.query ?? '')
+  if (toolName === 'WebFetch') return String(obj.url ?? '')
+  if (toolName === 'Agent') return String(obj.description ?? obj.prompt ?? '').slice(0, 300)
   if (obj.file_path) return String(obj.file_path)
   if (obj.path) return String(obj.path)
   const json = JSON.stringify(input ?? {})
   return json.length > 300 ? json.slice(0, 300) + '…' : json
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 }
 
 /**
@@ -295,6 +297,13 @@ function getHub(key: string): Hub {
   return h
 }
 
+/** 待审批重放：WS 接入（单播）与 attach（广播）共用——未裁决的审批补发给目标 */
+function replayApprovals(hub: Hub, send: (payload: unknown) => void): void {
+  for (const a of hub.pendingApprovals.values()) {
+    send({ kind: 'approval_request', ...a })
+  }
+}
+
 function broadcast(hub: Hub, payload: unknown): void {
   const text = JSON.stringify(payload)
   for (const ws of hub.clients) {
@@ -383,6 +392,35 @@ function pushStatus(hub: Hub, extra?: Record<string, unknown>): void {
   broadcast(hub, { kind: 'status', state: { ...statusOf(hub.key, undefined, true), ...extra } })
 }
 
+/** onStatusChange 的 leading+trailing 节流：并行后台任务的 task_progress 心跳每秒可触发多次，
+ *  statusOf 构造+广播是纯派生数据，窗口内合并即可。leading 立即发（busy/idle 转移零延迟），
+ *  窗口内后续变更合并为 trailing 一发——终态只是延迟 ≤300ms，不会丢失。
+ *  仅挂 onStatusChange 一路；审批/退出/attach 等事件路径仍直调 pushStatus 保证即时。 */
+const STATUS_THROTTLE_MS = 300
+const statusThrottle = new WeakMap<Hub, { timer: ReturnType<typeof setTimeout> | null; dirty: boolean }>()
+
+function throttledPushStatus(hub: Hub): void {
+  let st = statusThrottle.get(hub)
+  if (!st) {
+    st = { timer: null, dirty: false }
+    statusThrottle.set(hub, st)
+  }
+  if (st.timer) {
+    st.dirty = true
+    return
+  }
+  pushStatus(hub)
+  st.timer = setTimeout(() => {
+    st.timer = null
+    // Hub 可能已回收删除：确认还是同一个 Hub 再补发
+    if (st.dirty && hubs.get(hub.key) === hub) {
+      st.dirty = false
+      pushStatus(hub)
+    }
+  }, STATUS_THROTTLE_MS)
+  st.timer.unref?.()
+}
+
 /** codex 会话状态：与 statusOf 同形，供列表 managed 字段与 WS status 复用 */
 function codexStatusOf(key: string): Record<string, unknown> {
   const s = codexRuntime.get(key)
@@ -390,8 +428,8 @@ function codexStatusOf(key: string): Record<string, unknown> {
   const waiting = (s?.waiting ?? false) || (hub?.pendingApprovals.size ?? 0) > 0
   return {
     ...baseStatusOf(s, hub, waiting),
-    activeTaskCount: 0,
-    activeTasks: [],
+    // 不下发 activeTasks/activeTaskCount：codex 服务端不维护任务表，恒空数组会被
+    // hydrateTasks 误读为"权威空"而在空闲时判死 live 桶；字段缺席则前端跳过水合
     model: hub?.spawnOpts?.model,
     tailing: false,
     goal: s?.goal ?? null,
@@ -489,7 +527,7 @@ function sessionCallbacks(hub: Hub) {
       pushStatus(hub)
       processManager.get(hub.key)?.notifyExternalGate()
     },
-    onStatusChange: () => pushStatus(hub),
+    onStatusChange: () => throttledPushStatus(hub),
     onExit: (code: number) => {
       pushStatus(hub, { exited: true, exitCode: code, spawned: false, busy: false, waiting: false })
     },
@@ -671,9 +709,7 @@ function handleClientMessage(hub: Hub, raw: string): void {
       } else {
         pushStatus(hub)
       }
-      for (const a of hub.pendingApprovals.values()) {
-        broadcast(hub, { kind: 'approval_request', ...a })
-      }
+      replayApprovals(hub, (p) => broadcast(hub, p))
       break
     }
     case 'tail_subscribe': {
@@ -1208,6 +1244,20 @@ if (!hasWindowsSocketFix() && process.env.ANYPLANE_ALLOW_UNSAFE_BUN !== '1') {
   process.exit(1)
 }
 
+// ---------- /api/sessions 的 git 分支缓存 ----------
+// 列表被前端轮询，每个 cwd 的分支读取是 2-3 次同步文件 IO；分支变化不需要秒级新鲜度，30s TTL。
+const BRANCH_CACHE_TTL_MS = 30_000
+const branchCache = new Map<string, { branch: string | undefined; at: number }>()
+
+function branchOfCached(cwd?: string): string | undefined {
+  if (!cwd) return undefined
+  const hit = branchCache.get(cwd)
+  if (hit && Date.now() - hit.at < BRANCH_CACHE_TTL_MS) return hit.branch
+  const branch = readGitBranch(cwd) // 普通仓库与 worktree 都支持
+  branchCache.set(cwd, { branch, at: Date.now() })
+  return branch
+}
+
 async function handleApi(req: Request, url: URL): Promise<Response | undefined> {
   // ---------- Web Push 订阅管理 ----------
   if (url.pathname === '/api/push/public-key' && req.method === 'GET') {
@@ -1292,17 +1342,10 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
   }
   if (url.pathname === '/api/sessions' && req.method === 'GET') {
     const sessions = listSessions()
-    // 项目行 git 分支：按 cwd 各读一次（普通仓库与 worktree 都支持）
-    const branchOf = (cwd?: string): string | undefined => {
-      if (!cwd) return undefined
-      if (!branchCache.has(cwd)) branchCache.set(cwd, readGitBranch(cwd))
-      return branchCache.get(cwd)
-    }
-    const branchCache = new Map<string, string | undefined>()
     const claudeRows = sessions.map((s: SessionInfo) => ({
       ...s,
       backend: 'claude' as const,
-      gitBranch: branchOf(s.cwd),
+      gitBranch: branchOfCached(s.cwd),
       key: keyFor(s.slug, s.sessionId),
       // listSessions 已扫过 pid 文件，复用其结果，不为每行再扫一次（null = 已知不在线）
       managed: statusOf(
@@ -1324,7 +1367,7 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
         sizeBytes: 0,
         status: t.status,
         backend: 'codex' as const,
-        gitBranch: branchOf(t.cwd),
+        gitBranch: branchOfCached(t.cwd),
         key: t.key,
         managed: codexStatusOf(t.key),
       }))
@@ -1658,9 +1701,7 @@ function createServer(): ReturnType<typeof Bun.serve<WSData>> {
         processManager.get(ws.data.key)?.attachClient()
         codexRuntime.get(ws.data.key)?.attachClient()
         ws.send(JSON.stringify({ kind: 'status', state: statusOf(ws.data.key, undefined, true) }))
-        for (const a of hub.pendingApprovals.values()) {
-          ws.send(JSON.stringify({ kind: 'approval_request', ...a }))
-        }
+        replayApprovals(hub, (p) => ws.send(JSON.stringify(p)))
       },
       message(ws, raw) {
         if (ws.data.inbox) return // inbox 频道只发不收

--- a/server/src/portTakeover.ts
+++ b/server/src/portTakeover.ts
@@ -47,7 +47,7 @@ export function isOwnViteProcess(desc: PidDesc, webDir: string = WEB_DIR): boole
   return /\bvite\b/.test(normCmd(desc.cmdline)) && sameDir(desc.cwd, webDir)
 }
 
-/** 从 `ss -tlnp` 文本里抽出监听指定 TCP 端口的 pid（:8080 不误伤 :80）。语义同 scripts/gateway-lib.ts */
+/** 从 `ss -tlnp` 文本里抽出监听指定 TCP 端口的 pid（:8080 不误伤 :80）。scripts/gateway-lib 也复用本函数 */
 export function parseSsListenPids(ssOut: string, port: number): number[] {
   const pids = new Set<number>()
   const portRe = new RegExp(`(?:[:\\]])${port}(?:\\s|$)`)

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -32,6 +32,26 @@ export function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e)
 }
 
+/** HTML 文本转义（审批确认页、网关错误页等内联手写 HTML 共用；含单引号，可安全用于属性值） */
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] ?? c)
+}
+
+/** Host 头去端口（trim + 小写归一，兼容 [::1]:7480 形态）。
+ *  仅单冒号且冒号后是数字才截端口：多冒号是无方括号 IPv6 字面量（RFC 7230 允许裸写），
+ *  '::1' 误截成 ':' 会让真回环客户端被误判。缺少闭合方括号的按无效处理（原样返回），
+ *  避免截断后误配回环/域名。服务端跨源防护与网关分流共用本函数。 */
+export function hostNameOf(hostHeader: string): string {
+  const raw = hostHeader.trim().toLowerCase()
+  if (raw.startsWith('[')) {
+    const close = raw.indexOf(']')
+    if (close === -1) return raw
+    return raw.slice(1, close)
+  }
+  const i = raw.lastIndexOf(':')
+  return i > 0 && raw.indexOf(':') === i && /^\d+$/.test(raw.slice(i + 1)) ? raw.slice(0, i) : raw
+}
+
 /**
  * 传给 CLI 子进程（claude/codex app-server）的环境：process.env 叠加 extra，
  * 并剥离 anyplane 自身的服务端凭据 ANYPLANE_TOKEN——它是 /api 与 /ws 的唯一防线，

--- a/web/src/components/ContextRing.tsx
+++ b/web/src/components/ContextRing.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react'
 import type { SessionState } from '../lib/ws'
-import { fmtTokens } from '../lib/blocks'
+import { fmtTokens, usageSummary } from '../lib/blocks'
 import { PopupPanel } from './PopupPanel'
 
 type ContextUsage = NonNullable<SessionState['context']>
@@ -46,6 +46,7 @@ export function ContextRing(props: {
     ...(context.reasoningTokens != null ? [{ name: 'reasoning', tokens: context.reasoningTokens }] : []),
   ]
   const u = props.usage
+  const usageLine = usageSummary(u, '会话累计 ')
 
   return (
     <>
@@ -105,13 +106,7 @@ export function ContextRing(props: {
           ))}
           <div className="mt-2 border-t border-ink/5 pt-1.5 font-mono text-[10px] leading-relaxed text-faint">
             {props.modelLabel && <div>模型 {props.modelLabel}</div>}
-            {u && u.inputTokens + u.outputTokens > 0 && (
-              <div>
-                会话累计 ↑{fmtTokens(u.inputTokens)} ↓{fmtTokens(u.outputTokens)}
-                {u.cacheReadTokens ? ` · cache ${fmtTokens(u.cacheReadTokens)}` : ''}
-                {u.reasoningTokens ? ` · rs ${fmtTokens(u.reasoningTokens)}` : ''}
-              </div>
-            )}
+            {usageLine && <div>{usageLine}</div>}
           </div>
           {props.onOpenFullDetail && (
             <button

--- a/web/src/components/ImageAttachment.tsx
+++ b/web/src/components/ImageAttachment.tsx
@@ -1,0 +1,13 @@
+import { memo } from 'react'
+
+/** 图片附件：抄本行 / 侧问卡片 / user 气泡 / assistant 块展示共用 */
+export const ImageAttachment = memo(function ImageAttachment(props: { src?: string }) {
+  return (
+    <img
+      src={props.src}
+      alt="图片附件"
+      loading="lazy"
+      className="my-1.5 max-h-64 max-w-full rounded-[10px] object-contain"
+    />
+  )
+})

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -1,11 +1,13 @@
+import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
-/** AI/用户文本的 Markdown 渲染（GFM：表格、删除线、任务列表） */
-export function Markdown(props: { text: string }) {
+/** AI/用户文本的 Markdown 渲染（GFM：表格、删除线、任务列表）。
+ *  memo：text 不变时跳过 ReactMarkdown 重解析（渲染链里最重的单项）。 */
+export const Markdown = memo(function Markdown(props: { text: string }) {
   return (
     <div className="prose-cc">
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{props.text}</ReactMarkdown>
     </div>
   )
-}
+})

--- a/web/src/components/MessageView.tsx
+++ b/web/src/components/MessageView.tsx
@@ -1,9 +1,11 @@
+import { memo } from 'react'
+import { ImageAttachment } from './ImageAttachment'
 import { Markdown } from './Markdown'
 import { ActivityGroup } from './ActivityGroup'
 import {
+  fmtTokens,
   groupCollapsibleRuns,
   parseUserText,
-  shortTokens,
   type Block,
   type ChatMsg,
 } from '../lib/blocks'
@@ -52,18 +54,6 @@ function UserText(props: { text: string }) {
   )
 }
 
-/** 图片附件：侧问卡片 / user 气泡 / assistant 块三处展示共用 */
-function ImageAttachment(props: { src?: string }) {
-  return (
-    <img
-      src={props.src}
-      alt="图片附件"
-      loading="lazy"
-      className="my-1.5 max-h-64 max-w-full rounded-[10px] object-contain"
-    />
-  )
-}
-
 function contentKey(b: Block, i: number): string {
   return b.kind === 'tool' ? b.id : `${b.kind}:${i}`
 }
@@ -95,8 +85,9 @@ function BlockRuns(props: { blocks: Block[]; thinkingStreaming?: boolean; flush?
   )
 }
 
-/** 消息条目：user 右靠气泡 / assistant 按块分行；compact 表示与上一条同角色（连续块，收紧间距） */
-export function MessageView(props: { msg: ChatMsg; compact?: boolean }) {
+/** 消息条目：user 右靠气泡 / assistant 按块分行；compact 表示与上一条同角色（连续块，收紧间距）。
+ *  memo：msg 引用在所有落地路径上都不可变更新，输入击键/status 广播时跳过整条消息的 reconcile。 */
+export const MessageView = memo(function MessageView(props: { msg: ChatMsg; compact?: boolean }) {
   const { msg, compact } = props
 
   // 侧问卡片：独立样式，正文 Markdown，思考折叠
@@ -125,7 +116,7 @@ export function MessageView(props: { msg: ChatMsg; compact?: boolean }) {
           <div className="h-px flex-1 bg-line" />
           <span className="font-mono text-[10px] tracking-widest uppercase">
             {msg.compactMeta
-              ? `上下文已压缩 ${shortTokens(msg.compactMeta.preTokens)}→${shortTokens(msg.compactMeta.postTokens)}`
+              ? `上下文已压缩 ${fmtTokens(msg.compactMeta.preTokens)}→${fmtTokens(msg.compactMeta.postTokens)}`
               : msg.blocks[0]?.kind === 'text'
                 ? msg.blocks[0].text
                 : ''}
@@ -178,4 +169,4 @@ export function MessageView(props: { msg: ChatMsg; compact?: boolean }) {
       <BlockRuns blocks={msg.blocks} />
     </div>
   )
-}
+})

--- a/web/src/components/StatusPill.tsx
+++ b/web/src/components/StatusPill.tsx
@@ -106,13 +106,12 @@ export function StatusPill(props: {
       return
     }
     syncPanelPos()
-    const onReposition = () => syncPanelPos()
-    window.addEventListener('resize', onReposition)
+    window.addEventListener('resize', syncPanelPos)
     // 捕获阶段：任意滚动都会让 fixed 锚点漂移，重算位置
-    window.addEventListener('scroll', onReposition, true)
+    window.addEventListener('scroll', syncPanelPos, true)
     return () => {
-      window.removeEventListener('resize', onReposition)
-      window.removeEventListener('scroll', onReposition, true)
+      window.removeEventListener('resize', syncPanelPos)
+      window.removeEventListener('scroll', syncPanelPos, true)
     }
   }, [open])
 

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -14,7 +14,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Transcript } from './Transcript'
-import { shortTokens, type ChatMsg } from '../lib/blocks'
+import { fmtTokens, type ChatMsg } from '../lib/blocks'
 
 export interface TaskFeed {
   /** 主抄本中发起该任务的 tool_use 的 id（与主线工具卡同源） */
@@ -83,7 +83,7 @@ function TaskCard(props: { feed: TaskFeed; depth: number; onStop?: (taskId: stri
   const type = typeLabel(feed.agentType)
   const stats = [
     feed.usage?.tool_uses != null ? `${feed.usage.tool_uses} 次工具` : undefined,
-    feed.usage?.total_tokens != null ? `${shortTokens(feed.usage.total_tokens)} tok` : undefined,
+    feed.usage?.total_tokens != null ? `${fmtTokens(feed.usage.total_tokens)} tok` : undefined,
     fmtDuration(feed.usage?.duration_ms),
   ].filter(Boolean)
 

--- a/web/src/components/Transcript.tsx
+++ b/web/src/components/Transcript.tsx
@@ -1,25 +1,20 @@
+import { memo, useMemo } from 'react'
 import { buildTranscriptRows, type ChatMsg, type DraftBlockLike } from '../lib/blocks'
 import { ActivityGroup } from './ActivityGroup'
+import { ImageAttachment } from './ImageAttachment'
 import { Markdown } from './Markdown'
 import { MessageView } from './MessageView'
 
-function ImageAttachment(props: { src?: string }) {
-  return (
-    <img
-      src={props.src}
-      alt="图片附件"
-      loading="lazy"
-      className="my-1.5 max-h-64 max-w-full rounded-[10px] object-contain"
-    />
-  )
-}
-
-/** 对话抄本：跨消息合并相邻思考/工具，流式草稿并进同一组。 */
-export function Transcript(props: {
+/** 对话抄本：跨消息合并相邻思考/工具，流式草稿并进同一组。
+ *  memo + useMemo：messages/draft 引用不变（输入击键、status 广播）时整棵树跳过重建。 */
+export const Transcript = memo(function Transcript(props: {
   messages: ChatMsg[]
   draft?: { blocks: readonly DraftBlockLike[] } | null
 }) {
-  const rows = buildTranscriptRows(props.messages, props.draft)
+  const rows = useMemo(
+    () => buildTranscriptRows(props.messages, props.draft),
+    [props.messages, props.draft],
+  )
   const showCursor =
     Boolean(props.draft?.blocks.length) && props.draft!.blocks.every((b) => b.kind !== 'text')
 
@@ -67,4 +62,4 @@ export function Transcript(props: {
       )}
     </>
   )
-}
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,7 +5,8 @@ import { authHeaders, notifyAuthRequired } from './auth'
 /** 401 时抛出；App 层会显示令牌输入页，调用方静默忽略即可 */
 export class AuthRequiredError extends Error {}
 
-async function apiFetch(input: string, init?: RequestInit): Promise<Response> {
+/** 带认证头的 fetch：自动拼 authHeaders()，401 时通知 App 层弹令牌页并抛 AuthRequiredError */
+export async function apiFetch(input: string, init?: RequestInit): Promise<Response> {
   const r = await fetch(input, {
     ...init,
     headers: { ...authHeaders(), ...(init?.headers ?? {}) },
@@ -18,13 +19,13 @@ async function apiFetch(input: string, init?: RequestInit): Promise<Response> {
 }
 
 /** 非 2xx 应答 → Error：优先服务端的 {error} 字段（空串视同缺失），兜底 HTTP 状态码 */
-async function apiError(r: Response): Promise<Error> {
+export async function apiError(r: Response): Promise<Error> {
   const body = (await r.json().catch(() => null)) as { error?: string } | null
   return new Error(body?.error || `HTTP ${r.status}`)
 }
 
 /** POST JSON 小封装：统一 method/headers/序列化（错误检查由调用方按需补） */
-async function postJson(path: string, body: unknown): Promise<Response> {
+export async function postJson(path: string, body: unknown): Promise<Response> {
   return apiFetch(path, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },

--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from 'bun:test'
 import {
   buildTranscriptRows,
   draftBlockToBlock,
+  fmtTokens,
   groupCollapsibleRuns,
   parseUserText,
   rewindPreview,
-  shortTokens,
   stripAnsi,
   toolDetail,
   toolResultText,
@@ -113,7 +113,7 @@ describe('toolDetail（折叠区的完整内容）', () => {
   })
 })
 
-describe('toolResultText / stripAnsi / shortTokens', () => {
+describe('toolResultText / stripAnsi / fmtTokens', () => {
   test('tool_result content 的 string 与块数组两种形态', () => {
     expect(toolResultText('纯文本')).toBe('纯文本')
     expect(toolResultText([{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }])).toBe('ab')
@@ -127,11 +127,12 @@ describe('toolResultText / stripAnsi / shortTokens', () => {
     expect(stripAnsi('没有颜色')).toBe('没有颜色')
   })
 
-  test('shortTokens 千位缩写', () => {
-    expect(shortTokens(undefined)).toBe('?')
-    expect(shortTokens(999)).toBe('999')
-    expect(shortTokens(1000)).toBe('1k')
-    expect(shortTokens(231952)).toBe('232k')
+  test('fmtTokens 千位/百万位缩写', () => {
+    expect(fmtTokens(undefined)).toBe('?')
+    expect(fmtTokens(999)).toBe('999')
+    expect(fmtTokens(1000)).toBe('1.0k')
+    expect(fmtTokens(231952)).toBe('232.0k')
+    expect(fmtTokens(2_500_000)).toBe('2.5M')
   })
 })
 

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -348,17 +348,26 @@ export function rewindPreview(raw: string, maxSummaryLength = 160): RewindPrevie
   }
 }
 
-/** token 数简写：231952 → 232k */
-export function shortTokens(n?: number): string {
-  if (n == null) return '?'
-  if (n >= 1000) return `${Math.round(n / 1000)}k`
-  return String(n)
-}
-
-/** token 数格式化（一位小数的 k/M 简写）：上下文环形与输入行用量共用，
+/** token 数格式化（一位小数的 k/M 简写）：上下文环形、输入行用量、任务面板、compact 分隔线共用，
  *  全 UI 同口径（此前 Chat 与 ContextRing 各有一份私有实现，精度/单位已漂移） */
-export function fmtTokens(n: number): string {
+export function fmtTokens(n?: number): string {
+  if (n == null) return '?'
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
   return String(n)
+}
+
+/** 会话累计用量摘要行（`↑in ↓out · cache · rs`）：Chat 输入行与 ContextRing 详情面板共用 */
+export function usageSummary(
+  u:
+    | { inputTokens: number; outputTokens: number; cacheReadTokens?: number; reasoningTokens?: number }
+    | undefined,
+  prefix = '',
+): string | undefined {
+  if (!u || u.inputTokens + u.outputTokens <= 0) return undefined
+  return (
+    `${prefix}↑${fmtTokens(u.inputTokens)} ↓${fmtTokens(u.outputTokens)}` +
+    (u.cacheReadTokens ? ` · cache ${fmtTokens(u.cacheReadTokens)}` : '') +
+    (u.reasoningTokens ? ` · rs ${fmtTokens(u.reasoningTokens)}` : '')
+  )
 }

--- a/web/src/lib/push.ts
+++ b/web/src/lib/push.ts
@@ -1,7 +1,7 @@
 // Web Push 订阅管理：订阅/退订/状态查询
 // 密钥流：服务端 VAPID 公钥 → pushManager.subscribe → 订阅对象 POST 回服务端注册表
 
-import { authHeaders } from './auth'
+import { apiError, apiFetch, postJson } from './api'
 
 /** 当前浏览器是否支持推送（Service Worker + Push API + 通知） */
 export function pushSupported(): boolean {
@@ -35,8 +35,8 @@ export async function subscribePush(): Promise<{ ok: boolean; error?: string }> 
   try {
     const perm = await Notification.requestPermission()
     if (perm !== 'granted') return { ok: false, error: '通知权限被拒绝' }
-    const pkResp = await fetch('/api/push/public-key', { headers: authHeaders() })
-    if (!pkResp.ok) return { ok: false, error: `获取推送公钥失败（HTTP ${pkResp.status}）` }
+    const pkResp = await apiFetch('/api/push/public-key')
+    if (!pkResp.ok) return { ok: false, error: `获取推送公钥失败（${(await apiError(pkResp)).message}）` }
     const { publicKey } = (await pkResp.json()) as { publicKey: string }
     const reg = await navigator.serviceWorker.ready
     const sub = await reg.pushManager.subscribe({
@@ -44,12 +44,8 @@ export async function subscribePush(): Promise<{ ok: boolean; error?: string }> 
       applicationServerKey: urlBase64ToUint8Array(publicKey) as BufferSource,
     })
     const json = sub.toJSON() as { endpoint?: string; keys?: { p256dh: string; auth: string } }
-    const r = await fetch('/api/push/subscriptions', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', ...authHeaders() },
-      body: JSON.stringify({ endpoint: json.endpoint, keys: json.keys }),
-    })
-    if (!r.ok) return { ok: false, error: `注册订阅失败（HTTP ${r.status}）` }
+    const r = await postJson('/api/push/subscriptions', { endpoint: json.endpoint, keys: json.keys })
+    if (!r.ok) return { ok: false, error: `注册订阅失败（${(await apiError(r)).message}）` }
     return { ok: true }
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) }
@@ -65,9 +61,9 @@ export async function unsubscribePush(): Promise<void> {
     if (!sub) return
     const endpoint = sub.endpoint
     await sub.unsubscribe().catch(() => {})
-    await fetch('/api/push/subscriptions', {
+    await apiFetch('/api/push/subscriptions', {
       method: 'DELETE',
-      headers: { 'content-type': 'application/json', ...authHeaders() },
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ endpoint }),
     }).catch(() => {})
   } catch {}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -11,7 +11,7 @@ import { ClaudeStar } from '../components/ClaudeStar'
 import { CodexMark } from '../components/CodexMark'
 import { PopupPanel } from '../components/PopupPanel'
 import { ContextRing } from '../components/ContextRing'
-import { fmtTokens, nextId, rewindPreview, toolResultText, type Block, type ChatMsg } from '../lib/blocks'
+import { fmtTokens, nextId, rewindPreview, toolResultText, usageSummary, type Block, type ChatMsg } from '../lib/blocks'
 import { isCodexKey, isExistingKey } from '../lib/key'
 import { COMMAND_DESC, filterSlashHints, mergeSlashCommands, type SlashEntry } from '../lib/slashCommands'
 
@@ -95,11 +95,31 @@ const PHASE_LABEL: Record<string, string> = {
   compacting: '压缩上下文',
 }
 
+/** 输入行上方的会话状态文案：早退链，优先级即源码顺序。
+ *  spawned 为真时不再看 exited/tailing（保持原嵌套三元的求值顺序）。 */
+function statusLineOf(
+  state: SessionState,
+  opts: { connected: boolean; phase?: string; waiting: boolean },
+): string {
+  if (!opts.connected) return '连接中…'
+  if (opts.phase) return `${PHASE_LABEL[opts.phase] ?? opts.phase}…`
+  if (opts.waiting) return state.tailing ? '外部会话等待操作' : '等待审批'
+  const activeTaskCount = state.activeTaskCount ?? 0
+  if (activeTaskCount > 0) return `${activeTaskCount} 个后台任务运行中`
+  if (state.busy) return state.tailing ? '外部会话工作中' : '工作中'
+  if (state.spawned) return state.sessionState === 'idle' ? 'CLI 空闲' : 'CLI 运行中'
+  if (state.exited) return '进程已退出'
+  if (state.tailing) return '外部会话 · 实时跟踪中'
+  const hasPendingStartConfig = Boolean(state.model || state.permissionMode || state.effort)
+  return hasPendingStartConfig ? '配置已保存（发送消息时启动 CLI）' : '浏览中（发送消息时启动 CLI）'
+}
+
 /**
  * 历史加载与 tail 实时追加共用的消息归并：
  * tool_use ↔ tool_result 跨消息配对成卡，孤立结果降级为系统提示。
- * toolIdx：批量加载时由调用方持有的 toolUseId → 位置索引（O(1) 配对，免 O(n²) 回扫）；
- * 缺省（tail 单条追加）时线性回扫，并做不可变更新（out 与旧 state 共享 blocks 数组）。
+ * toolIdx：toolUseId → 位置索引（O(1) 配对，免 O(n²) 回扫）。tail 单条追加时
+ * 传入贯穿会话的实时索引；批量加载时由调用方持有局部索引。
+ * 配对永远做不可变更新——tail 路径的 out 与旧 state 共享消息/块对象。
  */
 function appendHistoryMsg(out: ChatMsg[], h: HistoryMessage, toolIdx?: Map<string, { mi: number; bi: number }>): void {
   if (h.isMeta) return
@@ -111,9 +131,12 @@ function appendHistoryMsg(out: ChatMsg[], h: HistoryMessage, toolIdx?: Map<strin
     if (!toolUseId) return false
     if (toolIdx) {
       const at = toolIdx.get(toolUseId)
-      const b = at ? out[at.mi]?.blocks[at.bi] : undefined
-      if (!at || !b || b.kind !== 'tool') return false
-      out[at.mi].blocks[at.bi] = { ...b, resultText: text, resultError: isError, pending: false }
+      const m = at ? out[at.mi] : undefined
+      const b = at ? m?.blocks[at.bi] : undefined
+      if (!at || !m || !b || b.kind !== 'tool' || b.id !== toolUseId) return false
+      const blocks = [...m.blocks]
+      blocks[at.bi] = { ...b, resultText: text, resultError: isError, pending: false }
+      out[at.mi] = { ...m, blocks }
       return true
     }
     for (let mi = out.length - 1; mi >= 0; mi--) {
@@ -250,6 +273,8 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const messagesRef = useRef<ChatMsg[]>([])
   const draftRef = useRef<Draft | null>(null)
   const pendingResultsRef = useRef(new Map<string, { text: string; isError: boolean }>())
+  /** toolUseId → 落地位置索引：tool_result 配对的 O(1) 快路径（失效时回退线性扫描） */
+  const toolPosRef = useRef(new Map<string, { mi: number; bi: number }>())
   /** 历史加载时服务端读到的 transcript 字节数，tail_subscribe 的起始偏移 */
   const historyOffsetRef = useRef<number | undefined>(undefined)
 
@@ -303,6 +328,16 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     maybeFetchCodexTranscript(b)
   }
 
+  /** 主线 tool_result 给运行中桶补终态：task_notification 未到的兜底，
+   *  也是外部会话（tailer 路径，无 task_notification）唯一的终态信号。 */
+  const settleBucketFromResult = (toolUseId: string | undefined, text: string, isError: boolean) => {
+    const b = toolUseId ? taskMapRef.current.get(toolUseId) : undefined
+    if (!b || b.status !== 'running') return
+    markTerminal(b, isError ? 'error' : 'done')
+    if (!b.summary && text) b.summary = text.slice(0, 500)
+    pubTasks()
+  }
+
   /** codex 子代理转录懒取：子线程不被父通知流转发，终态后经 thread/read 拉回填充 */
   const maybeFetchCodexTranscript = (b: TaskBucket) => {
     if (!isCodex || !b.agentId || b.transcriptFetched || b.messages.length > 0) return
@@ -319,7 +354,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
    * 用 SessionState.activeTasks（服务端权威运行任务表）水合桶：
    * 中途接入的客户端错过 live-only 的 task_started，没有这一步桶的首绘就会是终态。
    * 反方向：桶还 running 却不在任务表且会话空闲 → 通知在断线间隙丢了，判终态。
-   * 判死只对 claude 生效——codex 服务端不维护任务表（backgroundTasks 恒空），空表无信息。
+   * codex 服务端不维护任务表（状态里不带 activeTasks 字段），首行守卫直接跳过。
    */
   const hydrateTasks = (st: SessionState) => {
     if (!Array.isArray(st.activeTasks)) return
@@ -348,7 +383,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       b.parentToolUseId = t.parentToolUseId ?? b.parentToolUseId
       dirty = true
     }
-    if (!st.busy && !isCodex) {
+    if (!st.busy) {
       for (const b of taskMapRef.current.values()) {
         if (b.status === 'running' && !live.has(b.toolUseId)) {
           markTerminal(b, 'done')
@@ -367,7 +402,13 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     draftRef.current = d
     setDraft(d)
   }
-  const pushMsg = (m: ChatMsg) => setMsgs((prev) => [...prev, m])
+  const pushMsg = (m: ChatMsg) => {
+    const mi = messagesRef.current.length
+    m.blocks.forEach((b, bi) => {
+      if (b.kind === 'tool') toolPosRef.current.set(b.id, { mi, bi })
+    })
+    setMsgs((prev) => [...prev, m])
+  }
   const pushSystem = (text: string, kind: 'info' | 'error' = 'info') =>
     pushMsg({ id: nextId(), role: 'system', systemKind: kind, blocks: [{ kind: 'text', text }] })
 
@@ -443,6 +484,8 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     const toolIdx = new Map<string, { mi: number; bi: number }>()
     for (const h of resp.messages) appendHistoryMsg(out, h, toolIdx)
     setMsgs(() => out)
+    // 实时配对索引直接沿用历史加载建好的位置表（out 已成为新 state）
+    toolPosRef.current = toolIdx
 
     // 子代理侧链进桶；终态/报告以主线 Agent 工具卡的配对结果为准（tool_result 已落盘 = 已完成）
     taskMapRef.current.clear()
@@ -478,6 +521,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     setMsgs(() => [])
     setDraftBoth(null)
     pendingResultsRef.current.clear()
+    toolPosRef.current.clear()
     historyOffsetRef.current = undefined
     // Chat 组件在 session 切换时会复用，清掉上一会话的运行时/待启动配置。
     // 新会话的缓存选择会由随后到达的 status 恢复。
@@ -563,17 +607,29 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const pairToolResult = (toolUseId: string | undefined, text: string, isError: boolean) => {
     if (!toolUseId) return
     let found = false
-    setMsgs((prev) =>
-      prev.map((m) => {
-        const bi = m.blocks.findIndex((b) => b.kind === 'tool' && b.id === toolUseId)
+    const patchAt = (m: ChatMsg, bi: number): ChatMsg => {
+      const blocks = [...m.blocks]
+      const b = blocks[bi]
+      if (b.kind === 'tool') blocks[bi] = { ...b, resultText: text, resultError: isError, pending: false }
+      return { ...m, blocks }
+    }
+    setMsgs((prev) => {
+      // O(1) 快路径：索引命中且校验通过（rewind 截断等会使索引失效，回退全量扫描）
+      const at = toolPosRef.current.get(toolUseId)
+      const fast = at ? prev[at.mi]?.blocks[at.bi] : undefined
+      if (at && fast?.kind === 'tool' && fast.id === toolUseId) {
+        found = true
+        const out = [...prev]
+        out[at.mi] = patchAt(out[at.mi], at.bi)
+        return out
+      }
+      return prev.map((m) => {
+        const bi = m.blocks.findIndex((x) => x.kind === 'tool' && x.id === toolUseId)
         if (bi < 0) return m
         found = true
-        const blocks = [...m.blocks]
-        const b = blocks[bi]
-        if (b.kind === 'tool') blocks[bi] = { ...b, resultText: text, resultError: isError, pending: false }
-        return { ...m, blocks }
-      }),
-    )
+        return patchAt(m, bi)
+      })
+    })
     if (!found) pendingResultsRef.current.set(toolUseId, { text, isError })
   }
 
@@ -696,17 +752,10 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       const textBlocks: Block[] = []
       for (const c of blocks) {
         if (c?.type === 'tool_result') {
-          pairToolResult(c.tool_use_id, toolResultText(c.content), c.is_error === true)
+          const resultText = toolResultText(c.content)
+          pairToolResult(c.tool_use_id, resultText, c.is_error === true)
           // 主线 Agent tool_result 是子代理的终态兜底（正常路径是 task_notification 先到）
-          const b = c.tool_use_id ? taskMapRef.current.get(c.tool_use_id) : undefined
-          if (b && b.status === 'running') {
-            markTerminal(b, c.is_error === true ? 'error' : 'done')
-            if (!b.summary) {
-              const t = toolResultText(c.content)
-              if (t) b.summary = t.slice(0, 500)
-            }
-            pubTasks()
-          }
+          settleBucketFromResult(c.tool_use_id, resultText, c.is_error === true)
         } else if (c?.type === 'text' && c.text?.trim()) {
           // /goal 的评估器反馈（Stop hook）：goal 循环内的中途评估，渲染为系统提示而非用户气泡
           if (c.text.startsWith('Stop hook feedback:')) {
@@ -743,9 +792,9 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
           const toolUseId = rec.tool_use_id as string | undefined
           if (toolUseId) {
             const b = taskBucket(toolUseId)
-            b.agentId = (rec.task_id as string | undefined) ?? b.agentId
-            // codex 合成事件经 agent_thread_id 携带子线程 id（终态后懒拉转录用）
-            b.agentId = (rec.agent_thread_id as string | undefined) ?? b.agentId
+            // claude 用 task_id；codex 合成事件经 agent_thread_id 携带子线程 id（终态后懒拉转录用），后者优先
+            b.agentId =
+              (rec.agent_thread_id as string | undefined) ?? (rec.task_id as string | undefined) ?? b.agentId
             b.description = (rec.description as string | undefined) ?? b.description
             b.agentType = (rec.subagent_type as string | undefined) ?? (rec.task_type as string | undefined) ?? b.agentType
             b.kind = (rec.task_type as string | undefined) ?? b.kind
@@ -892,7 +941,18 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             )
             break
           }
-          case 'btw_result':
+          case 'btw_result': {
+            // 找不到 pending 卡（如校验失败路径或漏收 btw_pending）时自行建卡落地结果——
+            // 配对不变量由数据保证，不依赖服务端的消息时序
+            if (!messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
+              const blocks: Block[] = ev.ok
+                ? ev.text.trim()
+                  ? [{ kind: 'text', text: ev.text }]
+                  : []
+                : [{ kind: 'text', text: `⚠ ${ev.text}` }]
+              pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: false, blocks })
+              break
+            }
             setMsgs((prev) =>
               prev.map((m) => {
                 if (m.btw !== ev.question || !m.btwPending) return m
@@ -908,6 +968,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               }),
             )
             break
+          }
           case 'forked': {
             if (ev.branchOf) {
               // claude 懒分叉：b| key 导航，首条消息才真正 --fork-session；
@@ -1025,19 +1086,14 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             if (h.uuid && messagesRef.current.some((m) => m.id === h.uuid)) break
             setMsgs((prev) => {
               const out = [...prev]
-              appendHistoryMsg(out, h)
+              appendHistoryMsg(out, h, toolPosRef.current)
               return out
             })
             // 尾到的主线 tool_result 给已存在桶补终态——外部会话（tailer 路径）没有
             // task_notification，这是它唯一的终态信号；与历史回填同规则：终态挂 30s 驱逐
             for (const blk of h.blocks) {
               if (blk.kind !== 'tool_result' || !blk.id) continue
-              const b = taskMapRef.current.get(blk.id)
-              if (b && b.status === 'running') {
-                markTerminal(b, blk.isError ? 'error' : 'done')
-                if (!b.summary && blk.text) b.summary = blk.text.slice(0, 500)
-                pubTasks()
-              }
+              settleBucketFromResult(blk.id, blk.text ?? '', blk.isError === true)
             }
             break
           }
@@ -1200,106 +1256,122 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
 
   const send = () => {
     const text = input.trim()
-    if ((!text && pendingImages.length === 0) || !sockRef.current) return
-    // /rewind 及其官方别名 /checkpoint /undo
-    if (text === '/rewind' || text === '/checkpoint' || text === '/undo') {
-      setShowRewind(true)
-      setInput('')
-      return
-    }
-    if (/^\/btw(\s|$)/.test(text)) {
-      const q = text.slice(4).trim()
-      if (q) sockRef.current.send({ kind: 'btw', question: q })
-      else pushSystem('用法：/btw <问题>')
-      setInput('')
-      return
-    }
-    // 内建 /branch（有参时）会在 headless 下写孤立 fork 会话文件却不切换（context.resume 缺席），
-    // 必须全形拦截（含参数）；名字透传给分叉 spawn 的 -n
-    const branchMatch = text.match(/^\/(branch|fork)(?:\s+(.*))?$/)
-    if (branchMatch) {
-      if (isCodex) pushSystem('Codex 请用「回滚」面板的从此处分叉')
-      else sockRef.current.send({ kind: 'branch', ...(branchMatch[2]?.trim() ? { name: branchMatch[2].trim() } : {}) })
-      setInput('')
-      return
-    }
-    // /exit /quit headless 下会真的杀掉 CLI 进程——web 场景下多半是误触，拦下给替代指引
-    if (text === '/exit' || text === '/quit') {
-      pushSystem('此命令会终止 CLI 进程。要结束会话请回列表页归档（⌄ 按钮），进程回收由服务端空闲策略处理')
-      setInput('')
-      return
-    }
-    // codex 的斜杠命令不会被 app-server 解释（原样进模型上下文），有对应物的必须前端拦截
-    if (isCodex && text === '/compact') {
-      sockRef.current.send({ kind: 'control', subtype: 'compact' })
-      setInput('')
-      return
-    }
-    if (isCodex && text === '/context') {
-      // codex 无 get_context_usage 对应物；用状态里的累计 token 用量顶一句
-      const u = state.usage
-      pushSystem(
-        u
-          ? `◈ 线程累计：in ${u.inputTokens} / out ${u.outputTokens}${u.reasoningTokens ? ` / reasoning ${u.reasoningTokens}` : ''}（窗口占用明细请开「详情」）`
-          : '◈ 暂无用量数据（先跑一轮）',
-      )
-      setInput('')
-      return
-    }
-    if (isCodex && /^\/goal(\s|$)/.test(text)) {
-      const arg = text.slice(5).trim()
-      if (!arg) pushSystem(state.goal ? `◎ 当前目标：${state.goal.condition}` : '用法：/goal <条件>，/goal clear 清除')
-      else if (/^(clear|stop|off|reset|none|cancel)$/i.test(arg)) sendGoal()
-      else sendGoal(arg)
-      setInput('')
-      return
-    }
-    if (isCodex && /^\/review(\s|$)/.test(text)) {
-      // codex review/start：无参审未提交改动，带参按自定义说明审（inline 在本线程跑）
-      const instructions = text.slice(7).trim()
-      sockRef.current.send({ kind: 'control', subtype: 'review', ...(instructions ? { extra: { instructions } } : {}) })
-      pushSystem(instructions ? `◈ 审查中：${instructions}` : '◈ 审查未提交的改动中…')
-      setInput('')
-      return
-    }
-    if (isCodex && /^\/rename(\s|$)/.test(text)) {
-      const name = text.slice(7).trim()
-      if (!name) {
-        pushSystem('用法：/rename <新名字>')
+    const sock = sockRef.current
+    if ((!text && pendingImages.length === 0) || !sock) return
+
+    // 斜杠命令拦截表：顺序即优先级，命中即拦截并清空输入框。
+    // codex 的斜杠命令不会被 app-server 解释（原样进模型上下文），有对应物的必须前端拦截。
+    const interceptors: Array<{ match: (t: string) => boolean; run: (t: string) => void }> = [
+      {
+        // /rewind 及其官方别名 /checkpoint /undo
+        match: (t) => t === '/rewind' || t === '/checkpoint' || t === '/undo',
+        run: () => setShowRewind(true),
+      },
+      {
+        match: (t) => /^\/btw(\s|$)/.test(t),
+        run: (t) => {
+          const q = t.slice(4).trim()
+          if (q) sock.send({ kind: 'btw', question: q })
+          else pushSystem('用法：/btw <问题>')
+        },
+      },
+      {
+        // 内建 /branch（有参时）会在 headless 下写孤立 fork 会话文件却不切换（context.resume 缺席），
+        // 必须全形拦截（含参数）；名字透传给分叉 spawn 的 -n
+        match: (t) => /^\/(branch|fork)(\s|$)/.test(t),
+        run: (t) => {
+          const name = t.match(/^\/(?:branch|fork)(?:\s+(.*))?$/)?.[1]?.trim()
+          if (isCodex) pushSystem('Codex 请用「回滚」面板的从此处分叉')
+          else sock.send({ kind: 'branch', ...(name ? { name } : {}) })
+        },
+      },
+      {
+        // /exit /quit headless 下会真的杀掉 CLI 进程——web 场景下多半是误触，拦下给替代指引
+        match: (t) => t === '/exit' || t === '/quit',
+        run: () =>
+          pushSystem('此命令会终止 CLI 进程。要结束会话请回列表页归档（⌄ 按钮），进程回收由服务端空闲策略处理'),
+      },
+      {
+        match: (t) => isCodex && t === '/compact',
+        run: () => sock.send({ kind: 'control', subtype: 'compact' }),
+      },
+      {
+        match: (t) => isCodex && t === '/context',
+        run: () => {
+          // codex 无 get_context_usage 对应物；用状态里的累计 token 用量顶一句
+          const u = state.usage
+          pushSystem(
+            u
+              ? `◈ 线程累计：in ${u.inputTokens} / out ${u.outputTokens}${u.reasoningTokens ? ` / reasoning ${u.reasoningTokens}` : ''}（窗口占用明细请开「详情」）`
+              : '◈ 暂无用量数据（先跑一轮）',
+          )
+        },
+      },
+      {
+        match: (t) => isCodex && /^\/goal(\s|$)/.test(t),
+        run: (t) => {
+          const arg = t.slice(5).trim()
+          if (!arg) pushSystem(state.goal ? `◎ 当前目标：${state.goal.condition}` : '用法：/goal <条件>，/goal clear 清除')
+          else if (/^(clear|stop|off|reset|none|cancel)$/i.test(arg)) sendGoal()
+          else sendGoal(arg)
+        },
+      },
+      {
+        // codex review/start：无参审未提交改动，带参按自定义说明审（inline 在本线程跑）
+        match: (t) => isCodex && /^\/review(\s|$)/.test(t),
+        run: (t) => {
+          const instructions = t.slice(7).trim()
+          sock.send({ kind: 'control', subtype: 'review', ...(instructions ? { extra: { instructions } } : {}) })
+          pushSystem(instructions ? `◈ 审查中：${instructions}` : '◈ 审查未提交的改动中…')
+        },
+      },
+      {
+        match: (t) => isCodex && /^\/rename(\s|$)/.test(t),
+        run: (t) => {
+          const name = t.slice(7).trim()
+          if (!name) {
+            pushSystem('用法：/rename <新名字>')
+            return
+          }
+          sock.send({ kind: 'control', subtype: 'rename', extra: { name } })
+          pushSystem(`✎ 重命名线程为「${name}」`)
+        },
+      },
+      {
+        // codex /new 与 /clear 同为 thread/start 新线程：导航到 xn| 新会话页（懒启动）
+        match: (t) => isCodex && (t === '/new' || t === '/clear'),
+        run: () => {
+          const cwd = session.cwd
+          if (cwd) {
+            void createSession(cwd, 'codex').then(({ key }) =>
+              props.onNavigate?.(
+                makeSessionInfo({ key, slug: 'codex', sessionId: 'new', cwd, backend: 'codex', status: 'offline' }),
+              ),
+            )
+          } else {
+            pushSystem('⚠ 未知当前目录，无法新建线程', 'error')
+          }
+        },
+      },
+    ]
+    for (const it of interceptors) {
+      if (it.match(text)) {
+        it.run(text)
         setInput('')
         return
       }
-      sockRef.current.send({ kind: 'control', subtype: 'rename', extra: { name } })
-      pushSystem(`✎ 重命名线程为「${name}」`)
-      setInput('')
-      return
     }
-    if (isCodex && (text === '/new' || text === '/clear')) {
-      // codex /new 与 /clear 同为 thread/start 新线程：导航到 xn| 新会话页（懒启动）
-      const cwd = session.cwd
-      if (cwd) {
-        void createSession(cwd, 'codex').then(({ key }) =>
-          props.onNavigate?.(
-            makeSessionInfo({ key, slug: 'codex', sessionId: 'new', cwd, backend: 'codex', status: 'offline' }),
-          ),
-        )
-      } else {
-        pushSystem('⚠ 未知当前目录，无法新建线程', 'error')
-      }
-      setInput('')
-      return
-    }
-    const attachments = pendingImages.map(({ name, mediaType, dataBase64 }) => ({ name, mediaType, dataBase64 }))
+
     const echoBlocks: Block[] = [
       ...pendingImages.map((img) => ({ kind: 'image' as const, src: imgPreviewSrc(img) })),
       ...(text ? [{ kind: 'text' as const, text }] : []),
     ]
     pushMsg({ id: nextId(), role: 'user', blocks: echoBlocks })
-    sockRef.current.send({
+    sock.send({
       kind: 'user',
       text,
       ...(busy ? { sendMode } : {}),
-      ...(attachments.length > 0 ? { attachments } : {}),
+      ...(pendingImages.length > 0 ? { attachments: pendingImages } : {}),
     })
     setInput('')
     setPendingImages([])
@@ -1346,41 +1418,8 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
 
   const busy = state.busy
   const waiting = state.waiting || approvals.length > 0
-  const activeTaskCount = state.activeTaskCount ?? 0
-  const u = state.usage
-  const usageLine =
-    u && u.inputTokens + u.outputTokens > 0
-      ? `tok ↑${fmtTokens(u.inputTokens)} ↓${fmtTokens(u.outputTokens)}` +
-        (u.cacheReadTokens ? ` · cache ${fmtTokens(u.cacheReadTokens)}` : '') +
-        (u.reasoningTokens ? ` · rs ${fmtTokens(u.reasoningTokens)}` : '')
-      : undefined
-  const hasPendingStartConfig =
-    !state.spawned && Boolean(state.model || state.permissionMode || state.effort)
-  const statusLine = !connected
-    ? '连接中…'
-    : phase
-      ? `${PHASE_LABEL[phase] ?? phase}…`
-      : waiting
-        ? state.tailing
-          ? '外部会话等待操作'
-          : '等待审批'
-        : activeTaskCount > 0
-          ? `${activeTaskCount} 个后台任务运行中`
-        : busy
-          ? state.tailing
-            ? '外部会话工作中'
-            : '工作中'
-          : state.spawned
-            ? state.sessionState === 'idle'
-              ? 'CLI 空闲'
-              : 'CLI 运行中'
-            : state.exited
-              ? '进程已退出'
-              : state.tailing
-                ? '外部会话 · 实时跟踪中'
-                : hasPendingStartConfig
-                  ? '配置已保存（发送消息时启动 CLI）'
-                  : '浏览中（发送消息时启动 CLI）'
+  const usageLine = usageSummary(state.usage, 'tok ')
+  const statusLine = statusLineOf(state, { connected, phase, waiting })
 
   return (
     <div className="flex h-full min-h-0 bg-bg text-ink">
@@ -2106,7 +2145,12 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
         open={tasksOpen}
         onClose={() => setTasksOpen(false)}
         tasks={tasks}
-        onStop={(taskId) => sockRef.current?.send({ kind: 'control', subtype: 'stop_task', extra: { task_id: taskId } })}
+        onStop={
+          // codex app-server 没有 stop_task 对应物（sendControl 落 default 报错卡），不显示停止按钮
+          isCodex
+            ? undefined
+            : (taskId) => sockRef.current?.send({ kind: 'control', subtype: 'stop_task', extra: { task_id: taskId } })
+        }
       />
     </div>
   )

--- a/web/src/pages/SessionList.tsx
+++ b/web/src/pages/SessionList.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
+  apiFetch,
   archiveSession,
   createSession,
   fetchArchived,
   fetchSessions,
   makeSessionInfo,
+  postJson,
   renameSession,
   restoreSession,
   type ArchivedEntry,
@@ -13,7 +15,6 @@ import {
 } from '../lib/api'
 import { InboxSocket, type InboxApproval } from '../lib/inbox'
 import { currentPushEndpoint, pushSupported, subscribePush, unsubscribePush } from '../lib/push'
-import { authHeaders } from '../lib/auth'
 import { BellIcon } from '../components/BellIcon'
 import { AnyPlaneMark } from '../components/AnyPlaneMark'
 import { getThemeChoice, setThemeChoice, toggleTheme, type ThemeChoice } from '../lib/theme'
@@ -248,7 +249,7 @@ export function SessionList(props: {
   // 挂载时读取推送订阅现状与 webhook 通道数
   useEffect(() => {
     void currentPushEndpoint().then(setPushEndpoint)
-    fetch('/api/push/public-key', { headers: authHeaders() })
+    apiFetch('/api/push/public-key')
       .then((r) => (r.ok ? r.json() : null))
       .then((j: { webhooks?: number } | null) => setPushWebhooks(j?.webhooks ?? 0))
       .catch(() => {})
@@ -281,11 +282,7 @@ export function SessionList(props: {
     if (pushTestBusy) return
     setPushTestBusy(true)
     try {
-      const r = await fetch('/api/push/test', {
-        method: 'POST',
-        headers: { ...authHeaders(), 'content-type': 'application/json' },
-        body: '{}',
-      })
+      const r = await postJson('/api/push/test', {})
       const j = (await r.json()) as { ok?: boolean; sent?: number; subscriptions?: number; webhooks?: number; error?: string }
       const total = (j.subscriptions ?? 0) + (j.webhooks ?? 0)
       if (r.ok && j.ok) {


### PR DESCRIPTION
## 本次任务

按 /simplify 流程对**整个 anyplane 仓库**（server/、web/、scripts/ 全部 TS/TSX 源码，非仅 diff 范围）做了复用、简化、效率、altitude 四角度并行审查，去重后应用了 20 余项修复。不找 correctness bug；刻意设计（protocol 宽松透传、双后端同形契约、Windows 兼容、/clear 三层重键、busy 语义双源等）保持原样。

全量 `bun test` 273 pass / 0 fail（与基线一致）；`tsc --noEmit` 仅剩 6 个预存错误（cli/anyplane.ts、scripts/gateway.ts，均不在本次改动行上）。

## 关键改动

### 效率
- **web 渲染链 memo 化**：Transcript/MessageView/Markdown 三层 memo + buildTranscriptRows useMemo；为此把 appendHistoryMsg 的 toolIdx 快路径改为不可变更新，保证 msg 引用稳定。输入击键/status 广播不再触发整棵消息树 reconcile 与 ReactMarkdown 重解析
- **tool_result 配对 O(1) 索引**：Chat.tsx 加 toolPosRef 位置索引（id 校验 + 全扫回退），rewind 截断后旧索引由校验兜底，最坏退化为原行为
- **pushStatus 300ms leading+trailing 节流**：并行后台任务的 task_progress 心跳不再逐次触发 statusOf 构造+广播；仅挂 onStatusChange 一路，审批/退出/attach 等事件路径保持即时，终态延迟不超窗口
- **/api/sessions git 分支 30s TTL 缓存**：列表轮询不再每次对全部 cwd 做同步文件 IO
- **codex reasoning 侧车回插二分定位**：append-only 时间递增校验通过后，每 turn 时间窗 O(log n + 命中数)；校验失败回退原全扫

### 复用
- **hostNameOf / escapeHtml / loadAnyplaneConfigFile / parseSsListenPids 归位 server 端正本**（util.ts / config.ts / portTakeover.ts），auth.ts、gateway.ts、gateway-lib.ts 改为复用；escapeHtml 补上单引号转义；gateway 启动不再双重读取配置文件
- **claude 上下文占用收敛 coerceCallUsage/contextUsageOf**：四处各自展开的 usage 字段映射同口径
- **codex mapTokenUsage**：tokenUsage/contextUsage 两 getter 的五字段映射归一
- **web apiFetch/apiError/postJson 导出**：push.ts 三处、SessionList 两处手写 fetch 收敛，401 统一触发令牌页
- **fmtTokens/usageSummary**：shortTokens 并入 fmtTokens，会话累计用量行提取共用（Chat 输入行 × ContextRing 面板）
- **ImageAttachment 共享组件**：消除 Transcript/MessageView 逐字重复
- **replayApprovals**：WS 接入单播与 attach 广播两处审批重放归并

### 简化
- **Chat 状态行 12 层嵌套三元 → statusLineOf 早退链**（分支顺序保持原求值语义）
- **send() 十条斜杠拦截 if 链 → {match,run} 表驱动**
- **summarizeInput 按工具分派**（Glob/Grep/WebSearch/WebFetch/Agent 各有裁决关键字段）；审批场景 Bash 刻意保持 command 本体而不对齐 web 卡片的 description 优先——说明文字不能作裁决依据
- **codexStatusOf 不再下发恒空 activeTasks** + hydrateTasks 删 `!isCodex` 补丁：字段缺席即无权威数据，前端守卫自然兜底（成对修改，本 PR 内自洽）
- btw_result 断线后自行建卡、settleBucketFromResult 提取、archive 删 statSyncSafe、StatusPill 监听去包装等散点

### 评估后跳过（记录备查）
- sessionKey describeKey 泛化（6+ 调用点重排面大）、sidechain 服务端转换（WS 协议变更）、权限档位映射归一（跨端语义）、/goal 双解析器合并、translate.ts 五 switch 表驱动、query_result 注册表：均为大重构或协议变更，超出清理范围
- btw_delta 索引（memo 后边际收益低）、base64 图片缓存（低价值）：不硬改