### PR TITLE
test: 补 config/handoff/SessionSocket 三个无覆盖模块的单元测试

### DIFF
--- a/server/src/config.test.ts
+++ b/server/src/config.test.ts
@@ -1,0 +1,95 @@
+// 服务端配置：loadAnyplaneConfigFile 的候选优先级与坏 JSON 容错、模块级 config 的
+// 默认值/env 覆盖/permissionPolicy → defaultPermissionMode。
+// 全程子进程驱动：Bun 的 homedir() 在进程启动时定型（进程内改 HOME 无效），
+// 且模块级 config 在 import 时一次性定型——只能用干净子进程 + 临时 HOME 隔离验证。
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const CONFIG_URL = pathToFileURL(join(import.meta.dir, 'config.ts')).href
+const tmpRoots: string[] = []
+
+afterEach(() => {
+  for (const r of tmpRoots.splice(0)) rmSync(r, { recursive: true, force: true })
+})
+
+/** 在干净子进程中执行脚本（临时 HOME 隔离真实 ~/.anyplane/config.json），输出须为单行 JSON */
+function runInSubprocess(script: string, home: string, extra?: { cwd?: string; env?: Record<string, string> }): unknown {
+  const res = Bun.spawnSync({
+    cmd: [process.execPath, '-e', script],
+    env: { ...process.env, HOME: home, USERPROFILE: home, ...extra?.env },
+    cwd: extra?.cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if (res.exitCode !== 0) throw new Error(`子进程失败: ${res.stderr.toString()}`)
+  return JSON.parse(res.stdout.toString())
+}
+
+/** 造临时目录：home 下可放 ~/.anyplane/config.json,cwd 下可放 anyplane.config.json */
+function seedDirs(files: { home?: string; cwd?: string }): { home: string; cwd: string } {
+  const root = mkdtempSync(join(tmpdir(), 'anyplane-config-'))
+  tmpRoots.push(root)
+  const home = join(root, 'home')
+  const cwd = join(root, 'cwd')
+  mkdirSync(join(home, '.anyplane'), { recursive: true })
+  mkdirSync(cwd, { recursive: true })
+  if (files.home !== undefined) writeFileSync(join(home, '.anyplane', 'config.json'), files.home)
+  if (files.cwd !== undefined) writeFileSync(join(cwd, 'anyplane.config.json'), files.cwd)
+  return { home, cwd }
+}
+
+const loadScript = `import { loadAnyplaneConfigFile } from ${JSON.stringify(CONFIG_URL)};
+console.log(JSON.stringify(loadAnyplaneConfigFile()))`
+
+describe('loadAnyplaneConfigFile', () => {
+  // 候选顺序：cwd → 项目根（仓库中不存在）→ ~/.anyplane/config.json
+  test('cwd 配置优先于 ~/.anyplane/config.json', () => {
+    const { home, cwd } = seedDirs({
+      home: JSON.stringify({ port: 1111, authToken: 'from-home' }),
+      cwd: JSON.stringify({ port: 2222 }),
+    })
+    expect(runInSubprocess(loadScript, home, { cwd })).toEqual({ port: 2222 })
+  })
+
+  test('cwd 配置是坏 JSON → 落到下一个有效候选', () => {
+    const { home, cwd } = seedDirs({ home: JSON.stringify({ port: 1111 }), cwd: '{broken' })
+    expect(runInSubprocess(loadScript, home, { cwd })).toEqual({ port: 1111 })
+  })
+
+  test('所有候选缺失 → 空对象', () => {
+    const { home, cwd } = seedDirs({})
+    expect(runInSubprocess(loadScript, home, { cwd })).toEqual({})
+  })
+})
+
+const configScript = `import { config, defaultPermissionMode } from ${JSON.stringify(CONFIG_URL)};
+console.log(JSON.stringify({ ...config, defaultMode: defaultPermissionMode() }))`
+
+describe('模块级 config', () => {
+  test('干净环境走默认值：7480/回环/ask → defaultPermissionMode undefined', () => {
+    const { home, cwd } = seedDirs({})
+    const cfg = runInSubprocess(configScript, home, { cwd }) as Record<string, unknown>
+    expect(cfg.port).toBe(7480)
+    expect(cfg.host).toBe('127.0.0.1')
+    expect(cfg.authToken).toBeUndefined()
+    expect(cfg.permissionPolicy).toBe('ask')
+    expect(cfg.defaultMode).toBeUndefined() // ask 策略不预置 bypassPermissions
+  })
+
+  test('env 覆盖配置文件：ANYPLANE_PORT/TOKEN 胜出，bypass → bypassPermissions', () => {
+    const { home, cwd } = seedDirs({
+      home: JSON.stringify({ port: 9000, permissionPolicy: 'bypass', authToken: 'file-token' }),
+    })
+    const cfg = runInSubprocess(configScript, home, {
+      cwd,
+      env: { ANYPLANE_PORT: '9999', ANYPLANE_TOKEN: 'env-token' },
+    }) as Record<string, unknown>
+    expect(cfg.port).toBe(9999) // env 覆盖文件
+    expect(cfg.authToken).toBe('env-token')
+    expect(cfg.defaultMode).toBe('bypassPermissions') // 文件里的 bypass 策略生效
+  })
+})

--- a/server/src/handoff.test.ts
+++ b/server/src/handoff.test.ts
@@ -1,0 +1,136 @@
+// 接力编排：briefPrompt/seedMessage 的纯文案契约（进程内），
+// 以及 appendLineage/lineageFor 的血缘读写（子进程 + 临时 HOME 隔离——
+// ccDataDir 走 homedir() 而 Bun 的 homedir 进程启动时定型，且绝不能触碰真实 ~/.anyplane/lineage.json）。
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { BACKEND_LABEL, briefPrompt, seedMessage } from './handoff'
+
+describe('briefPrompt', () => {
+  test('三档字数上限分别嵌入提示词', () => {
+    expect(briefPrompt('brief')).toContain('300字以内')
+    expect(briefPrompt('standard')).toContain('500字以内')
+    expect(briefPrompt('detailed')).toContain('800字以内')
+  })
+
+  test('简报要素与"直接输出正文"指令齐备（源会话看不到对话外上下文是契约前提）', () => {
+    const p = briefPrompt('standard')
+    for (const kw of ['交接简报', '项目目标', '当前进度', '关键架构决策', '文件清单', '下一步任务', '直接输出简报正文']) {
+      expect(p).toContain(kw)
+    }
+  })
+})
+
+describe('seedMessage', () => {
+  test('携带 cwd、源后端显示名、简报原文与现场确认指令', () => {
+    const msg = seedMessage('/tmp/proj', 'claude', '简报<正文> & 一切')
+    expect(msg).toContain('/tmp/proj')
+    expect(msg).toContain(BACKEND_LABEL.claude) // 'Claude Code'
+    expect(msg).toContain('简报<正文> & 一切') // 原样嵌入，不转义（进 prompt 不进 HTML）
+    expect(msg).toContain('git log --oneline') // 现场确认是实验验证的关键一环
+  })
+
+  test('codex 源后端显示名为 Codex', () => {
+    expect(seedMessage('/p', 'codex', 'b')).toContain('Codex')
+  })
+})
+
+// ---------- 血缘（子进程隔离） ----------
+
+const HANDOFF_URL = pathToFileURL(join(import.meta.dir, 'handoff.ts')).href
+const tmpRoots: string[] = []
+
+afterEach(() => {
+  for (const r of tmpRoots.splice(0)) rmSync(r, { recursive: true, force: true })
+})
+
+function freshHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'anyplane-handoff-'))
+  tmpRoots.push(home)
+  return home
+}
+
+function runInSubprocess(script: string, home: string): unknown {
+  const res = Bun.spawnSync({
+    cmd: [process.execPath, '-e', script],
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  if (res.exitCode !== 0) throw new Error(`子进程失败: ${res.stderr.toString()}`)
+  return JSON.parse(res.stdout.toString())
+}
+
+const REC_A = {
+  id: 'ha',
+  at: '2026-09-04T00:00:00Z',
+  fromKey: 's|-proj|sid-1',
+  toKey: 'n|%2Ftmp%2Fproj',
+  toResolvedKey: 's|-proj|sid-2',
+  fromBackend: 'claude',
+  toBackend: 'claude',
+  cwd: '/tmp/proj',
+  detail: 'standard',
+  brief: '简报甲',
+}
+const REC_B = {
+  id: 'hb',
+  at: '2026-09-04T00:01:00Z',
+  fromKey: 'x|thread-9',
+  toKey: 'xn|%2Ftmp%2Fproj',
+  fromResolvedKey: 'x|thread-9',
+  fromBackend: 'codex',
+  toBackend: 'claude',
+  cwd: '/tmp/proj',
+  detail: 'brief',
+  brief: '简报乙',
+}
+
+describe('appendLineage / lineageFor（子进程 + 临时 HOME）', () => {
+  test('文件不存在→创建；连续追加累积；lineageFor 按四个 key 字段匹配且排除无关', () => {
+    const home = freshHome()
+    const script = `import { appendLineage, lineageFor } from ${JSON.stringify(HANDOFF_URL)};
+import { readFileSync } from 'node:fs';
+const before = lineageFor('s|-proj|sid-1'); // 文件都不存在时
+appendLineage(${JSON.stringify(REC_A)});
+appendLineage(${JSON.stringify(REC_B)});
+const file = JSON.parse(readFileSync(${JSON.stringify('HOME_PLACEHOLDER')} + '/.anyplane/lineage.json', 'utf8'));
+console.log(JSON.stringify({
+  before,
+  fileIds: file.map((r) => r.id),
+  byFromKey: lineageFor('s|-proj|sid-1').map((r) => r.id),
+  byToKey: lineageFor('n|%2Ftmp%2Fproj').map((r) => r.id),
+  byFromResolved: lineageFor('x|thread-9').map((r) => r.id),
+  byToResolved: lineageFor('s|-proj|sid-2').map((r) => r.id),
+  unrelated: lineageFor('s|-proj|sid-zzz'),
+}))`.replace('HOME_PLACEHOLDER', home)
+    const out = runInSubprocess(script, home) as Record<string, unknown[]>
+    expect(out.before).toEqual([])
+    expect(out.fileIds).toEqual(['ha', 'hb']) // 追加顺序保持
+    expect(out.byFromKey).toEqual(['ha'])
+    expect(out.byToKey).toEqual(['ha'])
+    expect(out.byFromResolved).toEqual(['hb']) // fromResolvedKey 也命中
+    expect(out.byToResolved).toEqual(['ha'])
+    expect(out.unrelated).toEqual([])
+  })
+
+  test('既有血缘文件是坏 JSON → 从空重建而非崩溃（readJsonFile 静默吞错的既定语义）', () => {
+    const home = freshHome()
+    const script = `import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+const dir = ${JSON.stringify('HOME_PLACEHOLDER')} + '/.anyplane';
+mkdirSync(dir, { recursive: true });
+writeFileSync(dir + '/lineage.json', '{corrupted');
+const { appendLineage, lineageFor } = await import(${JSON.stringify(HANDOFF_URL)});
+appendLineage(${JSON.stringify(REC_A)});
+console.log(JSON.stringify({
+  file: JSON.parse(readFileSync(dir + '/lineage.json', 'utf8')).map((r) => r.id),
+  found: lineageFor('s|-proj|sid-1').map((r) => r.id),
+}))`.replace('HOME_PLACEHOLDER', home)
+    const out = runInSubprocess(script, home) as { file: string[]; found: string[] }
+    expect(out.file).toEqual(['ha']) // 旧数据丢失是既定行为（半截文件防呆注释见 util.writeJsonFile）
+    expect(out.found).toEqual(['ha'])
+  })
+})

--- a/server/src/handoff.test.ts
+++ b/server/src/handoff.test.ts
@@ -97,7 +97,7 @@ import { readFileSync } from 'node:fs';
 const before = lineageFor('s|-proj|sid-1'); // 文件都不存在时
 appendLineage(${JSON.stringify(REC_A)});
 appendLineage(${JSON.stringify(REC_B)});
-const file = JSON.parse(readFileSync(${JSON.stringify('HOME_PLACEHOLDER')} + '/.anyplane/lineage.json', 'utf8'));
+const file = JSON.parse(readFileSync(process.env.HOME + '/.anyplane/lineage.json', 'utf8'));
 console.log(JSON.stringify({
   before,
   fileIds: file.map((r) => r.id),
@@ -106,7 +106,7 @@ console.log(JSON.stringify({
   byFromResolved: lineageFor('x|thread-9').map((r) => r.id),
   byToResolved: lineageFor('s|-proj|sid-2').map((r) => r.id),
   unrelated: lineageFor('s|-proj|sid-zzz'),
-}))`.replace('HOME_PLACEHOLDER', home)
+}))`
     const out = runInSubprocess(script, home) as Record<string, unknown[]>
     expect(out.before).toEqual([])
     expect(out.fileIds).toEqual(['ha', 'hb']) // 追加顺序保持
@@ -120,7 +120,7 @@ console.log(JSON.stringify({
   test('既有血缘文件是坏 JSON → 从空重建而非崩溃（readJsonFile 静默吞错的既定语义）', () => {
     const home = freshHome()
     const script = `import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
-const dir = ${JSON.stringify('HOME_PLACEHOLDER')} + '/.anyplane';
+const dir = process.env.HOME + '/.anyplane';
 mkdirSync(dir, { recursive: true });
 writeFileSync(dir + '/lineage.json', '{corrupted');
 const { appendLineage, lineageFor } = await import(${JSON.stringify(HANDOFF_URL)});
@@ -128,7 +128,7 @@ appendLineage(${JSON.stringify(REC_A)});
 console.log(JSON.stringify({
   file: JSON.parse(readFileSync(dir + '/lineage.json', 'utf8')).map((r) => r.id),
   found: lineageFor('s|-proj|sid-1').map((r) => r.id),
-}))`.replace('HOME_PLACEHOLDER', home)
+}))`
     const out = runInSubprocess(script, home) as { file: string[]; found: string[] }
     expect(out.file).toEqual(['ha']) // 旧数据丢失是既定行为（半截文件防呆注释见 util.writeJsonFile）
     expect(out.found).toEqual(['ha'])

--- a/web/src/lib/ws.test.ts
+++ b/web/src/lib/ws.test.ts
@@ -1,0 +1,178 @@
+// SessionSocket：会话频道 WS 客户端的自有逻辑——url 构造（key 编码）、
+// open 前发送排队 / open 时 FIFO 冲刷、断线期间重排队并在重连后冲刷到新连接。
+// 重连退避本身由基类 reconnectingSocket.test.ts 覆盖,这里只测 SessionSocket 增量。
+// 用 FakeWebSocket + 捕获式 setTimeout 全同步驱动（同基类测试的模式）。
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { SessionSocket, type ClientCommand, type ServerEvent } from './ws'
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSED = 3
+  static instances: FakeWebSocket[] = []
+
+  readyState = FakeWebSocket.CONNECTING
+  sent: string[] = []
+  onopen: ((e: unknown) => void) | null = null
+  onclose: ((e: unknown) => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onerror: ((e: unknown) => void) | null = null
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(text: string): void {
+    this.sent.push(text)
+  }
+
+  close(): void {
+    if (this.readyState === FakeWebSocket.CLOSED) return
+    this.readyState = FakeWebSocket.CLOSED
+    this.onclose?.({})
+  }
+
+  // ---- 测试驱动辅助 ----
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN
+    this.onopen?.({})
+  }
+  receive(data: string): void {
+    this.onmessage?.({ data })
+  }
+}
+
+interface ScheduledCall {
+  delay: number
+  fn: () => void
+}
+
+let scheduled: ScheduledCall[] = []
+let storedToken: string | null = null
+const real = {
+  setTimeout: globalThis.setTimeout,
+  WebSocket: globalThis.WebSocket,
+  location: (globalThis as Record<string, unknown>).location,
+  localStorage: (globalThis as Record<string, unknown>).localStorage,
+}
+
+beforeEach(() => {
+  scheduled = []
+  storedToken = null
+  FakeWebSocket.instances = []
+  const g = globalThis as Record<string, unknown>
+  g.WebSocket = FakeWebSocket as unknown as typeof WebSocket
+  g.setTimeout = ((fn: () => void, delay?: number) => {
+    scheduled.push({ delay: delay ?? 0, fn })
+    return 0
+  }) as unknown as typeof setTimeout
+  g.location = { protocol: 'http:', host: 'cc.test', search: '', href: 'http://cc.test/' }
+  g.localStorage = {
+    getItem: (k: string) => (k === 'anyplane-token' ? storedToken : null),
+    setItem: (_k: string, v: string) => {
+      storedToken = v
+    },
+    removeItem: () => {},
+    clear: () => {},
+  }
+})
+
+afterEach(() => {
+  const g = globalThis as Record<string, unknown>
+  g.setTimeout = real.setTimeout
+  g.WebSocket = real.WebSocket
+  g.location = real.location
+  g.localStorage = real.localStorage
+})
+
+function makeSocket(key = 's|-proj|sid-1') {
+  const events: ServerEvent[] = []
+  const opens: boolean[] = []
+  const s = new SessionSocket(
+    key,
+    (ev) => events.push(ev),
+    (open) => opens.push(open),
+  )
+  return { s, events, opens }
+}
+
+const userCmd: ClientCommand = { kind: 'user', text: '你好' }
+
+describe('SessionSocket URL 构造', () => {
+  test('key 经 encodeURIComponent 拼入 /ws/sessions/ 路径', () => {
+    makeSocket('n|/tmp/a b')
+    expect(FakeWebSocket.instances[0]?.url).toBe('ws://cc.test/ws/sessions/n%7C%2Ftmp%2Fa%20b')
+  })
+
+  test('localStorage 有 token 时由 wsUrl 附加编码后的 query', () => {
+    storedToken = 'tok 1'
+    makeSocket('x|thread-9')
+    expect(FakeWebSocket.instances[0]?.url).toBe('ws://cc.test/ws/sessions/x%7Cthread-9?token=tok%201')
+  })
+})
+
+describe('SessionSocket 发送队列', () => {
+  test('open 前 send 只排队不发送；open 时按 FIFO 冲刷且之后直发', () => {
+    const { s } = makeSocket()
+    const ws = FakeWebSocket.instances[0]!
+    s.send({ kind: 'attach' })
+    s.send(userCmd)
+    expect(ws.sent).toEqual([]) // CONNECTING 期间一条都不发
+
+    ws.open()
+    expect(ws.sent.map((t) => JSON.parse(t))).toEqual([{ kind: 'attach' }, userCmd]) // 按序冲刷
+
+    ws.sent.length = 0
+    s.send({ kind: 'btw', question: 'q' }) // open 后直发,不经队列
+    expect(ws.sent.map((t) => JSON.parse(t))).toEqual([{ kind: 'btw', question: 'q' }])
+  })
+
+  test('队列只冲刷一次:重连 open 不会重发历史命令', () => {
+    const { s } = makeSocket()
+    const ws = FakeWebSocket.instances[0]!
+    s.send(userCmd)
+    ws.open()
+    expect(ws.sent).toHaveLength(1)
+
+    // 断线 → 捕获的重连定时器到点 → 新连接 open:队列已空,不应重放
+    ws.close()
+    scheduled.shift()?.fn()
+    const ws2 = FakeWebSocket.instances[1]!
+    ws2.open()
+    expect(ws2.sent).toEqual([])
+  })
+
+  test('断线期间 send 重新排队,重连 open 时冲刷到新连接且保持先后序', () => {
+    const { s } = makeSocket()
+    const ws = FakeWebSocket.instances[0]!
+    ws.open()
+    s.send({ kind: 'user', text: '第一条' })
+    expect(ws.sent).toHaveLength(1)
+
+    ws.close() // 断线,open 状态回退
+    s.send({ kind: 'user', text: '断线期' }) // 未 open → 排队
+    s.send({ kind: 'control', subtype: 'interrupt' })
+    scheduled.shift()?.fn() // 重连
+
+    const ws2 = FakeWebSocket.instances[1]!
+    expect(ws2.sent).toEqual([]) // 新连接 open 前仍不发
+    ws2.open()
+    expect(ws2.sent.map((t) => JSON.parse(t))).toEqual([
+      { kind: 'user', text: '断线期' },
+      { kind: 'control', subtype: 'interrupt' },
+    ])
+  })
+})
+
+describe('SessionSocket 事件与连接状态回调', () => {
+  test('下行消息透传 onEvent;open/close 驱动 openCb', () => {
+    const { events, opens } = makeSocket()
+    const ws = FakeWebSocket.instances[0]!
+    ws.open()
+    ws.receive(JSON.stringify({ kind: 'status', state: { spawned: true, busy: true } }))
+    expect(events).toEqual([{ kind: 'status', state: { spawned: true, busy: true } }])
+    ws.close()
+    expect(opens).toEqual([true, false])
+  })
+})


### PR DESCRIPTION
## 背景

盘点 server/src 与 web/src 的纯逻辑模块测试覆盖,选出 3 个完全无测试的核心模块补测。已有 e2e 脚本覆盖的真实 CLI 链路(spawn/审批/rewind 等)未重复造单元测试;被测源码零改动。

测试总数:**273 → 290**(+17,expect 调用 723 → 770)。

## 补测模块

### 1. `server/src/config.ts` → `config.test.ts`(5 个测试)

- `loadAnyplaneConfigFile`:cwd 候选优先于 `~/.anyplane/config.json`;cwd 配置坏 JSON 时报错并落到下一个有效候选;所有候选缺失返回 `{}`。
- 模块级 `config`:干净环境走默认值(7480/回环/ask → `defaultPermissionMode()` 为 undefined);`ANYPLANE_PORT`/`ANYPLANE_TOKEN` 覆盖配置文件;文件里 `permissionPolicy: 'bypass'` → `bypassPermissions`。
- 实现说明:Bun 的 `homedir()` 在进程启动时定型(进程内改 `HOME` 无效)且模块级 config 在 import 时一次性定型,故全程 `bun -e` 子进程 + 临时 HOME 隔离驱动。

### 2. `server/src/handoff.ts` → `handoff.test.ts`(6 个测试)

- `briefPrompt`:三档字数上限(300/500/800)嵌入提示词,简报要素与「直接输出正文」指令齐备。
- `seedMessage`:携带 cwd、源后端显示名、简报原文(不转义)与现场确认指令。
- `appendLineage`/`lineageFor`:文件不存在时创建、连续追加保序;按 fromKey/toKey/fromResolvedKey/toResolvedKey 四字段匹配并排除无关记录;坏 JSON 血缘文件从空重建(readJsonFile 静默吞错的既定语义,防回归)。
- 血缘 I/O 走子进程 + 临时 HOME,绝不触碰真实 `~/.anyplane/lineage.json`。

### 3. `web/src/lib/ws.ts` → `ws.test.ts`(6 个测试)

- URL 构造:key 经 `encodeURIComponent` 拼入 `/ws/sessions/` 路径;localStorage 有 token 时附加编码 query。
- 发送队列:open 前 send 只排队不发;open 时 FIFO 冲刷且只冲刷一次(重连不重放历史命令);open 后直发。
- 断线重连:断线期间 send 重新排队,重连 open 冲刷到新连接实例并保持先后序。
- 下行消息透传 onEvent、open/close 驱动 openCb。
- 重连退避本身由基类 `reconnectingSocket.test.ts` 覆盖,这里只测 SessionSocket 增量;沿用同样的 FakeWebSocket + 捕获式 setTimeout 同步驱动模式。

## 验证

每个模块完成后跑全量 `bun test`:278 → 284 → 290,全绿后才提交下一模块。