### PR TITLE
test: 清理重复覆盖与同义反复断言（测试审计）

### DIFF
--- a/scripts/gateway-lib.test.ts
+++ b/scripts/gateway-lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { detectProtocol, hostnameOf, isOwnGatewayCmd, parseCookieMode, parseSsListenPids, pickMode } from './gateway-lib'
+import { detectProtocol, isOwnGatewayCmd, parseCookieMode, pickMode } from './gateway-lib'
 
 describe('detectProtocol', () => {
   test('TLS ClientHello', () => {
@@ -32,25 +32,13 @@ describe('pickMode', () => {
     expect(pickMode('anyplane.example.com', 'anyplane-mode=prod', devHost, 'dev')).toBe('dev')
     expect(pickMode('anyplane.example.com', 'anyplane-mode=dev', devHost, 'prod')).toBe('prod')
   })
-  test('strips port from Host', () => {
-    expect(hostnameOf('anyplane.example.com:80')).toBe('anyplane.example.com')
+  test('cookie 串里挑出 anyplane-mode', () => {
     expect(parseCookieMode('a=1; anyplane-mode=dev; b=2')).toBe('dev')
   })
 })
 
-describe('parseSsListenPids', () => {
-  const sample = `
-LISTEN 0 512 0.0.0.0:80 0.0.0.0:* users:(("bun",pid=1562281,fd=11))
-LISTEN 0 512 0.0.0.0:443 0.0.0.0:* users:(("bun",pid=1562281,fd=12))
-LISTEN 0 512 127.0.0.1:8080 0.0.0.0:* users:(("node",pid=9,fd=1))
-LISTEN 0 128 *:80 *:* users:(("nginx",pid=1,fd=8),("nginx",pid=2,fd=8))
-`
-  test('collects pids for exact port', () => {
-    expect(parseSsListenPids(sample, 80).sort((a, b) => a - b)).toEqual([1, 2, 1562281])
-    expect(parseSsListenPids(sample, 443)).toEqual([1562281])
-    expect(parseSsListenPids(sample, 8080)).toEqual([9])
-  })
-  test('own gateway cmdline', () => {
+describe('isOwnGatewayCmd', () => {
+  test('cmdline 含 scripts/gateway.ts → 自己人；其余进程不误杀', () => {
     expect(isOwnGatewayCmd('bun\0--bun\0scripts/gateway.ts\0--insecure')).toBe(true)
     expect(isOwnGatewayCmd('/usr/sbin/sshd')).toBe(false)
   })

--- a/server/src/portTakeover.test.ts
+++ b/server/src/portTakeover.test.ts
@@ -12,11 +12,12 @@ LISTEN   0        511              0.0.0.0:80             0.0.0.0:*       users:
 LISTEN   0        511              0.0.0.0:8080           0.0.0.0:*       users:(("python3",pid=200,fd=3))
 LISTEN   0        511            127.0.0.1:7480           0.0.0.0:*       users:(("bun",pid=300,fd=1353))
 LISTEN   0        511                [::]:443              [::]:*       users:(("bun",pid=100,fd=10),("bun",pid=101,fd=7))
+LISTEN   0        128                 *:80                   *:*       users:(("nginx",pid=1,fd=8),("nginx",pid=2,fd=8))
 `
 
 describe('parseSsListenPids', () => {
-  test('按端口精确匹配，不误伤 :8080', () => {
-    expect(parseSsListenPids(SS_SAMPLE, 80)).toEqual([100])
+  test('按端口精确匹配，不误伤 :8080；同端口跨行聚合（含 * 通配与单行多 pid）', () => {
+    expect(parseSsListenPids(SS_SAMPLE, 80).sort((a, b) => a - b)).toEqual([1, 2, 100])
     expect(parseSsListenPids(SS_SAMPLE, 8080)).toEqual([200])
     expect(parseSsListenPids(SS_SAMPLE, 7480)).toEqual([300])
   })

--- a/web/src/components/PopupPanel.test.ts
+++ b/web/src/components/PopupPanel.test.ts
@@ -9,8 +9,6 @@ describe('popupPosition', () => {
   test('cover-end 面板右下角与锚点右下角重合', () => {
     const pos = popupPosition(ring, 'cover-end', 6, vp)
     expect(pos).toEqual({ bottom: vp.height - ring.bottom, right: vp.width - ring.right })
-    expect(vp.width - pos.right!).toBe(ring.right)
-    expect(vp.height - pos.bottom!).toBe(ring.bottom)
   })
 
   test('cover-start 面板左下角与锚点左下角重合（StatusPill 同款）', () => {


### PR DESCRIPTION
## 审计范围

通读 server/、scripts/、web/ 下全部 32 个 `*.test.ts`（290 个测试），基线 290 pass / 0 fail。按三类问题（同义反复/假测试、重复覆盖、脆测试）判定后，**清理 3 处**，其余保留。全程未改任何被测源码；每批改动后 `bun test` 全绿，终态 289 pass / 0 fail。

## 删除/重写清单

### 1. 重复覆盖：`scripts/gateway-lib.test.ts` 的 `describe('parseSsListenPids')` 按端口收 pid 测试（删除，独有形态迁移）

- **理由**：`scripts/gateway-lib.ts:9` 为 `export { parseSsListenPids } from '../server/src/portTakeover'`（re-export，文件注释自证"正本在 server/src/portTakeover"）。`server/src/portTakeover.test.ts` 的同名 describe 已用等价断言覆盖这**同一个函数**（按端口精确匹配、同行多 pid、空输入），此处再测不增加任何行为保障。
- **无损处理**：gateway 样本唯一独有的形态——"同端口跨两行 + 单行多 pid 混合聚合"（`0.0.0.0:80` bun 行 + `*:80` nginx 双 pid 行）——已迁移到 `portTakeover.test.ts` 的 `SS_SAMPLE`，保障不降。

### 2. 重复覆盖：`gateway-lib.test.ts` 'strips port from Host' 中的 `hostnameOf` 断言（删行，测试改名保留）

- **理由**：`hostnameOf` 正本在 `server/src/util.ts:44`（`gateway-lib.ts:6` 注释自证），`auth.test.ts` 的 `describe('hostNameOf')` 已覆盖去端口行为，且含更难的 IPv6 方括号形态（`[::1]:7480`）。此处单域名断言完全等价。
- **无损处理**：同 test 中 `parseCookieMode` 断言是 gateway-lib 自有函数的**唯一覆盖点**，保留；test 随之改名「cookie 串里挑出 anyplane-mode」。

### 3. 同义反复：`web/src/components/PopupPanel.test.ts` 'cover-end' 测试的后两行断言（删行）

- **理由**：`vp.width - pos.right === ring.right` 与 `vp.height - pos.bottom === ring.bottom` 是同一 test 首行 `toEqual({ bottom: vp.height - ring.bottom, right: vp.width - ring.right })` 的代数恒等变形——首行失败它们必然同败，属于同一命题的重复表述，不增加保障。

### 附带保留（位置修正，非删除）

- `gateway-lib.test.ts` 中混放在 `describe('parseSsListenPids')` 里的 `isOwnGatewayCmd` 测试：gateway-lib 自有函数、唯一覆盖点，移入独立 `describe('isOwnGatewayCmd')` 保留。

## 保留待人工判断（拿不准一律未动）

| 位置 | 疑点 | 倾向保留的理由 |
|---|---|---|
| `server/src/archive.test.ts` | 5 个 test 存在顺序依赖（归档→列表→恢复→占用冲突） | 有意编排的状态流；bun:test 保证文件内顺序执行；不属于任务定义的三类问题 |
| `web/src/lib/key.test.ts` vs 服务端两个 `backend.test.ts` | key 形状用例高度相似 | 驱动的是前后端**两份独立实现**，防各自漂移；一份坏了另一份测试抓不到 |
| `server/src/handoff.test.ts` briefPrompt | 钉提示词文案关键词 | 提示词文案即该函数的行为契约（简报质量依赖要素齐备）；`toContain` 只钉要素不钉全文 |
| `web/src/lib/reconnectingSocket.test.ts` | 退避序列钉死 [1s,2s,4s,8s,15s,15s] | 这是设计规格（注释声明"1s 起 15s 封顶"），改参数就是改行为 |
| `server/src/backends/claude/discovery.test.ts` | readHistory rewind 过滤与 `isSelectableRewindTarget` 单测有交集 | 各有独立保障点：前者验证集成路径（isMeta 滤出抄本），后者枚举全部内部标签 |

## Commits

- `7ff6f0a` test(scripts): 删除 gateway-lib 对 re-export 正本的重复覆盖
- `ce80afd` test(web): 删除 PopupPanel cover-end 测试的同义反复断言