### PR TITLE
refactor: 方向六上帝文件重构——BackendPort 抽象 + index.ts 拆分 + Chat.tsx 拆解

### DIFF
--- a/server/scripts/e2e-branch-btw-goal.ts
+++ b/server/scripts/e2e-branch-btw-goal.ts
@@ -1,8 +1,8 @@
 // 验证链路：btw(side_question) → branch(懒分叉) → /goal 状态跟踪
-// 用法：bun run server/scripts/e2e-branch-btw-goal.ts
+// 用法：bun run server/scripts/e2e-branch-btw-goal.ts [cwd]（默认 /tmp；Windows 需显式传存在的目录）
 import { connect, exitWithSummary, makeNote } from './e2e-lib'
 
-const cwd = '/tmp'
+const cwd = process.argv[2] ?? '/tmp'
 const nKey = `n|${encodeURIComponent(cwd)}`
 const { note, results } = makeNote()
 

--- a/server/scripts/e2e-branch-btw-goal.ts
+++ b/server/scripts/e2e-branch-btw-goal.ts
@@ -23,7 +23,8 @@ a.on((ev) => {
   }
   if (ev.kind === 'cli' && (ev.msg as { type?: string }).type === 'result') turnDone = true
 })
-a.send({ kind: 'user', text: '记住暗号「星河战舰」，只回复「收到」两个字。' })
+// 禁止写 memory：暗号必须只活在对话上下文里（CLI 新版自动记忆会落盘，污染隔离语义）
+a.send({ kind: 'user', text: '记住暗号「星河战舰」，只回复「收到」两个字。为保证上下文隔离，禁止写入 memory。' })
 for (let i = 0; i < 120 && !turnDone; i++) await new Promise((r) => setTimeout(r, 1000))
 note(turnDone && !!sessionId, '源会话建立上下文', `sessionId=${sessionId.slice(0, 8)}`)
 

--- a/server/scripts/e2e-clear.ts
+++ b/server/scripts/e2e-clear.ts
@@ -53,9 +53,10 @@ async function awaitResult(fromIndex: number, ms: number): Promise<boolean> {
   return false
 }
 
-// 1. 建立上下文
+// 1. 建立上下文（禁止写 memory：CLI 新版会把暗号落盘到项目 memory/，clear 后的新会话
+//    会从记忆文件读回暗号——clear 语义本身没变，是测试前提被自动记忆行为腐化）
 let idx = events.length
-ws.send(JSON.stringify({ kind: 'user', text: '记住暗号「蓝莓蛋糕」，只回复「收到」两个字。' }))
+ws.send(JSON.stringify({ kind: 'user', text: '记住暗号「蓝莓蛋糕」，只回复「收到」两个字。为保证上下文隔离，禁止写入 memory。' }))
 note(await awaitResult(idx, 150_000), 'clear 前：上下文建立')
 
 // 2. /clear
@@ -78,6 +79,10 @@ console.log('\n>> 事件流:')
 for (const e of events) console.log(`  ${((e.at - events[0].at) / 1000).toFixed(1)}s ${e.kind} ${e.brief}`)
 
 ws.close()
-rmSync(dir, { recursive: true, force: true })
+// 清理 best-effort：claude 进程以该目录为 cwd，空闲回收（默认 5min）前 Windows 上 rm 必 EBUSY，
+// 失败不影响断言结论——临时目录留给系统自洁
+try {
+  rmSync(dir, { recursive: true, force: true, maxRetries: 2, retryDelay: 500 })
+} catch {}
 clearTimeout(timeout)
 exitWithSummary(results)

--- a/server/scripts/e2e-push.ts
+++ b/server/scripts/e2e-push.ts
@@ -1,7 +1,8 @@
 // E2E-Web Push：mock push service + 自造订阅密钥，验证推送全链路
 // 覆盖：订阅注册 → 真实审批触发推送 → VAPID JWT 校验 → RFC 8291/8188 解密 →
 //       能力 URL 直接审批 → 410 死订阅自动清理
-// 用法：bun run server/scripts/e2e-push.ts（需服务端已启动；会真实 spawn 一次 claude 触发审批）
+// 用法：bun run server/scripts/e2e-push.ts [cwd]（需服务端已启动；会真实 spawn 一次 claude 触发审批）
+// cwd 默认 /tmp（POSIX）；Windows 需显式传存在的目录
 import {
   createHmac,
   createPublicKey,
@@ -112,7 +113,8 @@ try {
   note(typeof secret === 'string' && secret.length > 20, '服务端返回能力密钥')
 
   // 2. 起 claude 会话，触发真实审批
-  const key = `n|${encodeURIComponent('/tmp')}`
+  const testCwd = process.argv[2] ?? '/tmp'
+  const key = `n|${encodeURIComponent(testCwd)}`
   const ws = new WebSocket(`${WS_BASE}/ws/sessions/${encodeURIComponent(key)}${TOKEN_Q}`)
   let resolved = false
   let sawResolvedEvent = false
@@ -126,7 +128,7 @@ try {
   ws.send(
     JSON.stringify({
       kind: 'user',
-      text: '请立即用 Write 工具创建文件 /tmp/ccr-push-test.txt，内容写 push-ok。只做这一件事，不要问任何问题。',
+      text: `请立即用 Write 工具创建文件 ${testCwd}/ccr-push-test.txt，内容写 push-ok。只做这一件事，不要问任何问题。`,
     }),
   )
 
@@ -175,7 +177,8 @@ try {
     !!payload.actions?.allow.endsWith(secret) && !!payload.actions.deny.endsWith(secret),
     '能力 URL 按订阅补全了 secret',
   )
-  note(payload.body.includes('/tmp/ccr-push-test.txt'), '推送正文含审批详情（详细内容策略）', payload.body.slice(0, 60))
+  // 只断言文件名：CLI 落盘的路径分隔符由工具规范化（Windows 全反斜杠），不宜断言拼接形态
+  note(payload.body.includes('ccr-push-test.txt'), '推送正文含审批详情（详细内容策略）', payload.body.slice(0, 60))
 
   // 6. 直接审批：POST 能力 URL（无 authToken——模拟 SW 环境）
   const allowResp = await fetch(`${BASE}${payload.actions!.allow}`, { method: 'POST' })
@@ -200,7 +203,7 @@ try {
   })
   gonePaths.add('/push/B')
   const countBefore = ((await (await fetch(`${BASE}/api/push/public-key`)).json()) as { subscriptions: number }).subscriptions
-  ws.send(JSON.stringify({ kind: 'user', text: '再用 Write 把文件 /tmp/ccr-push-test2.txt 内容写成 push-ok2。只做这一件事。' }))
+  ws.send(JSON.stringify({ kind: 'user', text: `再用 Write 把文件 ${testCwd}/ccr-push-test2.txt 内容写成 push-ok2。只做这一件事。` }))
   let pushB: Captured | undefined
   for (let i = 0; i < 120 && !pushB; i++) {
     await new Promise((r) => setTimeout(r, 1000))

--- a/server/scripts/e2e-push.ts
+++ b/server/scripts/e2e-push.ts
@@ -20,6 +20,10 @@ import { exitWithSummary, makeNote } from './e2e-lib'
 const BASE = process.env.ANYPLANE_BASE ?? 'http://127.0.0.1:7480'
 const WS_BASE = BASE.replace(/^http/, 'ws')
 const TOKEN_Q = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN}` : ''
+// /api 一律要鉴权（authToken 配置后）；能力 URL（approval-action）按设计绕开 token，
+// 这两处调用必须保持无 token，否则测不到"秘密只经加密推送投递"的红线
+const api = (path: string, init?: RequestInit) =>
+  fetch(`${BASE}${path}${path.includes('?') ? '&' : '?'}${TOKEN_Q.slice(1)}`, init)
 const { note, results } = makeNote()
 const b64url = (b: Buffer) => b.toString('base64url')
 // ---------- mock push service ----------
@@ -103,7 +107,7 @@ try {
     endpoint: 'http://127.0.0.1:18999/push/A',
     keys: { p256dh: b64url(uaPubRaw), auth: b64url(auth) },
   }
-  const reg = await fetch(`${BASE}/api/push/subscriptions`, {
+  const reg = await api('/api/push/subscriptions', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(subA),
@@ -177,8 +181,11 @@ try {
     !!payload.actions?.allow.endsWith(secret) && !!payload.actions.deny.endsWith(secret),
     '能力 URL 按订阅补全了 secret',
   )
-  // 只断言文件名：CLI 落盘的路径分隔符由工具规范化（Windows 全反斜杠），不宜断言拼接形态
-  note(payload.body.includes('ccr-push-test.txt'), '推送正文含审批详情（详细内容策略）', payload.body.slice(0, 60))
+  // 断言完整路径（分隔符归一化：Windows 上 CLI 落盘为反斜杠）——body 必须携带可行动的
+  // 绝对路径；只含 basename 或错目录的回归不能放绿（本断言是脚本唯一的 body 内容检查）
+  const expectPath = `${testCwd}/ccr-push-test.txt`.replace(/\\/g, '/')
+  const bodyNorm = payload.body.replace(/\\/g, '/')
+  note(bodyNorm.includes(expectPath), '推送正文含审批详情（完整路径）', payload.body.slice(0, 60))
 
   // 6. 直接审批：POST 能力 URL（无 authToken——模拟 SW 环境）
   const allowResp = await fetch(`${BASE}${payload.actions!.allow}`, { method: 'POST' })
@@ -193,7 +200,7 @@ try {
   note(badResp.status === 403, '错误 secret 被拒（403）')
 
   // 8. 死订阅 410 清理：注册 B（标记 410）→ 再触发一次审批 → B 应被自动摘除
-  await fetch(`${BASE}/api/push/subscriptions`, {
+  await api('/api/push/subscriptions', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
@@ -202,7 +209,7 @@ try {
     }),
   })
   gonePaths.add('/push/B')
-  const countBefore = ((await (await fetch(`${BASE}/api/push/public-key`)).json()) as { subscriptions: number }).subscriptions
+  const countBefore = ((await (await api('/api/push/public-key')).json()) as { subscriptions: number }).subscriptions
   ws.send(JSON.stringify({ kind: 'user', text: `再用 Write 把文件 ${testCwd}/ccr-push-test2.txt 内容写成 push-ok2。只做这一件事。` }))
   let pushB: Captured | undefined
   for (let i = 0; i < 120 && !pushB; i++) {
@@ -217,16 +224,16 @@ try {
     if (p2.actions) await fetch(`${BASE}${p2.actions.allow}`, { method: 'POST' })
   }
   await new Promise((r) => setTimeout(r, 1500))
-  const countAfter = ((await (await fetch(`${BASE}/api/push/public-key`)).json()) as { subscriptions: number }).subscriptions
+  const countAfter = ((await (await api('/api/push/public-key')).json()) as { subscriptions: number }).subscriptions
   note(countAfter === countBefore - 1, '410 死订阅自动摘除', `${countBefore} → ${countAfter}`)
 
   // 9. 清理测试订阅 A
-  await fetch(`${BASE}/api/push/subscriptions`, {
+  await api('/api/push/subscriptions', {
     method: 'DELETE',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ endpoint: subA.endpoint }),
   })
-  const countFinal = ((await (await fetch(`${BASE}/api/push/public-key`)).json()) as { subscriptions: number }).subscriptions
+  const countFinal = ((await (await api('/api/push/public-key')).json()) as { subscriptions: number }).subscriptions
   note(countFinal === 0, '测试订阅清理完毕', `剩余 ${countFinal}`)
 
   ws.close()

--- a/server/scripts/e2e-rewind.ts
+++ b/server/scripts/e2e-rewind.ts
@@ -11,7 +11,8 @@ const tokenQ = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN
 // 从 REST 拿一条用户消息 uuid。取最后一条带文本的用户消息：
 // 最早的消息通常早于文件检查点（无快照可恢复），最近的消息最可能有 checkpoint。
 const hist = await (await fetch(`http://localhost:7480/api/history/${slug}/${sessionId}`)).json()
-const candidates = hist.filter(
+// 端点返回 { messages, fileBytes, subagents }（历史响应带子代理水合字段后不再是裸数组）
+const candidates = (hist.messages ?? []).filter(
   (m) =>
     m.role === 'user' &&
     m.uuid &&

--- a/server/src/approvalRules.ts
+++ b/server/src/approvalRules.ts
@@ -64,7 +64,7 @@ export function parseApprovalRules(raw: unknown): ApprovalRule[] {
 
 // ---------- 匹配 ----------
 
-/** 工具输入字段提取（与 index.ts summarizeInput 的按工具分发对齐，不另起一套） */
+/** 工具输入字段提取（与 util.ts summarizeInput 的按工具分发对齐，不另起一套） */
 function extractField(toolName: string, input: unknown, field: 'command' | 'domain'): string | null {
   if (!input || typeof input !== 'object') return null
   const obj = input as Record<string, unknown>

--- a/server/src/backends/claude/port.ts
+++ b/server/src/backends/claude/port.ts
@@ -1,10 +1,24 @@
 // claude 后端适配器：把 processManager/discovery 的能力包装成 BackendPort。
 // 方法体多为 index.ts 原 claude 分支的逐字搬迁——重构红线是零行为改动。
 
-import { hydratedContextOf, splitExistingKey } from './backend'
+import { join } from 'node:path'
+import { config, defaultPermissionMode } from '../../config'
+import { briefPrompt, generateClaudeBrief, type HandoffDetail } from '../../handoff'
+import { log } from '../../log'
+import { errorMessage } from '../../util'
+import type { Hub } from '../../index'
+import {
+  baseStatusOf,
+  hubServices,
+  type BackendPort,
+  type SessionHandle,
+  type StatusContext,
+} from '../port'
+import type { SpawnOptions } from '../types'
+import { hydratedContextOf, keyForBranch, parseKey, splitExistingKey, type ParsedKey } from './backend'
 import { liveSessionInfo } from './discovery'
-import { processManager } from './processManager'
-import { baseStatusOf, type BackendPort, type SessionHandle, type StatusContext } from '../port'
+import { processManager, type ClaudeSession } from './processManager'
+import { TranscriptTailer } from './tailer'
 
 class ClaudePort implements BackendPort {
   readonly name = 'claude' as const
@@ -49,6 +63,391 @@ class ClaudePort implements BackendPort {
       liveStatus: live?.status,
       goal: hub?.goal ?? null,
     }
+  }
+
+  // ---------- 生命周期（原 index.ts ensureSpawned/ensureClaudeSession/tailer 三件套） ----------
+
+  onAttach(hub: Hub, msg: Record<string, unknown>): void {
+    // 浏览历史只握手，不 spawn。发消息 / 切 model·mode·effort / rewind / btw 时再启动 CLI。
+    // 若客户端显式传 warm:true，则预热 resume（用于主动续聊）。
+    if (msg.warm === true || msg.opts) {
+      this.ensureSpawned(hub, msg.opts as Partial<SpawnOptions> | undefined)
+    } else {
+      hubServices().pushStatus(hub)
+    }
+  }
+
+  async ensure(hub: Hub, opts?: Partial<SpawnOptions>): Promise<SessionHandle | undefined> {
+    // 零 await 红线：本函数体到 return 前不得出现 await——spawn/stopTailer/syncClients/
+    // pendingEnv 写入必须与调用同拍完成（调用方 await 只推迟其后续代码一个微任务）
+    this.ensureSpawned(hub, opts)
+    const s = processManager.get(hub.key)
+    return s && !s.exited ? s : undefined
+  }
+
+  async ensureForSend(hub: Hub): Promise<SessionHandle | undefined> {
+    // 零 await 红线同 ensure
+    return this.sessionForSend(hub)
+  }
+
+  /** 原 ensureClaudeSession：未运行则触发懒 spawn；仍未就绪返回 undefined
+   * （ensureSpawned 已广播具体错误）。同步路径（rewindBoth）也用它。 */
+  private sessionForSend(hub: Hub): ClaudeSession | undefined {
+    let s = processManager.get(hub.key)
+    if (!s || s.exited) {
+      this.ensureSpawned(hub)
+      s = processManager.get(hub.key)
+    }
+    return s && !s.exited ? s : undefined
+  }
+
+  private ensureSpawned(hub: Hub, opts?: Partial<SpawnOptions>, parsedHint?: ParsedKey): void {
+    // parseKey 会反查 listSessions()（一次文件系统扫描）；调用方已解析过时直接复用
+    const parsed = parsedHint ?? parseKey(hub.key)
+    if (!parsed) {
+      hubServices().broadcastError(hub, '无法解析会话（项目目录不存在？）')
+      return
+    }
+    const spawnOpts: SpawnOptions = {
+      cwd: parsed.cwd,
+      resumeSessionId: parsed.resumeSessionId,
+      forkFromSessionId: parsed.forkFromSessionId,
+      permissionMode: defaultPermissionMode(),
+      ...hub.spawnOpts,
+      ...opts,
+    }
+    // b| 懒分叉的一次性语义：首个 init 已把分叉产出的新 sessionId 记入 hub.sessionId，
+    // 此后 respawn/rewind 必须 resume 分叉自身。否则 spawn() 里 fork 分支优先于 resume，
+    // 会从源会话重新 fork 出全新 sessionId，静默丢弃分叉后的全部对话；rewind 路径更致命——
+    // --resume-session-at 带的 messageId 在源 transcript 里根本不存在。
+    if (spawnOpts.forkFromSessionId && hub.sessionId) {
+      delete spawnOpts.forkFromSessionId
+      spawnOpts.resumeSessionId = hub.sessionId
+    }
+    hub.spawnOpts = spawnOpts
+    try {
+      const s = processManager.ensure(hub.key, spawnOpts, hubServices().sessionCallbacks(hub))
+      // spawn 成功（或已有存活进程）：live 流接管，停掉 transcript tailer 避免重复推送
+      this.stopTailer(hub)
+      // 懒 spawn：WS 可能在进程创建前已 open，对齐客户端引用计数
+      s.syncClients(hub.clients.size)
+      // 自定义 env 必须排在首条 user 消息之前写入；stdin 保证顺序。
+      if (hub.pendingEnv && Object.keys(hub.pendingEnv).length > 0) {
+        s.write({ type: 'update_environment_variables', variables: hub.pendingEnv })
+        hub.pendingEnv = undefined
+      }
+    } catch (e) {
+      log.error(`[session ${hub.key}] spawn 失败:`, e) // 原对象打日志保留堆栈
+      hubServices().broadcastError(hub, errorMessage(e))
+    }
+    // resumeSessionAt 是一次性 spawn 参数（命令行 args 已在 spawn() 内同步生成）。
+    // 无论本次成败都不能留在 hub.spawnOpts 里，否则之后空闲回收后的普通 respawn
+    // 会带着它再次截断同一条消息，静默丢弃回滚之后的新对话。
+    delete hub.spawnOpts.resumeSessionAt
+    hubServices().pushStatus(hub)
+  }
+
+  afterUserSent(hub: Hub, text: string): void {
+    // /goal 是 claude 的本地斜杠命令（2.1.139+）：goal 状态不进 stream-json，
+    // 这里从出站文本跟踪 chip 状态；result 到达时清除（见 onMessage）
+    const goalMatch = text.match(/^\/goal\s*(.*)$/i)
+    if (goalMatch) {
+      const arg = goalMatch[1].trim()
+      if (!arg) {
+        // /goal 无参 = 查询状态，本地输出，不改变跟踪
+      } else if (/^(clear|stop|off|reset|none|cancel)$/i.test(arg)) {
+        hub.goal = undefined
+      } else {
+        hub.goal = { condition: arg, since: Date.now() }
+      }
+      hubServices().pushStatus(hub)
+    }
+    // 记录首条真实 user 消息作为标题素材（斜杠首消息不算会话主题，跳过）；
+    // 实际触发在 maybeGenerateTitle——需要 sessionId（init 可能尚未到达）。
+    // 条件显式写：titleGeneratedFor 与 sessionId 同 undefined 时也必须放行（全新 Hub）
+    if (text.trim() && !text.startsWith('/') && !(hub.titleGeneratedFor && hub.titleGeneratedFor === hub.sessionId)) {
+      hub.pendingTitleText ??= text
+      this.maybeGenerateTitle(hub)
+    }
+  }
+
+  /**
+   * 官方 AI 标题（generate_session_title）：首条真实 user 消息 × 首个 init 双条件齐备即触发。
+   * 两路调用——user 消息时（sessionId 已知）与 init 到达时（消息已记账）；按 sessionId 去重，
+   * /clear 重键后的新会话自然再生成一次。CLI persist 把 ai-title 写进 transcript，
+   * discovery 标题链（custom-title > ai-title > summary > 首条消息）自动接住，列表轮询内出现。
+   */
+  maybeGenerateTitle(hub: Hub): void {
+    const sid = hub.sessionId
+    const text = hub.pendingTitleText
+    if (!sid || !text || hub.titleGeneratedFor === sid) return
+    const s = processManager.get(hub.key)
+    if (!s) return
+    hub.titleGeneratedFor = sid
+    hub.pendingTitleText = undefined
+    void s
+      .generateSessionTitle(text)
+      .then((title) => {
+        if (title) log.info(`[title] ${hubServices().sessionNameOf(hub.key)} → ${title}`)
+      })
+      .catch(() => {}) // 标题失败无害：列表回退首条消息摘要
+  }
+
+  // ---------- transcript tailer（外部会话实时跟踪） ----------
+
+  stopTailer(hub: Hub): void {
+    hub.tailer?.stop()
+    hub.tailer = undefined
+  }
+
+  private throttledTailStatus(hub: Hub): void {
+    const now = Date.now()
+    if (now - (hub.tailStatusAt ?? 0) < 2000) return
+    hub.tailStatusAt = now
+    hubServices().pushStatus(hub)
+  }
+
+  startTailer(hub: Hub, from?: number): void {
+    if (hub.tailer) return
+    const ek = splitExistingKey(hub.key)
+    if (!ek) return // 新会话还没有 transcript
+    if (processManager.get(hub.key)) return // 已 spawn：live 流覆盖，无需 tail
+    const path = join(config.claudeConfigDir, 'projects', ek.slug, `${ek.sessionId}.jsonl`)
+    hub.tailer = new TranscriptTailer(path, from, {
+      onMessage: (msg) => {
+        hubServices().broadcast(hub, { kind: 'tail', msg })
+        this.throttledTailStatus(hub)
+      },
+      onReset: () => {
+        this.stopTailer(hub)
+        hubServices().broadcast(hub, { kind: 'tail_reset' })
+        hubServices().pushStatus(hub)
+      },
+      onTick: () => this.throttledTailStatus(hub),
+    })
+    hub.tailer.start()
+    hubServices().pushStatus(hub)
+  }
+
+  // ---------- 回滚 ----------
+
+  rewindConversation(hub: Hub, userMessageId: string): void {
+    if (hubServices().rewindBusy(hub)) return
+    this.rewindConversationAt(hub, userMessageId, 'conversation')
+  }
+
+  rewindBoth(hub: Hub, at: string): void {
+    if (hubServices().rewindBusy(hub)) return
+    const s = this.sessionForSend(hub)
+    if (!s) return
+
+    // 官方 TUI 的“恢复代码和对话”也是两个动作。这里必须先收到文件
+    // checkpoint 成功响应，才允许销毁旧进程并以 resume-session-at 截断对话。
+    // rewind_files 没有 CLI 侧超时，大项目恢复可达分钟级，给足 120s。
+    hub.rewindPending = true
+    hubServices().pushStatus(hub, { rewindPending: true })
+    void s.sendControlAndWait('rewind_files', { user_message_id: at }, 120_000)
+      .then(() => {
+        if (processManager.get(hub.key) !== s || s.exited) {
+          hubServices().broadcastError(hub, '恢复文件后会话已变化，未回滚对话')
+          return
+        }
+        this.rewindConversationAt(hub, at, 'both')
+      })
+      .catch((error) => {
+        hubServices().broadcastError(hub, `回滚文件失败，未回滚对话：${errorMessage(error)}`)
+      })
+      .finally(() => {
+        hub.rewindPending = false
+        hubServices().pushStatus(hub, { rewindPending: false })
+      })
+  }
+
+  private rewindConversationAt(hub: Hub, userMessageId: string, scope: 'conversation' | 'both'): void {
+    const current = processManager.get(hub.key)
+    const parsed = parseKey(hub.key)
+    const sid = current?.sessionId ?? parsed?.resumeSessionId
+    if (!parsed || !sid) {
+      hubServices().broadcastError(hub, '无法回滚：未知会话 ID')
+      return
+    }
+    // 先从 map 摘掉再 kill，避免旧 onExit 污染新会话。
+    processManager.dispose(hub.key)
+    hub.spawnOpts = { ...hub.spawnOpts, cwd: parsed.cwd, resumeSessionId: sid, resumeSessionAt: userMessageId }
+    this.ensureSpawned(hub, undefined, parsed)
+    const respawned = processManager.get(hub.key)
+    if (!respawned || respawned.exited) {
+      // ensureSpawned 已广播具体的 spawn 错误；不能向客户端虚报回滚成功。
+      return
+    }
+    hubServices().broadcast(hub, { kind: 'rewound', userMessageId, scope })
+  }
+
+  // ---------- 消息域 ----------
+
+  deliverControl(hub: Hub, subtype: string, extra: Record<string, unknown>): void {
+    const { broadcastError, pushStatus } = hubServices()
+    // 中断：未启动则无需操作
+    if (subtype === 'interrupt') {
+      const s = processManager.get(hub.key)
+      if (s && !s.exited) {
+        try {
+          s.sendControl(subtype, extra)
+        } catch (e) {
+          broadcastError(hub, `中断失败: ${errorMessage(e)}`)
+        }
+        pushStatus(hub)
+      }
+      return
+    }
+    let s = processManager.get(hub.key)
+    if (!s || s.exited) {
+      if (subtype === 'set_model' || subtype === 'set_permission_mode') {
+        pushStatus(hub)
+        return
+      }
+      // 其他控制可能没有 CLI 参数等价物，仍需进程承接。
+      this.ensureSpawned(hub)
+      s = processManager.get(hub.key)
+    }
+    if (!s || s.exited) return
+    try {
+      s.sendControl(subtype, extra)
+      pushStatus(hub)
+    } catch (e) {
+      broadcastError(hub, `控制请求失败: ${errorMessage(e)}`)
+      pushStatus(hub)
+    }
+  }
+
+  updateEnv(hub: Hub, variables: Record<string, string>): void {
+    const { broadcastError, pushStatus } = hubServices()
+    const otherVariables = Object.fromEntries(
+      Object.entries(variables).filter(([key]) => key !== 'CLAUDE_CODE_EFFORT_LEVEL'),
+    )
+    const s = processManager.get(hub.key)
+    if (!s || s.exited) {
+      if (Object.keys(otherVariables).length > 0) {
+        hub.pendingEnv = { ...hub.pendingEnv, ...otherVariables }
+      }
+      pushStatus(hub)
+      return
+    }
+    try {
+      s.write({ type: 'update_environment_variables', variables })
+      pushStatus(hub)
+    } catch (e) {
+      broadcastError(hub, `更新环境变量失败: ${errorMessage(e)}`)
+      pushStatus(hub)
+    }
+  }
+
+  /** 分叉当前会话：懒分叉（b| key，首条消息才 --fork-session） */
+  branch(hub: Hub, name: string): void {
+    const { broadcast, broadcastError, getHub } = hubServices()
+    const parsed = parseKey(hub.key)
+    const srcSid =
+      processManager.get(hub.key)?.sessionId ?? parsed?.resumeSessionId ?? parsed?.forkFromSessionId
+    if (!parsed || !srcSid) {
+      broadcastError(hub, '分叉需要已有会话（先发过至少一条消息）')
+      return
+    }
+    const branchKey = keyForBranch(parsed.cwd, srcSid)
+    // 预建 Hub 并缓存分叉源：首条 user 消息 ensureSpawned 时经 parseKey 拿到 forkFromSessionId
+    const branchHub = getHub(branchKey)
+    // /branch <名字>：透传给分叉 spawn 的 -n（列表页可区分分支用途）
+    const branchName = name.trim()
+    if (branchName) branchHub.spawnOpts = { ...branchHub.spawnOpts, sessionName: branchName }
+    broadcast(hub, { kind: 'forked', targetKey: branchKey, branchOf: srcSid, ...(branchName ? { name: branchName } : {}) })
+  }
+
+  /** 官方 side_question 控制通道（进程内轻量 fork，共享 prompt cache，
+   *  不产生磁盘 FORK 会话）。无流式增量，应答单次返回。 */
+  btw(hub: Hub, question: string): void {
+    const { broadcast } = hubServices()
+    const parsed = parseKey(hub.key)
+    const sid =
+      processManager.get(hub.key)?.sessionId ?? parsed?.resumeSessionId ?? parsed?.forkFromSessionId
+    if (!question || !parsed || !sid) {
+      broadcast(hub, { kind: 'btw_result', ok: false, question, text: '侧问需要已有会话（先发过至少一条消息）' })
+      return
+    }
+    const s = this.sessionForSend(hub)
+    if (!s) return // ensureSpawned 已广播具体错误
+    s.sideQuestion(question)
+      .then((text) => broadcast(hub, { kind: 'btw_result', ok: true, question, text }))
+      .catch((e) =>
+        broadcast(hub, { kind: 'btw_result', ok: false, question, text: `侧问失败: ${errorMessage(e)}` }),
+      )
+  }
+
+  query(
+    hub: Hub,
+    query: string,
+    extra: Record<string, unknown>,
+    reply: (payload: Record<string, unknown>) => void,
+  ): void {
+    const s = this.sessionForSend(hub)
+    if (!s) {
+      reply({ ok: false, error: '进程未运行' })
+      return
+    }
+    // 重连/启用是完整 MCP 握手，慢于普通查询，给足超时
+    const timeoutMs = query === 'mcp_reconnect' || query === 'mcp_toggle' ? 30_000 : 15_000
+    s.sendControlAndWait(query, extra, timeoutMs)
+      .then((d) => reply({ ok: true, data: d }))
+      .catch((e) => reply({ ok: false, error: errorMessage(e) }))
+  }
+
+  // ---------- handoff（接力） ----------
+
+  handoffSource(key: string): { cwd?: string; sourceId?: string } {
+    const parsed = parseKey(key)
+    return { cwd: parsed?.cwd, sourceId: processManager.get(key)?.sessionId ?? parsed?.resumeSessionId }
+  }
+
+  async handoffCwdOf(key: string, _sourceId: string): Promise<string | undefined> {
+    return parseKey(key)?.cwd
+  }
+
+  async forkBriefForHandoff(
+    fromKey: string,
+    cwd: string,
+    sourceId: string,
+    detail: HandoffDetail,
+  ): Promise<{ text: string; usage?: Record<string, number> }> {
+    // claude 源在线时走 side_question 控制通道（进程内 fork，零冷启动、不留 FORK 会话）；
+    // 离线才 spawn 一次性 --fork-session --bare 进程
+    const live = processManager.get(fromKey)
+    if (live && !live.exited) {
+      try {
+        const text = await live.sideQuestion(briefPrompt(detail))
+        if (text.trim()) return { text, usage: undefined }
+      } catch {
+        // side_question 失败回落 fork spawn（如 CLI 版本过旧无此通道）
+      }
+    }
+    return generateClaudeBrief(cwd, sourceId, detail)
+  }
+
+  async seedHandoffTarget(hub: Hub, seed: string): Promise<string | undefined> {
+    this.ensureSpawned(hub)
+    const s = processManager.get(hub.key)
+    if (!s || s.exited) throw new Error('目标 claude 会话启动失败')
+    s.sendUserText(seed)
+    // claude 的 sessionId 在 init 时才就绪：短轮询等待，随后回填真实 key（血缘导航用）
+    if (!s.sessionId) {
+      const deadline = Date.now() + 30_000
+      // 每轮重新取句柄：等待期间旧进程可能退出并被重生，旧引用拿不到新 sessionId
+      for (;;) {
+        const cur = processManager.get(hub.key)
+        if (!cur || cur.sessionId || cur.exited || Date.now() >= deadline) {
+          return cur?.sessionId
+        }
+        await Bun.sleep(500)
+      }
+    }
+    return s.sessionId
   }
 }
 

--- a/server/src/backends/claude/port.ts
+++ b/server/src/backends/claude/port.ts
@@ -1,0 +1,55 @@
+// claude 后端适配器：把 processManager/discovery 的能力包装成 BackendPort。
+// 方法体多为 index.ts 原 claude 分支的逐字搬迁——重构红线是零行为改动。
+
+import { hydratedContextOf, splitExistingKey } from './backend'
+import { liveSessionInfo } from './discovery'
+import { processManager } from './processManager'
+import { baseStatusOf, type BackendPort, type SessionHandle, type StatusContext } from '../port'
+
+class ClaudePort implements BackendPort {
+  readonly name = 'claude' as const
+
+  sessionOf(key: string): SessionHandle | undefined {
+    return processManager.get(key)
+  }
+
+  hasLiveSession(key: string): boolean {
+    return !!processManager.get(key)
+  }
+
+  notifyExternalGate(key: string): void {
+    processManager.get(key)?.notifyExternalGate()
+  }
+
+  statusOf(key: string, cx: StatusContext): Record<string, unknown> {
+    const s = processManager.get(key)
+    const hub = cx.hub
+    const pending = hub?.pendingApprovals.size ?? 0
+    // 未被本服务 spawn 的会话：读 pid 文件，把外部 CLI 的实时状态反映到 busy/waiting
+    let live: { status: string; pid: number } | undefined
+    if (!s || s.exited) {
+      const ek = splitExistingKey(key)
+      if (ek) live = cx.liveHint === undefined ? liveSessionInfo(ek.sessionId) : (cx.liveHint ?? undefined)
+    }
+    const waiting = (s?.waiting ?? false) || pending > 0 || live?.status === 'waiting'
+    const st = baseStatusOf(s, hub, waiting)
+    if (live?.status === 'busy') st.busy = true // 审批等待与外部进程 busy 都算 busy，防止误回收
+    // 离线/未 spawn 水合：直读 transcript 尾部，点开会话即有上下文环形（无需先发消息）；
+    // live 值存在时恒优先（spawn 内水合与实时跟踪是同源数据的更新版）
+    if (cx.hydrateContext && st.context == null) st.context = hydratedContextOf(key)
+    return {
+      ...st,
+      activeTaskCount: s?.activeTaskCount ?? 0,
+      activeTasks: s?.backgroundTasks ?? [],
+      slashCommands: s?.slashCommands,
+      // spawnOpts.model 是用户显式选择（未 spawn 时的待应用值）；initModel 是进程 init 报告的解析后 ID。
+      // 后者让重连 attach 的页面不必等下一轮就能显示模型（StatusPill 再经 modelNames 映射成配置名）
+      model: hub?.spawnOpts?.model ?? s?.initModel,
+      tailing: !!hub?.tailer,
+      liveStatus: live?.status,
+      goal: hub?.goal ?? null,
+    }
+  }
+}
+
+export const claudePort = new ClaudePort()

--- a/server/src/backends/claude/port.ts
+++ b/server/src/backends/claude/port.ts
@@ -1,7 +1,9 @@
 // claude 后端适配器：把 processManager/discovery 的能力包装成 BackendPort。
 // 方法体多为 index.ts 原 claude 分支的逐字搬迁——重构红线是零行为改动。
 
+import { appendFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { archiveClaudeSession, restoreClaudeSession } from '../../archive'
 import { config, defaultPermissionMode } from '../../config'
 import { briefPrompt, generateClaudeBrief, type HandoffDetail } from '../../handoff'
 import { log } from '../../log'
@@ -11,6 +13,7 @@ import {
   baseStatusOf,
   hubServices,
   type BackendPort,
+  type RouteResult,
   type SessionHandle,
   type StatusContext,
 } from '../port'
@@ -448,6 +451,52 @@ class ClaudePort implements BackendPort {
       }
     }
     return s.sessionId
+  }
+
+  // ---------- REST 管理面（归档/恢复/改名） ----------
+
+  async archive(key: string): Promise<RouteResult> {
+    const ek = splitExistingKey(key)
+    if (!ek) return { ok: false, error: '仅支持已有会话', status: 400 }
+    try {
+      if (processManager.get(key) || liveSessionInfo(ek.sessionId)) {
+        return { ok: false, error: '会话正在运行，无法归档', status: 409 }
+      }
+      archiveClaudeSession(ek.slug, ek.sessionId)
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: errorMessage(e), status: 500 }
+    }
+  }
+
+  async restore(key: string): Promise<RouteResult> {
+    const ek = splitExistingKey(key)
+    if (!ek) return { ok: false, error: '仅支持 claude 会话恢复', status: 400 }
+    try {
+      restoreClaudeSession(ek.slug, ek.sessionId)
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: errorMessage(e), status: 500 }
+    }
+  }
+
+  /** 仅离线会话（在线会话的 transcript 由 CLI 持有，改名走其内部路径） */
+  async rename(key: string, title: string): Promise<RouteResult> {
+    const ek = splitExistingKey(key)
+    if (!ek) return { ok: false, error: '仅支持已有 claude 会话', status: 400 }
+    const { slug, sessionId } = ek
+    if (processManager.get(key) || liveSessionInfo(sessionId)) {
+      return { ok: false, error: '会话正在运行，请在 CLI 退出后改名', status: 409 }
+    }
+    const file = join(config.claudeConfigDir, 'projects', slug, `${sessionId}.jsonl`)
+    if (!existsSync(file)) return { ok: false, error: 'transcript 不存在', status: 404 }
+    try {
+      // 与官方 /rename 相同的条目形状；discovery 读取时后者优先
+      appendFileSync(file, JSON.stringify({ type: 'custom-title', sessionId, customTitle: title }) + '\n')
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: errorMessage(e), status: 500 }
+    }
   }
 }
 

--- a/server/src/backends/claude/port.ts
+++ b/server/src/backends/claude/port.ts
@@ -8,7 +8,7 @@ import { config, defaultPermissionMode } from '../../config'
 import { briefPrompt, generateClaudeBrief, type HandoffDetail } from '../../handoff'
 import { log } from '../../log'
 import { errorMessage } from '../../util'
-import type { Hub } from '../../index'
+import type { Hub } from '../../hub/types'
 import {
   baseStatusOf,
   hubServices,

--- a/server/src/backends/claude/port.ts
+++ b/server/src/backends/claude/port.ts
@@ -3,7 +3,7 @@
 
 import { appendFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { archiveClaudeSession, restoreClaudeSession } from '../../archive'
+import { archiveClaudeSession, listTrash, restoreClaudeSession } from '../../archive'
 import { config, defaultPermissionMode } from '../../config'
 import { briefPrompt, generateClaudeBrief, type HandoffDetail } from '../../handoff'
 import { log } from '../../log'
@@ -11,7 +11,10 @@ import { errorMessage } from '../../util'
 import type { Hub } from '../../hub/types'
 import {
   baseStatusOf,
+  btwDeliver,
+  btwRejectNoSession,
   hubServices,
+  type ArchivedEntry,
   type BackendPort,
   type RouteResult,
   type SessionHandle,
@@ -367,21 +370,16 @@ class ClaudePort implements BackendPort {
   /** 官方 side_question 控制通道（进程内轻量 fork，共享 prompt cache，
    *  不产生磁盘 FORK 会话）。无流式增量，应答单次返回。 */
   btw(hub: Hub, question: string): void {
-    const { broadcast } = hubServices()
     const parsed = parseKey(hub.key)
     const sid =
       processManager.get(hub.key)?.sessionId ?? parsed?.resumeSessionId ?? parsed?.forkFromSessionId
     if (!question || !parsed || !sid) {
-      broadcast(hub, { kind: 'btw_result', ok: false, question, text: '侧问需要已有会话（先发过至少一条消息）' })
+      btwRejectNoSession(hub, question)
       return
     }
     const s = this.sessionForSend(hub)
     if (!s) return // ensureSpawned 已广播具体错误
-    s.sideQuestion(question)
-      .then((text) => broadcast(hub, { kind: 'btw_result', ok: true, question, text }))
-      .catch((e) =>
-        broadcast(hub, { kind: 'btw_result', ok: false, question, text: `侧问失败: ${errorMessage(e)}` }),
-      )
+    btwDeliver(hub, question, () => s.sideQuestion(question))
   }
 
   query(
@@ -497,6 +495,18 @@ class ClaudePort implements BackendPort {
     } catch (e) {
       return { ok: false, error: errorMessage(e), status: 500 }
     }
+  }
+
+  /** claude 无官方归档概念：回收站即 ~/.anyplane/trash/claude/ 的 transcript 迁移记录 */
+  async listArchived(): Promise<ArchivedEntry[]> {
+    return listTrash().map((t) => ({
+      key: t.key,
+      sessionId: t.sessionId,
+      slug: t.slug,
+      backend: 'claude' as const,
+      trashedAt: t.trashedAt,
+      sizeBytes: t.sizeBytes,
+    }))
   }
 }
 

--- a/server/src/backends/codex/backend.ts
+++ b/server/src/backends/codex/backend.ts
@@ -77,6 +77,15 @@ export async function listSessions(): Promise<SessionSummary[]> {
   return rows
 }
 
+/** 归档线程列表（/api/sessions/archived）：与活跃列表共用 toSummary 唯一映射，
+ *  避免 wire 形状变化时两处漂移。不走 listSessions 的 TTL 缓存——归档页低频。 */
+export async function listArchivedSessions(): Promise<SessionSummary[]> {
+  const res = (await codexRuntime.rpcRequest('thread/list', { archived: true, limit: 100 })) as {
+    data?: ThreadRow[]
+  }
+  return (res.data ?? []).map(toSummary)
+}
+
 export function readHistory(threadId: string): Promise<HistoryMessage[]> {
   return codexRuntime.readHistory(threadId)
 }

--- a/server/src/backends/codex/port.ts
+++ b/server/src/backends/codex/port.ts
@@ -1,8 +1,20 @@
 // codex 后端适配器：把 codexRuntime 的能力包装成 BackendPort。
 // 方法体多为 index.ts 原 codex 分支的逐字搬迁——重构红线是零行为改动。
 
-import { baseStatusOf, type BackendPort, type SessionHandle, type StatusContext } from '../port'
-import { codexRuntime } from './runtime'
+import { defaultPermissionMode } from '../../config'
+import { generateCodexBrief, type HandoffDetail } from '../../handoff'
+import { errorMessage } from '../../util'
+import type { Hub } from '../../index'
+import {
+  baseStatusOf,
+  hubServices,
+  type BackendPort,
+  type SessionHandle,
+  type StatusContext,
+} from '../port'
+import type { SpawnOptions } from '../types'
+import { parseKey as codexParseKey } from './backend'
+import { codexRuntime, type CodexSession } from './runtime'
 
 class CodexPort implements BackendPort {
   readonly name = 'codex' as const
@@ -32,6 +44,173 @@ class CodexPort implements BackendPort {
       tailing: false,
       goal: s?.goal ?? null,
     }
+  }
+
+  // ---------- 生命周期 ----------
+
+  onAttach(hub: Hub, msg: Record<string, unknown>): void {
+    // x| 会话 attach 即 resume（订阅实时事件）；xn| 新会话保持懒启动
+    if (msg.warm === true || msg.opts || hub.key.startsWith('x|')) {
+      void this.ensure(hub, msg.opts as Partial<SpawnOptions> | undefined)
+    } else {
+      hubServices().pushStatus(hub)
+    }
+  }
+
+  /** 原 index.ts ensureCodexSession：attach(x|) 或首条 user 消息时 resume/start 线程 */
+  async ensure(hub: Hub, opts?: Partial<SpawnOptions>): Promise<CodexSession | undefined> {
+    const parsed = codexParseKey(hub.key)
+    if (!parsed) {
+      hubServices().broadcastError(hub, '无法解析 codex 会话 key')
+      return undefined
+    }
+    const spawnOpts = {
+      cwd: parsed.cwd,
+      resumeThreadId: parsed.resumeThreadId,
+      permissionMode: defaultPermissionMode(),
+      ...hub.spawnOpts,
+      ...opts,
+    }
+    hub.spawnOpts = spawnOpts
+    const s = codexRuntime.ensure(hub.key, spawnOpts, hubServices().sessionCallbacks(hub))
+    s.syncClients(hub.clients.size)
+    try {
+      await s.start()
+    } catch (e) {
+      hubServices().broadcastError(hub, errorMessage(e))
+      hubServices().pushStatus(hub)
+      return undefined
+    }
+    hubServices().pushStatus(hub)
+    return s
+  }
+
+  async ensureForSend(hub: Hub): Promise<SessionHandle | undefined> {
+    let s = codexRuntime.get(hub.key)
+    if (!s || s.exited || !s.sessionId) {
+      s = (await this.ensure(hub)) as CodexSession | undefined
+    }
+    if (!s || s.exited) return undefined // ensure 已广播具体错误
+    return s
+  }
+
+  // 无出站 /goal 跟踪与 AI 标题通道（codex 的 goal 由 thread/goal/* 通知驱动）
+  maybeGenerateTitle(_hub: Hub): void {}
+
+  // codex 的实时流走 app-server 订阅，无 tailer 概念
+  startTailer(_hub: Hub, _from?: number): void {}
+  stopTailer(_hub: Hub): void {}
+
+  /** codex：分叉语义——thread/fork(beforeTurnId) 复制该轮之前的历史为新线程，
+   *  原线程不动。userMessageId 即历史的轮首 userMessage 的 turnId。 */
+  rewindConversation(hub: Hub, at: string): void {
+    const tid = codexRuntime.get(hub.key)?.sessionId ?? codexParseKey(hub.key)?.resumeThreadId
+    if (!tid) {
+      hubServices().broadcastError(hub, 'codex 会话未就绪，无法分叉')
+      return
+    }
+    void codexRuntime
+      .forkAt(tid, at)
+      .then((newId) => {
+        hubServices().broadcast(hub, {
+          kind: 'forked',
+          targetKey: `x|${newId}`,
+          targetSessionId: newId,
+          fromTurnId: at,
+        })
+      })
+      .catch((e) => hubServices().broadcastError(hub, `分叉失败: ${errorMessage(e)}`))
+  }
+
+  rewindBoth(hub: Hub, _at: string): void {
+    hubServices().broadcastError(hub, 'Codex 没有文件检查点，不支持文件回滚（可用 git 管理代码历史）')
+  }
+
+  // ---------- 消息域 ----------
+
+  /** interrupt/set_model/set_permission_mode/compact 直接翻译；其余控制请求暂无对应物 */
+  deliverControl(hub: Hub, subtype: string, extra: Record<string, unknown>): void {
+    const s = codexRuntime.get(hub.key)
+    if (s && !s.exited) {
+      s.sendControl(subtype, extra)
+    }
+    hubServices().pushStatus(hub)
+  }
+
+  /** 映射为 reasoning effort（CodexSession.write 内部翻译） */
+  updateEnv(hub: Hub, variables: Record<string, string>): void {
+    const s = codexRuntime.get(hub.key)
+    if (s && !s.exited) {
+      s.write({ type: 'update_environment_variables', variables })
+    }
+    hubServices().pushStatus(hub)
+  }
+
+  branch(hub: Hub, _name: string): void {
+    // codex 走既有 thread/fork（RewindPicker 的"从此处分叉"）
+    hubServices().broadcastError(hub, 'Codex 请用回滚面板的「从此处分叉」')
+  }
+
+  btw(hub: Hub, question: string): void {
+    const { broadcast } = hubServices()
+    const parsed = codexParseKey(hub.key)
+    const tid = codexRuntime.get(hub.key)?.sessionId ?? parsed?.resumeThreadId
+    if (!question || !tid) {
+      broadcast(hub, { kind: 'btw_result', ok: false, question, text: '侧问需要已有会话（先发过至少一条消息）' })
+      return
+    }
+    void codexRuntime
+      .runEphemeralQuestion(tid, question, 180_000, (delta, thinking) => {
+        broadcast(hub, { kind: 'btw_delta', question, delta, thinking: thinking || undefined })
+      })
+      .then((r) => broadcast(hub, { kind: 'btw_result', ok: true, question, text: r.text }))
+      .catch((e) =>
+        broadcast(hub, { kind: 'btw_result', ok: false, question, text: `侧问失败: ${errorMessage(e)}` }),
+      )
+  }
+
+  query(
+    hub: Hub,
+    query: string,
+    _extra: Record<string, unknown>,
+    reply: (payload: Record<string, unknown>) => void,
+  ): void {
+    // codex 仅 mcp_status 有对应物 mcpServerStatus/list（动作类一律拒绝）
+    if (query !== 'mcp_status') {
+      reply({ ok: false, error: `codex 后端暂不支持 ${query}` })
+      return
+    }
+    void codexRuntime
+      .rpcRequest('mcpServerStatus/list', {})
+      .then((d) => reply({ ok: true, data: d }))
+      .catch((e) => reply({ ok: false, error: errorMessage(e) }))
+  }
+
+  // ---------- handoff（接力） ----------
+
+  handoffSource(key: string): { cwd?: string; sourceId?: string } {
+    const parsed = codexParseKey(key)
+    return { cwd: parsed?.cwd, sourceId: parsed?.resumeThreadId }
+  }
+
+  async handoffCwdOf(_key: string, sourceId: string): Promise<string | undefined> {
+    return codexRuntime.threadCwd(sourceId)
+  }
+
+  async forkBriefForHandoff(
+    _fromKey: string,
+    _cwd: string,
+    sourceId: string,
+    detail: HandoffDetail,
+  ): Promise<{ text: string; usage?: Record<string, number> }> {
+    return generateCodexBrief(sourceId, detail)
+  }
+
+  async seedHandoffTarget(hub: Hub, seed: string): Promise<string | undefined> {
+    const s = await this.ensure(hub)
+    if (!s || s.exited) throw new Error('目标 codex 会话启动失败')
+    s.sendUserText(seed)
+    return s.sessionId
   }
 }
 

--- a/server/src/backends/codex/port.ts
+++ b/server/src/backends/codex/port.ts
@@ -1,0 +1,38 @@
+// codex 后端适配器：把 codexRuntime 的能力包装成 BackendPort。
+// 方法体多为 index.ts 原 codex 分支的逐字搬迁——重构红线是零行为改动。
+
+import { baseStatusOf, type BackendPort, type SessionHandle, type StatusContext } from '../port'
+import { codexRuntime } from './runtime'
+
+class CodexPort implements BackendPort {
+  readonly name = 'codex' as const
+
+  sessionOf(key: string): SessionHandle | undefined {
+    return codexRuntime.get(key)
+  }
+
+  hasLiveSession(key: string): boolean {
+    const s = codexRuntime.get(key)
+    return !!s && !s.exited
+  }
+
+  // 外部门禁（control.sock 生态）是 claude-only 概念；codex 无对应物
+  notifyExternalGate(_key: string): void {}
+
+  /** 与 claude 适配器的 statusOf 同形，供列表 managed 字段与 WS status 复用 */
+  statusOf(key: string, cx: StatusContext): Record<string, unknown> {
+    const s = codexRuntime.get(key)
+    const hub = cx.hub
+    const waiting = (s?.waiting ?? false) || (hub?.pendingApprovals.size ?? 0) > 0
+    return {
+      ...baseStatusOf(s, hub, waiting),
+      // 不下发 activeTasks/activeTaskCount：codex 服务端不维护任务表，恒空数组会被
+      // hydrateTasks 误读为"权威空"而在空闲时判死 live 桶；字段缺席则前端跳过水合
+      model: hub?.spawnOpts?.model,
+      tailing: false,
+      goal: s?.goal ?? null,
+    }
+  }
+}
+
+export const codexPort = new CodexPort()

--- a/server/src/backends/codex/port.ts
+++ b/server/src/backends/codex/port.ts
@@ -9,11 +9,12 @@ import {
   baseStatusOf,
   hubServices,
   type BackendPort,
+  type RouteResult,
   type SessionHandle,
   type StatusContext,
 } from '../port'
 import type { SpawnOptions } from '../types'
-import { parseKey as codexParseKey } from './backend'
+import { parseKey as codexParseKey, splitThreadId } from './backend'
 import { codexRuntime, type CodexSession } from './runtime'
 
 class CodexPort implements BackendPort {
@@ -211,6 +212,41 @@ class CodexPort implements BackendPort {
     if (!s || s.exited) throw new Error('目标 codex 会话启动失败')
     s.sendUserText(seed)
     return s.sessionId
+  }
+
+  // ---------- REST 管理面（官方 RPC：loaded/stored thread 均可） ----------
+
+  async archive(key: string): Promise<RouteResult> {
+    const threadId = splitThreadId(key)
+    if (!threadId) return { ok: false, error: '无法解析 threadId', status: 400 }
+    try {
+      await codexRuntime.rpcRequest('thread/archive', { threadId })
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: errorMessage(e), status: 500 }
+    }
+  }
+
+  async restore(key: string): Promise<RouteResult> {
+    const threadId = splitThreadId(key)
+    if (!threadId) return { ok: false, error: '无法解析 threadId', status: 400 }
+    try {
+      await codexRuntime.rpcRequest('thread/unarchive', { threadId })
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: errorMessage(e), status: 500 }
+    }
+  }
+
+  async rename(key: string, title: string): Promise<RouteResult> {
+    const threadId = splitThreadId(key)
+    if (!threadId) return { ok: false, error: '无法解析 threadId', status: 400 }
+    try {
+      await codexRuntime.rpcRequest('thread/name/set', { threadId, name: title })
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: errorMessage(e), status: 500 }
+    }
   }
 }
 

--- a/server/src/backends/codex/port.ts
+++ b/server/src/backends/codex/port.ts
@@ -4,7 +4,7 @@
 import { defaultPermissionMode } from '../../config'
 import { generateCodexBrief, type HandoffDetail } from '../../handoff'
 import { errorMessage } from '../../util'
-import type { Hub } from '../../index'
+import type { Hub } from '../../hub/types'
 import {
   baseStatusOf,
   hubServices,

--- a/server/src/backends/codex/port.ts
+++ b/server/src/backends/codex/port.ts
@@ -3,18 +3,22 @@
 
 import { defaultPermissionMode } from '../../config'
 import { generateCodexBrief, type HandoffDetail } from '../../handoff'
+import { log } from '../../log'
 import { errorMessage } from '../../util'
 import type { Hub } from '../../hub/types'
 import {
   baseStatusOf,
+  btwDeliver,
+  btwRejectNoSession,
   hubServices,
+  type ArchivedEntry,
   type BackendPort,
   type RouteResult,
   type SessionHandle,
   type StatusContext,
 } from '../port'
 import type { SpawnOptions } from '../types'
-import { parseKey as codexParseKey, splitThreadId } from './backend'
+import { listArchivedSessions, parseKey as codexParseKey, splitThreadId } from './backend'
 import { codexRuntime, type CodexSession } from './runtime'
 
 class CodexPort implements BackendPort {
@@ -153,21 +157,18 @@ class CodexPort implements BackendPort {
   }
 
   btw(hub: Hub, question: string): void {
-    const { broadcast } = hubServices()
     const parsed = codexParseKey(hub.key)
     const tid = codexRuntime.get(hub.key)?.sessionId ?? parsed?.resumeThreadId
     if (!question || !tid) {
-      broadcast(hub, { kind: 'btw_result', ok: false, question, text: '侧问需要已有会话（先发过至少一条消息）' })
+      btwRejectNoSession(hub, question)
       return
     }
-    void codexRuntime
-      .runEphemeralQuestion(tid, question, 180_000, (delta, thinking) => {
-        broadcast(hub, { kind: 'btw_delta', question, delta, thinking: thinking || undefined })
+    btwDeliver(hub, question, async () => {
+      const r = await codexRuntime.runEphemeralQuestion(tid, question, 180_000, (delta, thinking) => {
+        hubServices().broadcast(hub, { kind: 'btw_delta', question, delta, thinking: thinking || undefined })
       })
-      .then((r) => broadcast(hub, { kind: 'btw_result', ok: true, question, text: r.text }))
-      .catch((e) =>
-        broadcast(hub, { kind: 'btw_result', ok: false, question, text: `侧问失败: ${errorMessage(e)}` }),
-      )
+      return r.text
+    })
   }
 
   query(
@@ -216,36 +217,48 @@ class CodexPort implements BackendPort {
 
   // ---------- REST 管理面（官方 RPC：loaded/stored thread 均可） ----------
 
-  async archive(key: string): Promise<RouteResult> {
+  /** thread 管理 RPC 共享核：splitThreadId 守卫 + rpcRequest + RouteResult 信封只有一份，
+   *  守卫措辞或错误映射（如 -32600 线程被占用）修订时三处管理端点不会分叉 */
+  private async threadRpc(key: string, method: string, params: Record<string, unknown>): Promise<RouteResult> {
     const threadId = splitThreadId(key)
     if (!threadId) return { ok: false, error: '无法解析 threadId', status: 400 }
     try {
-      await codexRuntime.rpcRequest('thread/archive', { threadId })
+      await codexRuntime.rpcRequest(method, { threadId, ...params })
       return { ok: true }
     } catch (e) {
       return { ok: false, error: errorMessage(e), status: 500 }
     }
   }
 
-  async restore(key: string): Promise<RouteResult> {
-    const threadId = splitThreadId(key)
-    if (!threadId) return { ok: false, error: '无法解析 threadId', status: 400 }
-    try {
-      await codexRuntime.rpcRequest('thread/unarchive', { threadId })
-      return { ok: true }
-    } catch (e) {
-      return { ok: false, error: errorMessage(e), status: 500 }
-    }
+  archive(key: string): Promise<RouteResult> {
+    return this.threadRpc(key, 'thread/archive', {})
   }
 
-  async rename(key: string, title: string): Promise<RouteResult> {
-    const threadId = splitThreadId(key)
-    if (!threadId) return { ok: false, error: '无法解析 threadId', status: 400 }
+  restore(key: string): Promise<RouteResult> {
+    return this.threadRpc(key, 'thread/unarchive', {})
+  }
+
+  rename(key: string, title: string): Promise<RouteResult> {
+    return this.threadRpc(key, 'thread/name/set', { name: title })
+  }
+
+  /** codex 归档列表：复用 backend 的 toSummary 唯一映射；RPC 失败降级空数组不拖垮 claude trash */
+  async listArchived(): Promise<ArchivedEntry[]> {
     try {
-      await codexRuntime.rpcRequest('thread/name/set', { threadId, name: title })
-      return { ok: true }
+      const rows = await listArchivedSessions()
+      return rows.map((s) => ({
+        key: s.key,
+        sessionId: s.id,
+        slug: 'codex',
+        backend: 'codex' as const,
+        title: s.title,
+        lastPrompt: s.lastPrompt,
+        cwd: s.cwd,
+        mtime: s.mtime,
+      }))
     } catch (e) {
-      return { ok: false, error: errorMessage(e), status: 500 }
+      log.warn('[api] codex archived 列表失败:', e instanceof Error ? e.message : e)
+      return []
     }
   }
 }

--- a/server/src/backends/port.ts
+++ b/server/src/backends/port.ts
@@ -1,0 +1,103 @@
+// BackendPort：Hub 编排层对后端的唯一能力入口。
+// 两后端各一个适配器（claude/port.ts、codex/port.ts），编排层经 portFor(key) 分发，
+// 编排层不再出现 isCodexKey 能力分支（key 工具函数除外——key 本身编码后端，属元数据读取）。
+//
+// 依赖红线：适配器可以 import 具体后端实现（processManager/codexRuntime），
+// 但绝不 import hub 编排层（index.ts）的运行时代码——回调经 HubServices 注入（S1.2 起）。
+// Hub 目前以 import type 引用（type-only，无运行时环；S2 迁入 hub/types.ts）。
+//
+// 模块环说明：port.ts ↔ claude/port.ts、codex/port.ts 之间存在 import 环
+//（portFor 需要适配器实例，适配器需要 baseStatusOf/类型）。两侧都只在方法体内
+//  deferred 使用对方绑定（implements 为 type-only 已擦除），模块求值期无 TDZ 读取。
+
+import type { Hub } from '../index'
+import { isCodexKey } from './codex/backend'
+import { claudePort } from './claude/port'
+import { codexPort } from './codex/port'
+import type { ApprovalDecision, BackendName } from './types'
+
+/** 浏览器上传的图片附件（base64）；codex 侧落盘后走 localImage */
+export interface ImageAttachment {
+  name: string
+  mediaType: string
+  dataBase64: string
+}
+
+/** Hub 可见的最小会话句柄面：ClaudeSession/CodexSession 已结构化同形（契约见 types.ts
+ *  末尾注释），两个类文件零改动——TS 结构类型自动兼容本接口。
+ *  claude-only 的能力（sideQuestion/generateSessionTitle/notifyExternalGate 等）
+ *  不进本接口，由 claude 适配器内部用具体类型承接。 */
+export interface SessionHandle {
+  readonly sessionId: string | undefined
+  readonly exited: boolean
+  readonly busy: boolean
+  readonly waiting: boolean
+  readonly sessionState: string
+  readonly connectedClients: number
+  readonly tokenUsage: unknown
+  readonly contextUsage: unknown
+  sendUserText(text: string, sendMode?: 'steer' | 'queue', images?: ImageAttachment[]): void
+  sendApproval(requestId: string, decision: ApprovalDecision): void
+  sendControl(subtype: string, extra?: Record<string, unknown>): void
+  sendControlAndWait(
+    subtype: string,
+    extra?: Record<string, unknown>,
+    timeoutMs?: number,
+  ): Promise<unknown>
+  write(msg: { type: 'update_environment_variables'; variables: Record<string, string> }): void
+  syncClients(count: number): void
+  attachClient(): void
+  detachClient(): void
+}
+
+/** statusOf 的调用上下文：hub 由编排层传入（适配器不反查 hubs 注册表） */
+export interface StatusContext {
+  hub: Hub | undefined
+  /** 调用方（/api/sessions）刚做过 pid 扫描时传入复用，避免每行各扫一次；
+   *  显式 null 表示"已知不在线"（跳过扫描），undefined 才现扫。仅 claude 适配器使用。 */
+  liveHint?: { status: string; pid: number } | null
+  /** 仅单会话 attach/pushStatus 路径开启（离线时读 transcript 尾部补上下文占用）；
+   *  列表端点禁止开启（N 行 × 文件读）。 */
+  hydrateContext?: boolean
+}
+
+export interface BackendPort {
+  readonly name: BackendName
+  /** 当前存活（或已退出待回收）的会话句柄；取代编排层散落的 isCodexKey ? codexRuntime.get : processManager.get */
+  sessionOf(key: string): SessionHandle | undefined
+  /** 存活判定（ws close 的 Hub 回收依据）：claude = 句柄存在；codex = 句柄存在且未退出 */
+  hasLiveSession(key: string): boolean
+  /** 外部门禁（control.sock 生态）通知：claude 转发句柄方法；codex 无对应物，no-op */
+  notifyExternalGate(key: string): void
+  /** 会话状态派生（两后端函数体分别在各自适配器内；公共字段走 baseStatusOf） */
+  statusOf(key: string, cx: StatusContext): Record<string, unknown>
+}
+
+/** 两后端会话状态的公共字段（claude/codex 会话句柄结构化同形，契约见 backends/types.ts 末尾） */
+export function baseStatusOf(
+  s: SessionHandle | undefined,
+  hub: Hub | undefined,
+  waiting: boolean,
+): Record<string, unknown> {
+  return {
+    spawned: !!s && !s.exited,
+    busy: (s?.busy ?? false) || waiting,
+    waiting,
+    sessionState: s?.sessionState ?? 'idle',
+    sessionId: s?.sessionId,
+    clients: s?.connectedClients ?? hub?.clients.size ?? 0,
+    usage: s?.tokenUsage,
+    context: s?.contextUsage,
+    permissionMode: hub?.spawnOpts?.permissionMode,
+    effort: hub?.spawnOpts?.effort,
+  }
+}
+
+export function backendOf(key: string): BackendName {
+  return isCodexKey(key) ? 'codex' : 'claude'
+}
+
+/** 编排层唯一的后端分支点：全仓库的能力分发都收敛到这一个三元 */
+export function portFor(key: string): BackendPort {
+  return isCodexKey(key) ? codexPort : claudePort
+}

--- a/server/src/backends/port.ts
+++ b/server/src/backends/port.ts
@@ -11,10 +11,37 @@
 //  deferred 使用对方绑定（implements 为 type-only 已擦除），模块求值期无 TDZ 读取。
 
 import type { Hub } from '../index'
+import type { HandoffDetail } from '../handoff'
 import { isCodexKey } from './codex/backend'
 import { claudePort } from './claude/port'
 import { codexPort } from './codex/port'
-import type { ApprovalDecision, BackendName } from './types'
+import type { ApprovalDecision, BackendName, SessionCallbacks, SpawnOptions } from './types'
+
+/** 适配器回调编排层的服务面（装配层 initBackendPorts 注入一次；适配器禁止 import index.ts） */
+export interface HubServices {
+  broadcast(hub: Hub, payload: unknown): void
+  broadcastError(hub: Hub, message: string): void
+  pushStatus(hub: Hub, extra?: Record<string, unknown>): void
+  sessionCallbacks(hub: Hub): SessionCallbacks
+  getHub(key: string): Hub
+  /** 会话显示名（推送/日志用）；实现在 push 域，由装配层注入 */
+  sessionNameOf(key: string): string
+  /** 回滚进行中拒绝新操作：返回 true 表示已拒绝（错误已广播） */
+  rewindBusy(hub: Hub, message?: string): boolean
+}
+
+let services: HubServices | undefined
+
+/** 装配层（index.ts）一次性注入；不依赖 ESM import 顺序副作用 */
+export function initBackendPorts(s: HubServices): void {
+  services = s
+}
+
+/** 适配器取回调服务；未装配即调用是编程错误，fail fast */
+export function hubServices(): HubServices {
+  if (!services) throw new Error('[port] initBackendPorts 未在装配层调用')
+  return services
+}
 
 /** 浏览器上传的图片附件（base64）；codex 侧落盘后走 localImage */
 export interface ImageAttachment {
@@ -71,6 +98,60 @@ export interface BackendPort {
   notifyExternalGate(key: string): void
   /** 会话状态派生（两后端函数体分别在各自适配器内；公共字段走 baseStatusOf） */
   statusOf(key: string, cx: StatusContext): Record<string, unknown>
+
+  /** attach 分流：claude 懒启动（warm/opts 才 spawn）；codex x| 即 resume、xn| 懒启动 */
+  onAttach(hub: Hub, msg: Record<string, unknown>): void
+  /** 懒启动/续跑会话。时序红线：claude 实现的函数体到 return 前禁止出现 await——
+   *  调用方依赖 spawn/stopTailer/syncClients/pendingEnv 写入与调用同拍完成 */
+  ensure(hub: Hub, opts?: Partial<SpawnOptions>): Promise<SessionHandle | undefined>
+  /** 发送路径的就绪检查：未运行则触发懒启动；未就绪返回 undefined（错误已广播）。
+   *  时序红线同 ensure（claude 实现零 await）。 */
+  ensureForSend(hub: Hub): Promise<SessionHandle | undefined>
+  /** 发送成功后的后端特定跟踪（claude：/goal 出站跟踪 + 标题素材记账）；codex 不实现 */
+  afterUserSent?(hub: Hub, text: string): void
+  /** 官方 AI 标题双条件触发（claude）；codex no-op */
+  maybeGenerateTitle(hub: Hub): void
+  /** transcript 实时跟踪（claude 外部会话）；codex 无 tailer 概念，no-op */
+  startTailer(hub: Hub, from?: number): void
+  stopTailer(hub: Hub): void
+  /** 对话回滚：claude=原地截断重 spawn；codex=thread/fork 分叉语义 */
+  rewindConversation(hub: Hub, userMessageId: string): void
+  /** 组合回滚（文件+对话）：claude 先 rewind_files 再截断；codex 无文件检查点，拒绝 */
+  rewindBoth(hub: Hub, userMessageId: string): void
+
+  // ---------- 消息域（model/mode 缓存与 rewindPending 守卫留在 hub 层，此处为后端投递） ----------
+  /** 通用控制请求：codex 直接翻译（interrupt/set_model/set_permission_mode/compact）；
+   *  claude 未 spawn 时除 set_model/set_permission_mode（有启动参数等价物）外触发懒启动 */
+  deliverControl(hub: Hub, subtype: string, extra: Record<string, unknown>): void
+  /** 环境变量（effort 已在上层缓存进 spawnOpts）：claude 未 spawn 时并入 pendingEnv；
+   *  codex 映射 reasoning effort */
+  updateEnv(hub: Hub, variables: Record<string, string>): void
+  /** 分叉当前会话：claude 懒分叉（b| key，首条消息才 --fork-session）；codex 拒绝（引导走回滚面板） */
+  branch(hub: Hub, name: string): void
+  /** 侧问：借用当前会话上下文的一次性问答（btw_pending 已由上层先行广播） */
+  btw(hub: Hub, question: string): void
+  /** 带应答的只读查询/MCP 管理动作；codex 仅 mcp_status 有对应物 */
+  query(
+    hub: Hub,
+    query: string,
+    extra: Record<string, unknown>,
+    reply: (payload: Record<string, unknown>) => void,
+  ): void
+
+  // ---------- handoff（接力） ----------
+  /** 接力源解析：cwd（codex x| key 不含，可能缺省）+ 会话 id */
+  handoffSource(key: string): { cwd?: string; sourceId?: string }
+  /** cwd 的惰性补全：codex 走 thread/read；claude 重查 parseKey */
+  handoffCwdOf(key: string, sourceId: string): Promise<string | undefined>
+  /** 源会话 fork 自摘要：claude 在线走 side_question、离线一次性 fork spawn；codex ephemeral fork */
+  forkBriefForHandoff(
+    fromKey: string,
+    cwd: string,
+    sourceId: string,
+    detail: HandoffDetail,
+  ): Promise<{ text: string; usage?: Record<string, number> }>
+  /** 目标会话播种首条消息，返回目标 sessionId（claude 含 init 前 30s 轮询）；启动失败抛错 */
+  seedHandoffTarget(hub: Hub, seed: string): Promise<string | undefined>
 }
 
 /** 两后端会话状态的公共字段（claude/codex 会话句柄结构化同形，契约见 backends/types.ts 末尾） */

--- a/server/src/backends/port.ts
+++ b/server/src/backends/port.ts
@@ -88,6 +88,9 @@ export interface StatusContext {
   hydrateContext?: boolean
 }
 
+/** REST 管理面结果：路由层原样映射为 HTTP 响应（状态码逐字保留） */
+export type RouteResult = { ok: true } | { ok: false; error: string; status: number }
+
 export interface BackendPort {
   readonly name: BackendName
   /** 当前存活（或已退出待回收）的会话句柄；取代编排层散落的 isCodexKey ? codexRuntime.get : processManager.get */
@@ -152,6 +155,11 @@ export interface BackendPort {
   ): Promise<{ text: string; usage?: Record<string, number> }>
   /** 目标会话播种首条消息，返回目标 sessionId（claude 含 init 前 30s 轮询）；启动失败抛错 */
   seedHandoffTarget(hub: Hub, seed: string): Promise<string | undefined>
+
+  // ---------- REST 管理面（归档/恢复/改名） ----------
+  archive(key: string): Promise<RouteResult>
+  restore(key: string): Promise<RouteResult>
+  rename(key: string, title: string): Promise<RouteResult>
 }
 
 /** 两后端会话状态的公共字段（claude/codex 会话句柄结构化同形，契约见 backends/types.ts 末尾） */

--- a/server/src/backends/port.ts
+++ b/server/src/backends/port.ts
@@ -12,6 +12,7 @@
 
 import type { Hub } from '../hub/types'
 import type { HandoffDetail } from '../handoff'
+import { errorMessage } from '../util'
 import { isCodexKey } from './codex/backend'
 import { claudePort } from './claude/port'
 import { codexPort } from './codex/port'
@@ -94,6 +95,21 @@ export interface StatusContext {
 /** REST 管理面结果：路由层原样映射为 HTTP 响应（状态码逐字保留） */
 export type RouteResult = { ok: true } | { ok: false; error: string; status: number }
 
+/** 归档/回收站列表行（/api/sessions/archived）：claude=trash（trashedAt/sizeBytes），
+ *  codex=archived threads（title/lastPrompt/cwd/mtime）——两后端字段并集，缺省即不渲染 */
+export interface ArchivedEntry {
+  key: string
+  sessionId: string
+  slug: string
+  backend: BackendName
+  title?: string
+  lastPrompt?: string
+  cwd?: string
+  mtime?: number
+  trashedAt?: string
+  sizeBytes?: number
+}
+
 export interface BackendPort {
   readonly name: BackendName
   /** 当前存活（或已退出待回收）的会话句柄；取代编排层散落的 isCodexKey ? codexRuntime.get : processManager.get */
@@ -163,6 +179,9 @@ export interface BackendPort {
   archive(key: string): Promise<RouteResult>
   restore(key: string): Promise<RouteResult>
   rename(key: string, title: string): Promise<RouteResult>
+  /** 归档/回收站列表：claude=trash（同步文件读），codex=archived thread/list。
+   *  单后端失败降级为空数组（适配器内 log），不拖垮另一后端的列表。 */
+  listArchived(): Promise<ArchivedEntry[]>
 }
 
 /** 两后端会话状态的公共字段（claude/codex 会话句柄结构化同形，契约见 backends/types.ts 末尾） */
@@ -192,4 +211,26 @@ export function backendOf(key: string): BackendName {
 /** 编排层唯一的后端分支点：全仓库的能力分发都收敛到这一个三元 */
 export function portFor(key: string): BackendPort {
   return isCodexKey(key) ? codexPort : claudePort
+}
+
+// ---------- /btw 侧问的共享信封（校验失败文案与 btw_result 广播只有一份，双后端不分叉） ----------
+
+/** 无会话可借上下文时的统一拒绝（空问题 / 无 sessionId） */
+export function btwRejectNoSession(hub: Hub, question: string): void {
+  hubServices().broadcast(hub, {
+    kind: 'btw_result',
+    ok: false,
+    question,
+    text: '侧问需要已有会话（先发过至少一条消息）',
+  })
+}
+
+/** 执行体跑完后统一广播 btw_result；流式增量（btw_delta）由后端在执行体内自行广播 */
+export function btwDeliver(hub: Hub, question: string, run: () => Promise<string>): void {
+  const { broadcast } = hubServices()
+  run()
+    .then((text) => broadcast(hub, { kind: 'btw_result', ok: true, question, text }))
+    .catch((e) =>
+      broadcast(hub, { kind: 'btw_result', ok: false, question, text: `侧问失败: ${errorMessage(e)}` }),
+    )
 }

--- a/server/src/backends/port.ts
+++ b/server/src/backends/port.ts
@@ -10,7 +10,7 @@
 //（portFor 需要适配器实例，适配器需要 baseStatusOf/类型）。两侧都只在方法体内
 //  deferred 使用对方绑定（implements 为 type-only 已擦除），模块求值期无 TDZ 读取。
 
-import type { Hub } from '../index'
+import type { Hub } from '../hub/types'
 import type { HandoffDetail } from '../handoff'
 import { isCodexKey } from './codex/backend'
 import { claudePort } from './claude/port'
@@ -63,6 +63,9 @@ export interface SessionHandle {
   readonly connectedClients: number
   readonly tokenUsage: unknown
   readonly contextUsage: unknown
+  /** 会话 cwd（codex 句柄有 getter；claude 缺席——x| key 的 sessionNameOf 反查用，
+   *  可选属性使 ClaudeSession 无需改动即结构化兼容） */
+  readonly cwd?: string
   sendUserText(text: string, sendMode?: 'steer' | 'queue', images?: ImageAttachment[]): void
   sendApproval(requestId: string, decision: ApprovalDecision): void
   sendControl(subtype: string, extra?: Record<string, unknown>): void

--- a/server/src/hub/broadcast.ts
+++ b/server/src/hub/broadcast.ts
@@ -1,0 +1,64 @@
+// Hub 级广播与 inbox 事件出口。
+// 依赖红线：hub/* 绝不 import push/*（循环）——inbox 事件经 InboxSink 注册器流出，
+// 真实实现（/ws/inbox 扇出 + Web Push 分发）在 push/inbox.ts，由装配层 initInbox() 一次性接线。
+
+import { pushCliRing } from '../cliReplay'
+import { errFields, log } from '../log'
+import type { Hub, InboxEvent } from './types'
+
+/** inbox 事件的真实出口（push/inbox.ts 注册）：/ws/inbox 扇出 + Web Push 分发 */
+export interface InboxSink {
+  publish(ev: InboxEvent): void
+}
+
+let inboxSink: InboxSink | undefined
+let sinkWarned = false
+
+/** 装配层（index.ts 经 push/inbox.initInbox）一次性注册；不依赖 ESM import 顺序副作用 */
+export function setInboxSink(s: InboxSink): void {
+  inboxSink = s
+}
+
+/** hub 各模块的 inbox 事件统一出口。sink 缺失是装配错误：warn 留痕但不 throw
+ * （broadcast 的 error 路径会走到这里，throw 会把普通错误广播变成异常）。 */
+export function publishInbox(ev: InboxEvent): void {
+  if (!inboxSink) {
+    if (!sinkWarned) {
+      sinkWarned = true
+      log.warn('[inbox] sink 未注册（initInbox 未在装配层调用），inbox 事件被丢弃')
+    }
+    return
+  }
+  inboxSink.publish(ev)
+}
+
+/** 待审批重放：WS 接入（单播）与 attach（广播）共用——未裁决的审批补发给目标 */
+export function replayApprovals(hub: Hub, send: (payload: unknown) => void): void {
+  for (const a of hub.pendingApprovals.values()) {
+    send({ kind: 'approval_request', ...a })
+  }
+}
+
+export function broadcast(hub: Hub, payload: unknown): void {
+  const kindForRing = (payload as { kind?: string } | null | undefined)?.kind
+  if (kindForRing === 'cli') pushCliRing(hub, payload as Record<string, unknown>)
+  const text = JSON.stringify(payload)
+  for (const ws of hub.clients) {
+    try {
+      ws.send(text)
+    } catch (e) {
+      // 向刚关闭的连接发送是竞态常态（close 处理器尚未跑到），属预期内噪声——
+      // 降到 debug 而非吞掉：排查"消息没收到"时开 ANYPLANE_LOG_LEVEL=debug 就能看见
+      log.debug(`[ws ${hub.key}] 下行发送失败（连接可能已关闭）`, errFields(e))
+    }
+  }
+  // 错误事件同步进全局收件箱（审批/完成由各自路径单独发布）
+  const kind = (payload as { kind?: string } | null | undefined)?.kind
+  if (kind === 'error') {
+    publishInbox({ type: 'error', key: hub.key, message: String((payload as { message?: unknown }).message ?? '') })
+  }
+}
+
+export function broadcastError(hub: Hub, message: string): void {
+  broadcast(hub, { kind: 'error', message })
+}

--- a/server/src/hub/callbacks.ts
+++ b/server/src/hub/callbacks.ts
@@ -6,10 +6,13 @@ import { keyFor, parseKey } from '../backends/claude/backend'
 import { sanitizePath } from '../backends/claude/discovery'
 import { processManager } from '../backends/claude/processManager'
 import { isInternalUserMessage, type CliMessage } from '../backends/claude/protocol'
+import { isCodexKey } from '../backends/codex/backend'
 import { portFor } from '../backends/port'
 import { config } from '../config'
 import { log } from '../log'
+import { summarizeInput } from '../util'
 import { broadcast, publishInbox } from './broadcast'
+import { deliverApproval } from './lifecycle'
 import { hubs } from './registry'
 import { pushStatus, throttledPushStatus } from './status'
 import type { Hub } from './types'
@@ -24,7 +27,9 @@ export function sessionCallbacks(hub: Hub) {
       if (isInternalUserMessage(msg)) return
       // /clear（别名 /reset /new）：CLI 发 conversation_reset 并以新 session_id 续跑。
       // Hub 随之重键到 s|slug|<newSid>——新会话页承载后续对话，旧 transcript 原样留存。
-      if (msg.type === 'conversation_reset') {
+      // claude-only 语义，守卫防漂移：codex 若未来发出同形事件，落入普通透传而不是
+      // 误触 claude 专属的重键（parseKey/processManager.rekey 作用在 x| key 上即消息黑洞）。
+      if (msg.type === 'conversation_reset' && !isCodexKey(hub.key)) {
         hub.pendingRekey = true
         return // 原始事件不进主抄本，迁移以 moved 事件表达
       }
@@ -84,12 +89,14 @@ export function sessionCallbacks(hub: Hub) {
           requestId: req.requestId,
           toolName: req.toolName,
           input: req.input,
+          // 摘要由服务端唯一口径 summarizeInput 算好下发，前端不再各自提取字段
+          detail: summarizeInput(req.toolName, req.input),
           action: auto.rule.action,
           rule: label,
         })
-        const s = portFor(hub.key).sessionOf(hub.key)
-        if (s) s.sendApproval(req.requestId, decisionOfRule(auto.rule, req.input))
-        else log.warn(`[approval] ${hub.key} 会话句柄已不存在，自动裁决无法送达`)
+        // 与手动裁决共用投递半段（退出检查/异常防护/门禁刷新）；
+        // 不广播 approval_resolved——请求从未入 pending，没有卡片需要清除
+        deliverApproval(hub, req.requestId, decisionOfRule(auto.rule, req.input))
         return
       }
       hub.pendingApprovals.set(req.requestId, req)

--- a/server/src/hub/callbacks.ts
+++ b/server/src/hub/callbacks.ts
@@ -1,0 +1,111 @@
+// 两个后端共用的会话回调装配：CLI/翻译层消息广播、审批入 Hub 表、状态推动。
+// /clear 重键的三层同步（Hub / 进程 map / 存活 WS 的 data.key）全在这里——少一层即双进程或消息黑洞。
+
+import { decisionOfRule, matchApprovalRule } from '../approvalRules'
+import { keyFor, parseKey } from '../backends/claude/backend'
+import { sanitizePath } from '../backends/claude/discovery'
+import { processManager } from '../backends/claude/processManager'
+import { isInternalUserMessage, type CliMessage } from '../backends/claude/protocol'
+import { portFor } from '../backends/port'
+import { config } from '../config'
+import { log } from '../log'
+import { broadcast, publishInbox } from './broadcast'
+import { hubs } from './registry'
+import { pushStatus, throttledPushStatus } from './status'
+import type { Hub } from './types'
+
+/** 两个后端共用的会话回调：CLI/翻译层消息广播、审批入 Hub 表、状态推动 */
+export function sessionCallbacks(hub: Hub) {
+  return {
+    onMessage: (msg: CliMessage) => {
+      // 后台 Agent 完成通知会作为伪装成 user 的内部 XML 记录出现。
+      // 生命周期本身已由 ProcessManager 消费为 system/task_notification；
+      // 不再把原始内部载荷广播进主聊天或 rewind 历史。
+      if (isInternalUserMessage(msg)) return
+      // /clear（别名 /reset /new）：CLI 发 conversation_reset 并以新 session_id 续跑。
+      // Hub 随之重键到 s|slug|<newSid>——新会话页承载后续对话，旧 transcript 原样留存。
+      if (msg.type === 'conversation_reset') {
+        hub.pendingRekey = true
+        return // 原始事件不进主抄本，迁移以 moved 事件表达
+      }
+      if (hub.pendingRekey && msg.type === 'system' && msg.subtype === 'init') {
+        hub.pendingRekey = false
+        const newSid = String(msg.session_id ?? '')
+        const cwd = hub.spawnOpts?.cwd ?? parseKey(hub.key)?.cwd
+        if (newSid && cwd) {
+          const newKey = keyFor(sanitizePath(cwd), newSid)
+          const oldKey = hub.key
+          hubs.delete(oldKey)
+          hub.goal = undefined // 上下文已清，goal 与待审批随之失效
+          hub.pendingApprovals.clear()
+          hub.pendingTitleText = undefined // 旧会话的标题素材不带给新会话
+          hub.key = newKey
+          hubs.set(newKey, hub)
+          // 进程 map 同步重键：否则按新 key 查不到进程会再 spawn 一个（双进程同 transcript）
+          processManager.rekey(oldKey, newKey)
+          // 重键后同步改写存活连接的 data.key：message 路由（getHub(ws.data.key)）依赖它，
+          // 否则旧 key 上的后续消息会新建空 Hub（消息黑洞）
+          for (const ws of hub.clients) {
+            if (!ws.data.inbox) ws.data.key = newKey
+          }
+          // 已知限制：新 transcript 文件尚未落盘时 parseKey 无法反查 cwd（进程存活期间无影响，
+          // spawnOpts 持有 cwd；空闲回收后若文件仍未写则报"无法解析会话"）
+          broadcast(hub, { kind: 'moved', targetKey: newKey, targetSessionId: newSid, reason: 'clear' })
+          pushStatus(hub)
+        }
+      }
+      // 每个 init 都更新会话身份（首次 spawn 与 /clear 重键共用；rekey 分支不落 return，会走到这里）
+      if (msg.type === 'system' && msg.subtype === 'init') {
+        hub.sessionId = String(msg.session_id ?? '') || undefined
+        portFor(hub.key).maybeGenerateTitle(hub) // 首条消息可能已记账在等 sessionId（codex no-op）
+      }
+      broadcast(hub, { kind: 'cli', msg })
+      // turn 收尾是收件箱的核心提醒信号（agent 跑完了）
+      if (msg.type === 'result') {
+        publishInbox({ type: 'done', key: hub.key, ok: msg.is_error !== true })
+        // claude /goal：goal 激活期间 turn 只会因"条件达成"结束（Stop hook 拦截其余收尾），
+        // 所以 result 到达即视为目标完成（用户中断也会到此，chip 随之清除，语义可接受）
+        if (hub.goal) {
+          hub.goal = undefined
+          pushStatus(hub)
+        }
+      }
+    },
+    onApprovalRequest: (req: { requestId: string; toolName: string; input: unknown }) => {
+      // 审批规则引擎：按序首条命中即自动裁决——不进 pending、不推送、不打扰，
+      // 但广播 approval_auto 留痕事件（UI 灰底卡 + 服务端日志），审计可回溯。
+      // 规则只做服务端裁决，绝不进入推送能力 URL 路径。
+      const auto = matchApprovalRule(config.approvalRules ?? [], req.toolName, req.input)
+      if (auto) {
+        const label = auto.rule.note ?? `approvalRules[${auto.index}]`
+        log.info(`[approval] ${hub.key} 规则自动${auto.rule.action === 'allow' ? '放行' : '拒绝'} ${req.toolName}（${label}）`)
+        broadcast(hub, {
+          kind: 'approval_auto',
+          requestId: req.requestId,
+          toolName: req.toolName,
+          input: req.input,
+          action: auto.rule.action,
+          rule: label,
+        })
+        const s = portFor(hub.key).sessionOf(hub.key)
+        if (s) s.sendApproval(req.requestId, decisionOfRule(auto.rule, req.input))
+        else log.warn(`[approval] ${hub.key} 会话句柄已不存在，自动裁决无法送达`)
+        return
+      }
+      hub.pendingApprovals.set(req.requestId, req)
+      broadcast(hub, {
+        kind: 'approval_request',
+        requestId: req.requestId,
+        toolName: req.toolName,
+        input: req.input,
+      })
+      publishInbox({ type: 'approval', key: hub.key, requestId: req.requestId, toolName: req.toolName, input: req.input })
+      pushStatus(hub)
+      portFor(hub.key).notifyExternalGate(hub.key)
+    },
+    onStatusChange: () => throttledPushStatus(hub),
+    onExit: (code: number) => {
+      pushStatus(hub, { exited: true, exitCode: code, spawned: false, busy: false, waiting: false })
+    },
+  }
+}

--- a/server/src/hub/handoff.ts
+++ b/server/src/hub/handoff.ts
@@ -1,0 +1,95 @@
+// 接力（handoff）跨后端编排：源会话自摘要 → 目标会话播种 → 血缘落盘。
+// 领域函数（简报生成/播种文案/血缘 IO）在 ../handoff.ts；这里只做编排与进度事件推源 Hub。
+
+import { keyFor, keyForNew } from '../backends/claude/backend'
+import { sanitizePath } from '../backends/claude/discovery'
+import { keyForNew as codexKeyForNew } from '../backends/codex/backend'
+import { portFor } from '../backends/port'
+import { appendLineage, seedMessage, type HandoffDetail } from '../handoff'
+import { errorMessage } from '../util'
+import { broadcast } from './broadcast'
+import { getHub, hubs } from './registry'
+
+/**
+ * POST /api/handoff { fromKey, toBackend, detail } → 立即应答；进度事件推到 fromKey 所在 Hub：
+ * handoff_pending → handoff_done { targetKey, brief } / handoff_error { message }。
+ * 目标会话由服务端直接创建并播种首条消息（无需浏览器在场）。
+ */
+export function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detail: HandoffDetail): string | undefined {
+  const sourceHub = hubs.get(fromKey)
+  const fromPort = portFor(fromKey)
+  const fromBackend = fromPort.name
+  if (fromBackend === toBackend) return '接力目标必须与源会话是不同后端'
+
+  // 源解析：cwd + 会话 id（codex 的 x| key 不含 cwd，需在异步路径里惰性解析）
+  const src = fromPort.handoffSource(fromKey)
+  if (fromBackend === 'claude' && !src.cwd) return '无法确定源会话目录'
+  if (!src.sourceId) return '源会话还没有任何消息，无法接力'
+
+  const sid = src.sourceId
+  void (async () => {
+    try {
+      // codex x| key：cwd 需要 thread/read 惰性解析
+      const sourceCwd = src.cwd ?? (await fromPort.handoffCwdOf(fromKey, sid))
+      if (!sourceCwd) throw new Error('无法确定源会话目录（thread/read 未返回 cwd）')
+      if (sourceHub) broadcast(sourceHub, { kind: 'handoff_pending', toBackend })
+      // 1. 源会话 fork 自摘要
+      //    claude 源在线时走 side_question 控制通道（进程内 fork，零冷启动、不留 FORK 会话）；
+      //    离线才 spawn 一次性 --fork-session --bare 进程
+      const { text: brief, usage } = await fromPort.forkBriefForHandoff(fromKey, sourceCwd, sid, detail)
+      if (sourceHub) broadcast(sourceHub, { kind: 'handoff_brief', brief })
+
+      // 2. 目标会话播种（服务端直接发送首条消息；启动失败抛错）
+      const targetKey = toBackend === 'codex' ? codexKeyForNew(sourceCwd) : keyForNew(sourceCwd)
+      const targetHub = getHub(targetKey)
+      const seed = seedMessage(sourceCwd, fromBackend, brief)
+      const targetSessionId = await portFor(targetKey).seedHandoffTarget(targetHub, seed)
+      const toResolvedKey =
+        toBackend === 'codex'
+          ? targetSessionId
+            ? `x|${targetSessionId}`
+            : undefined
+          : targetSessionId
+            ? keyFor(sanitizePath(sourceCwd), targetSessionId)
+            : undefined
+      const fromResolvedKey = (() => {
+        if (fromBackend === 'claude') {
+          if (fromKey.startsWith('s|')) return fromKey
+          const sidNow = fromPort.sessionOf(fromKey)?.sessionId
+          return sidNow ? keyFor(sanitizePath(sourceCwd), sidNow) : undefined
+        }
+        if (fromKey.startsWith('x|')) return fromKey
+        const tidNow = fromPort.sessionOf(fromKey)?.sessionId
+        return tidNow ? `x|${tidNow}` : undefined
+      })()
+
+      // 3. 血缘
+      appendLineage({
+        id: `ho-${Date.now().toString(36)}`,
+        at: new Date().toISOString(),
+        fromKey,
+        toKey: targetKey,
+        fromResolvedKey,
+        toResolvedKey,
+        fromBackend,
+        toBackend,
+        cwd: sourceCwd,
+        detail,
+        brief,
+        briefUsage: usage,
+      })
+      if (sourceHub)
+        broadcast(sourceHub, {
+          kind: 'handoff_done',
+          targetKey: toResolvedKey ?? targetKey,
+          targetSessionId,
+          toBackend,
+          brief,
+        })
+    } catch (e) {
+      const message = errorMessage(e)
+      if (sourceHub) broadcast(sourceHub, { kind: 'handoff_error', message })
+    }
+  })()
+  return undefined
+}

--- a/server/src/hub/lifecycle.ts
+++ b/server/src/hub/lifecycle.ts
@@ -15,11 +15,12 @@ export function rewindBusy(hub: Hub, message = '已有回滚操作正在进行')
 }
 
 /**
- * 审批解析共享路径：WS approval 消息与推送直接审批（/api/approval-action）共用。
- * 返回 false 表示 requestId 已不在 pending（重复点击/已在别处处理）。
+ * 审批投递共享半段：手动裁决（resolveApproval）与规则自动裁决（callbacks.ts）共用——
+ * 退出检查 + sendApproval 异常防护 + 外部门禁刷新。
+ * 留痕事件不进这里：手动路径广播 approval_resolved（有 pending 卡要清），
+ * 规则路径广播 approval_auto（请求从未入 pending，没有卡可清）。
  */
-export function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision): boolean {
-  if (!hub.pendingApprovals.delete(requestId)) return false
+export function deliverApproval(hub: Hub, requestId: string, decision: ApprovalDecision): void {
   const port = portFor(hub.key)
   const s = port.sessionOf(hub.key)
   if (s && !s.exited) {
@@ -33,6 +34,15 @@ export function resolveApproval(hub: Hub, requestId: string, decision: ApprovalD
     broadcastError(hub, '会话未在运行，审批未能送达（该请求会在上游自行超时）')
   }
   port.notifyExternalGate(hub.key)
+}
+
+/**
+ * 审批解析共享路径：WS approval 消息与推送直接审批（/api/approval-action）共用。
+ * 返回 false 表示 requestId 已不在 pending（重复点击/已在别处处理）。
+ */
+export function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision): boolean {
+  if (!hub.pendingApprovals.delete(requestId)) return false
+  deliverApproval(hub, requestId, decision)
   broadcast(hub, { kind: 'approval_resolved', requestId })
   publishInbox({ type: 'approval_resolved', key: hub.key, requestId })
   pushStatus(hub)

--- a/server/src/hub/lifecycle.ts
+++ b/server/src/hub/lifecycle.ts
@@ -1,0 +1,40 @@
+// 审批裁决共享路径与回滚互斥守卫。
+
+import { portFor } from '../backends/port'
+import type { ApprovalDecision } from '../backends/types'
+import { errorMessage } from '../util'
+import { broadcast, broadcastError, publishInbox } from './broadcast'
+import { pushStatus } from './status'
+import type { Hub } from './types'
+
+/** 回滚进行中拒绝新操作：返回 true 表示已拒绝（错误已广播） */
+export function rewindBusy(hub: Hub, message = '已有回滚操作正在进行'): boolean {
+  if (!hub.rewindPending) return false
+  broadcastError(hub, message)
+  return true
+}
+
+/**
+ * 审批解析共享路径：WS approval 消息与推送直接审批（/api/approval-action）共用。
+ * 返回 false 表示 requestId 已不在 pending（重复点击/已在别处处理）。
+ */
+export function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision): boolean {
+  if (!hub.pendingApprovals.delete(requestId)) return false
+  const port = portFor(hub.key)
+  const s = port.sessionOf(hub.key)
+  if (s && !s.exited) {
+    try {
+      s.sendApproval(requestId, decision)
+    } catch (e) {
+      broadcastError(hub, `审批回复失败: ${errorMessage(e)}`)
+    }
+  } else {
+    // 会话已退出/未就绪：决定无处投递（上游请求将自行超时），本地照常解析并告知用户
+    broadcastError(hub, '会话未在运行，审批未能送达（该请求会在上游自行超时）')
+  }
+  port.notifyExternalGate(hub.key)
+  broadcast(hub, { kind: 'approval_resolved', requestId })
+  publishInbox({ type: 'approval_resolved', key: hub.key, requestId })
+  pushStatus(hub)
+  return true
+}

--- a/server/src/hub/messages.ts
+++ b/server/src/hub/messages.ts
@@ -74,9 +74,11 @@ export function handleClientMessage(
       const text = String(data.text ?? '')
       void (async () => {
         const port = portFor(hub.key)
-        const s = await port.ensureForSend(hub)
-        if (!s) return // 适配器已广播具体错误
         try {
+          // ensure 也必须罩在 try 内：fire-and-forget IIFE 里 await 抛在 catch 之外
+          // 会变 unhandled rejection——消息无声消失，客户端连错误卡都收不到
+          const s = await port.ensureForSend(hub)
+          if (!s) return // 适配器已广播具体错误
           // sendMode 直通：claude 侧 steer=priority 'now'（中断处理）、queue=服务端排队
           s.sendUserText(text, sendMode, attachments)
           // 后端特定的发送后跟踪（claude：/goal 出站跟踪 + 标题素材记账；codex 无）

--- a/server/src/hub/messages.ts
+++ b/server/src/hub/messages.ts
@@ -1,0 +1,167 @@
+// WS 上行消息分发：11 类 kind 全部经 portFor 分发给后端适配器。
+// Hub 级状态（spawnOpts 缓存、rewindPending 守卫、重连补发单播）留在本层——适配器只做后端投递。
+
+import type { ServerWebSocket } from 'bun'
+import { portFor } from '../backends/port'
+import type { ApprovalDecision } from '../backends/types'
+import { replayCliSince } from '../cliReplay'
+import { errFields, log } from '../log'
+import { errorMessage } from '../util'
+import { broadcast, broadcastError, replayApprovals } from './broadcast'
+import { resolveApproval, rewindBusy } from './lifecycle'
+import { pushStatus } from './status'
+import type { Hub, WSData } from './types'
+
+export function handleClientMessage(
+  hub: Hub,
+  raw: string,
+  /** 发起方连接：仅重连补发需要单播（其余一律 hub 级广播） */
+  ws?: ServerWebSocket<WSData>,
+): void {
+  let data: Record<string, unknown>
+  try {
+    data = JSON.parse(raw)
+  } catch (e) {
+    // 曾是静默 return：协议漂移/帧截断时表现为"消息就是没了"，零线索。
+    // 客户端不可能合法发出非 JSON，这一定是 bug 或攻击面探测，按 error 留痕。
+    log.error(`[ws ${hub.key}] 上行非 JSON 帧，已丢弃`, { bytes: raw.length, head: raw.slice(0, 120), ...errFields(e) })
+    return
+  }
+  switch (data.kind) {
+    case 'attach': {
+      // 浏览历史只握手，不 spawn。发消息 / 切 model·mode·effort / rewind / btw 时再启动 CLI。
+      // 各后端的 attach 策略（warm 预热、codex x| 即 resume）见适配器 onAttach。
+      portFor(hub.key).onAttach(hub, data)
+      replayApprovals(hub, (p) => broadcast(hub, p))
+      // 重连补发：客户端带上断线前的最高 seq，取回这期间错过的 cli 事件。
+      // **必须单播**：走 broadcast 会让补发内容重新入环并分配新序号（自我污染），
+      // 且已在线的其他客户端会收到重复投递。
+      const fromSeq = typeof data.fromSeq === 'number' ? data.fromSeq : undefined
+      if (fromSeq !== undefined && ws) {
+        const unicast = (p: unknown) => {
+          try {
+            ws.send(JSON.stringify(p))
+          } catch (e) {
+            log.debug(`[ws ${hub.key}] 补发单播失败`, errFields(e))
+          }
+        }
+        // 环里已挤掉起点时告知缺口，由前端重载历史补全（transcript 是权威事实源）
+        const gap = replayCliSince(hub, fromSeq, unicast)
+        if (gap) {
+          log.info(`[ws ${hub.key}] 补发存在缺口，通知客户端重载历史`, { fromSeq, ringFrom: hub.cliRing?.[0]?.seq })
+          unicast({ kind: 'replay_gap', fromSeq })
+        }
+      }
+      break
+    }
+    case 'tail_subscribe': {
+      // 客户端加载完历史后订阅 transcript 追加（from = 历史读取时的文件字节数，无缝衔接）；
+      // codex 的实时流走 app-server 订阅，无 tailer 概念（适配器内 no-op）
+      portFor(hub.key).startTailer(hub, typeof data.from === 'number' ? data.from : undefined)
+      break
+    }
+    case 'user': {
+      if (rewindBusy(hub, '正在恢复文件，请等待回滚完成后再发送消息')) return
+      const sendMode = data.sendMode === 'steer' || data.sendMode === 'queue' ? data.sendMode : undefined
+      // 图片附件：服务端统一校验（类型/大小），claude 并 content blocks，codex 落盘走 localImage
+      const attachments = (
+        Array.isArray(data.attachments) ? (data.attachments as Array<Record<string, unknown>>) : []
+      ).map((a) => ({
+        name: String(a.name ?? 'image'),
+        mediaType: String(a.mediaType ?? 'image/png'),
+        dataBase64: String(a.dataBase64 ?? ''),
+      }))
+      const text = String(data.text ?? '')
+      void (async () => {
+        const port = portFor(hub.key)
+        const s = await port.ensureForSend(hub)
+        if (!s) return // 适配器已广播具体错误
+        try {
+          // sendMode 直通：claude 侧 steer=priority 'now'（中断处理）、queue=服务端排队
+          s.sendUserText(text, sendMode, attachments)
+          // 后端特定的发送后跟踪（claude：/goal 出站跟踪 + 标题素材记账；codex 无）
+          port.afterUserSent?.(hub, text)
+          pushStatus(hub)
+        } catch (e) {
+          broadcastError(hub, `发送失败: ${errorMessage(e)}`)
+          pushStatus(hub)
+        }
+      })()
+      break
+    }
+    case 'control': {
+      const subtype = String(data.subtype)
+      const extra = (data.extra as Record<string, unknown>) ?? {}
+      // 组合回滚等待期间，通用控制路径不得再发 rewind_files 与之竞争
+      if (hub.rewindPending && subtype === 'rewind_files') {
+        broadcastError(hub, '已有回滚操作正在进行')
+        return
+      }
+      // model/mode 都有等价启动参数：先缓存最终选择（未 spawn 时首条消息应用），
+      // 已 spawn 时再发运行时控制。两个后端同此序。
+      if (subtype === 'set_model' && extra.model) {
+        hub.spawnOpts = { ...hub.spawnOpts, model: String(extra.model) }
+      }
+      if (subtype === 'set_permission_mode' && extra.mode) {
+        hub.spawnOpts = { ...hub.spawnOpts, permissionMode: String(extra.mode) }
+      }
+      portFor(hub.key).deliverControl(hub, subtype, extra)
+      break
+    }
+    case 'update_env': {
+      // effort 有 --effort 启动参数。未 spawn 时只缓存，首条消息时应用；
+      // 已 spawn 时通过 update_environment_variables 影响后续 turn。
+      const variables = (data.variables as Record<string, string>) ?? {}
+      const effort = variables.CLAUDE_CODE_EFFORT_LEVEL
+      if (effort) hub.spawnOpts = { ...hub.spawnOpts, effort }
+      portFor(hub.key).updateEnv(hub, variables)
+      break
+    }
+    case 'branch': {
+      // 分叉当前会话：claude 懒分叉（b| key，首条消息才 --fork-session），
+      // codex 走既有 thread/fork（RewindPicker 的"从此处分叉"，适配器内拒绝并引导）
+      portFor(hub.key).branch(hub, String(data.name ?? ''))
+      break
+    }
+    case 'rewind_conversation': {
+      const at = String(data.userMessageId ?? '')
+      if (!at) return
+      // claude=原地截断重 spawn；codex=thread/fork 分叉语义（rewindPending 守卫在适配器内）
+      portFor(hub.key).rewindConversation(hub, at)
+      break
+    }
+    case 'rewind_both': {
+      const at = String(data.userMessageId ?? '')
+      if (!at) return
+      // 组合回滚：claude 先 rewind_files 再截断；codex 无文件检查点（适配器内拒绝）
+      portFor(hub.key).rewindBoth(hub, at)
+      break
+    }
+    case 'btw': {
+      // 侧问：借用当前会话上下文的一次性问答，不进主会话历史
+      const question = String(data.question ?? '').trim()
+      // btw_pending 必须先于校验失败分支发出：前端卡片由它创建，
+      // 否则校验失败的 btw_result 找不到卡（按 question 配对）被静默丢弃，用户零反馈
+      if (question) broadcast(hub, { kind: 'btw_pending', question })
+      portFor(hub.key).btw(hub, question)
+      break
+    }
+    case 'query': {
+      // 带应答的控制请求通道：只读查询（mcp_status / get_settings / get_context_usage）
+      // 与 MCP 管理动作（mcp_reconnect / mcp_toggle，经 extra 传参）共用；
+      // codex 仅 mcp_status 有对应物 mcpServerStatus/list（动作类一律拒绝，见适配器）
+      const id = String(data.id ?? '')
+      const query = String(data.query ?? '')
+      const extra = (data.extra as Record<string, unknown> | undefined) ?? {}
+      const reply = (payload: Record<string, unknown>) => broadcast(hub, { kind: 'query_result', id, ...payload })
+      if (!id || !query) return
+      portFor(hub.key).query(hub, query, extra, reply)
+      break
+    }
+    case 'approval': {
+      const requestId = String(data.requestId)
+      resolveApproval(hub, requestId, data.decision as ApprovalDecision)
+      break
+    }
+  }
+}

--- a/server/src/hub/registry.ts
+++ b/server/src/hub/registry.ts
@@ -1,0 +1,17 @@
+// Hub 注册表：sessionKey → Hub。
+// Hub 生命周期不变量（重要）：任何后端的会话句柄存活期间，其 Hub 不得删除——
+// 否则重连复用旧会话时，其回调会把事件广播进已删除的 Hub（消息黑洞）。
+// 回收判定在 hub/socket.ts 的 close 处理器（按后端判定存活）。
+
+import type { Hub } from './types'
+
+export const hubs = new Map<string, Hub>()
+
+export function getHub(key: string): Hub {
+  let h = hubs.get(key)
+  if (!h) {
+    h = { key, clients: new Set(), pendingApprovals: new Map() }
+    hubs.set(key, h)
+  }
+  return h
+}

--- a/server/src/hub/socket.ts
+++ b/server/src/hub/socket.ts
@@ -1,0 +1,76 @@
+// Bun.serve 的 websocket handlers：连接生命周期 + 下行保活 + 上行分发。
+
+import type { ServerWebSocket } from 'bun'
+import { portFor } from '../backends/port'
+import { log } from '../log'
+import { addInboxClient, inboxSnapshot, removeInboxClient } from '../push/inbox'
+import { errorMessage } from '../util'
+import { replayApprovals } from './broadcast'
+import { handleClientMessage } from './messages'
+import { getHub, hubs } from './registry'
+import { statusOf } from './status'
+import type { WSData, WSDataInbox } from './types'
+
+// 30s 协议层下行 ping：前端 ReconnectingSocket 没有应用层心跳，空闲会话的 /ws 长连接
+// 可能数分钟无任何消息——Bun.serve 默认 idleTimeout=120s 会把它静默掐断（前端重连虽无感，
+// 但审批/事件推送会落在重连窗口里）；经 gateway 访问时也能为后端腿持续制造下行流量。
+export function wsOpen(ws: ServerWebSocket<WSData>): void {
+  ws.data.keepalive = setInterval(() => {
+    try {
+      ws.ping()
+    } catch {}
+  }, 30_000)
+  if (ws.data.inbox) {
+    addInboxClient(ws as ServerWebSocket<WSDataInbox>)
+    ws.send(JSON.stringify(inboxSnapshot()))
+    return
+  }
+  const hub = getHub(ws.data.key)
+  hub.clients.add(ws)
+  portFor(ws.data.key).sessionOf(ws.data.key)?.attachClient()
+  ws.send(JSON.stringify({ kind: 'status', state: statusOf(ws.data.key, undefined, true) }))
+  replayApprovals(hub, (p) => ws.send(JSON.stringify(p)))
+}
+
+export function wsMessage(ws: ServerWebSocket<WSData>, raw: string | Buffer): void {
+  if (ws.data.inbox) return // inbox 频道只发不收
+  const hub = getHub(ws.data.key)
+  try {
+    handleClientMessage(hub, typeof raw === 'string' ? raw : raw.toString(), ws)
+  } catch (e) {
+    log.error(`[ws ${hub.key}] 处理消息异常:`, e) // 原对象打日志保留堆栈
+    try {
+      ws.send(JSON.stringify({ kind: 'error', message: errorMessage(e) }))
+    } catch {}
+  }
+}
+
+export function wsClose(ws: ServerWebSocket<WSData>): void {
+  if (ws.data.keepalive) clearInterval(ws.data.keepalive)
+  if (ws.data.inbox) {
+    removeInboxClient(ws as ServerWebSocket<WSDataInbox>)
+    return
+  }
+  let hub = hubs.get(ws.data.key)
+  if (!hub) {
+    // 会话可能因 /clear 重键（hub.key 已换成新 s| key）：按客户端成员资格找回
+    for (const h of hubs.values()) {
+      if (h.clients.has(ws)) {
+        hub = h
+        break
+      }
+    }
+  }
+  if (!hub) return
+  hub.clients.delete(ws)
+  // 不变量：任何后端的会话句柄存活期间，其 Hub 必须存活——
+  // 否则重连时复用旧会话，其回调会把事件广播进已删除的 Hub（消息黑洞）。
+  // 用 hub.key 而非 ws.data.key：重键后进程注册在新 key 下
+  const port = portFor(hub.key)
+  port.sessionOf(hub.key)?.detachClient()
+  const alive = port.hasLiveSession(hub.key)
+  if (hub.clients.size === 0) {
+    port.stopTailer(hub)
+    if (!alive) hubs.delete(hub.key)
+  }
+}

--- a/server/src/hub/status.ts
+++ b/server/src/hub/status.ts
@@ -1,0 +1,52 @@
+// 会话状态派生与推送：statusOf 编排（portFor 分发）+ pushStatus + onStatusChange 节流。
+
+import { portFor } from '../backends/port'
+import { broadcast } from './broadcast'
+import { hubs } from './registry'
+import type { Hub } from './types'
+
+/** liveHint：调用方（/api/sessions）刚做过 pid 扫描时传入复用，避免每行各扫一次；
+ *  显式 null 表示"已知不在线"（跳过扫描），undefined 才现扫。
+ *  hydrateContext：仅单会话 attach/pushStatus 路径开启（离线时读 transcript 尾部补
+ *  上下文占用）；列表端点禁止开启（N 行 × 文件读）。
+ *  实现已按后端收敛进适配器（backends/port.ts 的 portFor 分发；公共字段见 baseStatusOf）。 */
+export function statusOf(
+  key: string,
+  liveHint?: { status: string; pid: number } | null,
+  hydrateContext = false,
+): Record<string, unknown> {
+  return portFor(key).statusOf(key, { hub: hubs.get(key), liveHint, hydrateContext })
+}
+
+export function pushStatus(hub: Hub, extra?: Record<string, unknown>): void {
+  broadcast(hub, { kind: 'status', state: { ...statusOf(hub.key, undefined, true), ...extra } })
+}
+
+/** onStatusChange 的 leading+trailing 节流：并行后台任务的 task_progress 心跳每秒可触发多次，
+ *  statusOf 构造+广播是纯派生数据，窗口内合并即可。leading 立即发（busy/idle 转移零延迟），
+ *  窗口内后续变更合并为 trailing 一发——终态只是延迟 ≤300ms，不会丢失。
+ *  仅挂 onStatusChange 一路；审批/退出/attach 等事件路径仍直调 pushStatus 保证即时。 */
+const STATUS_THROTTLE_MS = 300
+const statusThrottle = new WeakMap<Hub, { timer: ReturnType<typeof setTimeout> | null; dirty: boolean }>()
+
+export function throttledPushStatus(hub: Hub): void {
+  let st = statusThrottle.get(hub)
+  if (!st) {
+    st = { timer: null, dirty: false }
+    statusThrottle.set(hub, st)
+  }
+  if (st.timer) {
+    st.dirty = true
+    return
+  }
+  pushStatus(hub)
+  st.timer = setTimeout(() => {
+    st.timer = null
+    // Hub 可能已回收删除：确认还是同一个 Hub 再补发
+    if (st.dirty && hubs.get(hub.key) === hub) {
+      st.dirty = false
+      pushStatus(hub)
+    }
+  }, STATUS_THROTTLE_MS)
+  st.timer.unref?.()
+}

--- a/server/src/hub/types.ts
+++ b/server/src/hub/types.ts
@@ -1,0 +1,66 @@
+// Hub 模型与 WS 数据面的共享类型：纯类型模块，零运行时依赖。
+// （原本定义在 index.ts；S2 拆出后这里是唯一正本，backends/port.ts 也 type-import 这里。）
+
+import type { ServerWebSocket } from 'bun'
+import type { TranscriptTailer } from '../backends/claude/tailer'
+import type { SpawnOptions } from '../backends/types'
+
+export interface PendingApproval {
+  requestId: string
+  toolName: string
+  input: unknown
+}
+
+export interface WSDataSession {
+  key: string
+  inbox?: never
+  /** 下行保活定时器（见 hub/socket.ts 注释） */
+  keepalive?: ReturnType<typeof setInterval>
+}
+
+export interface WSDataInbox {
+  inbox: true
+  key?: never
+  keepalive?: ReturnType<typeof setInterval>
+}
+
+export type WSData = WSDataSession | WSDataInbox
+
+export interface Hub {
+  key: string
+  clients: Set<ServerWebSocket<WSData>>
+  pendingApprovals: Map<string, PendingApproval>
+  /** 下行 cli 事件的单调序号（重连补发用，见 cliReplay.ts） */
+  cliSeq?: number
+  /** 最近 CLI_RING_CAP 条可落盘 cli 事件的环形缓冲（不含 stream_event） */
+  cliRing?: Array<{ seq: number; payload: Record<string, unknown> }>
+  /** 未 spawn 时缓存启动偏好；已 spawn 时记录当前选择，供 UI 重连恢复 */
+  spawnOpts?: Partial<SpawnOptions>
+  /** 除 effort 外、需要在进程启动后按顺序写入 stdin 的环境变量 */
+  pendingEnv?: Record<string, string>
+  /** 组合回滚正在等待 rewind_files 的 CLI 确认，期间禁止再切断当前会话。 */
+  rewindPending?: boolean
+  /** 未 spawn 时对 transcript JSONL 的实时跟踪（外部运行中的会话） */
+  tailer?: TranscriptTailer
+  /** tail 状态推送的节流时间戳 */
+  tailStatusAt?: number
+  /** 当前目标（claude /goal 由出站消息解析跟踪；codex 由 thread/goal/* 通知驱动） */
+  goal?: { condition: string; since: number }
+  /** /clear 触发的对话重置：conversation_reset 到达后置位，紧随的 init 完成 Hub 重键 */
+  pendingRekey?: boolean
+  /** 当前会话的 sessionId（每次 system/init 更新；/clear 重键后是新值） */
+  sessionId?: string
+  /** 已为哪个 sessionId 生成过 AI 标题（按会话去重，/clear 后的新会话自然再触发一次） */
+  titleGeneratedFor?: string
+  /** 首条 user 消息原文（标题素材）：init 未到时先记账，maybeGenerateTitle 两路触发 */
+  pendingTitleText?: string
+  /** sessionNameOf 的 s|/x| key cwd 缓存：反查（listSessions / CodexSession.cwd）至多一次（'' = 已查过、未知） */
+  nameCwd?: string
+}
+
+/** 全局收件箱（/ws/inbox）的事件种类：跨会话审批/完成/错误汇总 */
+export type InboxEvent =
+  | { type: 'approval'; key: string; requestId: string; toolName: string; input: unknown }
+  | { type: 'approval_resolved'; key: string; requestId: string }
+  | { type: 'done'; key: string; ok: boolean }
+  | { type: 'error'; key: string; message: string }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -463,7 +463,7 @@ function sessionCallbacks(hub: Hub) {
           action: auto.rule.action,
           rule: label,
         })
-        const s = isCodexKey(hub.key) ? codexRuntime.get(hub.key) : processManager.get(hub.key)
+        const s = portFor(hub.key).sessionOf(hub.key)
         if (s) s.sendApproval(req.requestId, decisionOfRule(auto.rule, req.input))
         else log.warn(`[approval] ${hub.key} 会话句柄已不存在，自动裁决无法送达`)
         return
@@ -477,7 +477,7 @@ function sessionCallbacks(hub: Hub) {
       })
       publishInbox({ type: 'approval', key: hub.key, requestId: req.requestId, toolName: req.toolName, input: req.input })
       pushStatus(hub)
-      processManager.get(hub.key)?.notifyExternalGate()
+      portFor(hub.key).notifyExternalGate(hub.key)
     },
     onStatusChange: () => throttledPushStatus(hub),
     onExit: (code: number) => {
@@ -653,8 +653,8 @@ function handleClientMessage(
  */
 function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision): boolean {
   if (!hub.pendingApprovals.delete(requestId)) return false
-  const codex = isCodexKey(hub.key)
-  const s = codex ? codexRuntime.get(hub.key) : processManager.get(hub.key)
+  const port = portFor(hub.key)
+  const s = port.sessionOf(hub.key)
   if (s && !s.exited) {
     try {
       s.sendApproval(requestId, decision)
@@ -665,7 +665,7 @@ function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision
     // 会话已退出/未就绪：决定无处投递（上游请求将自行超时），本地照常解析并告知用户
     broadcastError(hub, '会话未在运行，审批未能送达（该请求会在上游自行超时）')
   }
-  if (!codex) s?.notifyExternalGate()
+  port.notifyExternalGate(hub.key)
   broadcast(hub, { kind: 'approval_resolved', requestId })
   publishInbox({ type: 'approval_resolved', key: hub.key, requestId })
   pushStatus(hub)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,22 +1,22 @@
 // anyplane 服务端入口：REST + WebSocket + 静态托管
 
-import { appendFileSync, existsSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
 import { join, resolve } from 'node:path'
 import { hostAllowed, isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
-import { keyFor, keyForNew, parseKey, splitExistingKey } from './backends/claude/backend'
-import { listSessions, liveSessionInfo, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
+import { keyFor, keyForNew, parseKey } from './backends/claude/backend'
+import { listSessions, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
 import { resolveTierModelNames } from './backends/claude/modelNames'
 import { processManager } from './backends/claude/processManager'
 import { isInternalUserMessage, type CliMessage } from './backends/claude/protocol'
 import type { TranscriptTailer } from './backends/claude/tailer'
-import { isCodexKey, keyForNew as codexKeyForNew, listSessions as listCodexSessions, readHistory as readCodexHistory, splitThreadId } from './backends/codex/backend'
+import { keyForNew as codexKeyForNew, listSessions as listCodexSessions, readHistory as readCodexHistory } from './backends/codex/backend'
 import { codexRuntime } from './backends/codex/runtime'
 import { initBackendPorts, portFor } from './backends/port'
 import type { ApprovalDecision, SpawnOptions } from './backends/types'
 import { config } from './config'
 import { isOwnServerProcess, takeoverStaleListeners } from './portTakeover'
-import { archiveClaudeSession, listTrash, restoreClaudeSession } from './archive'
+import { listTrash } from './archive'
 import { FsBrowseError, listDirectories, readGitBranch } from './fsbrowse'
 import { resolveUpload } from './uploads'
 import {
@@ -958,41 +958,14 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
   if (url.pathname === '/api/sessions/archive' && req.method === 'POST') {
     const body = await readJsonBody<{ key?: string }>(req)
     if (!body.key) return json({ error: '缺少 key' }, { status: 400 })
-    try {
-      if (isCodexKey(body.key)) {
-        const threadId = splitThreadId(body.key)
-        if (!threadId) return json({ error: '无法解析 threadId' }, { status: 400 })
-        await codexRuntime.rpcRequest('thread/archive', { threadId })
-        return json({ ok: true })
-      }
-      const ek = splitExistingKey(body.key)
-      if (!ek) return json({ error: '仅支持已有会话' }, { status: 400 })
-      if (processManager.get(body.key) || liveSessionInfo(ek.sessionId)) {
-        return json({ error: '会话正在运行，无法归档' }, { status: 409 })
-      }
-      archiveClaudeSession(ek.slug, ek.sessionId)
-      return json({ ok: true })
-    } catch (e) {
-      return json({ error: errorMessage(e) }, { status: 500 })
-    }
+    const r = await portFor(body.key).archive(body.key)
+    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
   }
   if (url.pathname === '/api/sessions/restore' && req.method === 'POST') {
     const body = await readJsonBody<{ key?: string }>(req)
     if (!body.key) return json({ error: '缺少 key' }, { status: 400 })
-    try {
-      if (isCodexKey(body.key)) {
-        const threadId = splitThreadId(body.key)
-        if (!threadId) return json({ error: '无法解析 threadId' }, { status: 400 })
-        await codexRuntime.rpcRequest('thread/unarchive', { threadId })
-        return json({ ok: true })
-      }
-      const ek = splitExistingKey(body.key)
-      if (!ek) return json({ error: '仅支持 claude 会话恢复' }, { status: 400 })
-      restoreClaudeSession(ek.slug, ek.sessionId)
-      return json({ ok: true })
-    } catch (e) {
-      return json({ error: errorMessage(e) }, { status: 500 })
-    }
+    const r = await portFor(body.key).restore(body.key)
+    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
   }
   // 归档/回收站列表：codex archived + claude trash 合并
   if (url.pathname === '/api/sessions/archived' && req.method === 'GET') {
@@ -1028,33 +1001,10 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
     const body = await readJsonBody<{ key?: string; title?: string }>(req)
     const title = body.title?.trim()
     if (!body.key || !title) return json({ error: '缺少 key 或 title' }, { status: 400 })
-    // codex：官方 API，loaded/stored thread 均可
-    if (isCodexKey(body.key)) {
-      const threadId = splitThreadId(body.key)
-      if (!threadId) return json({ error: '无法解析 threadId' }, { status: 400 })
-      try {
-        await codexRuntime.rpcRequest('thread/name/set', { threadId, name: title })
-        return json({ ok: true })
-      } catch (e) {
-        return json({ error: errorMessage(e) }, { status: 500 })
-      }
-    }
-    // claude：仅离线会话（在线会话的 transcript 由 CLI 持有，改名走其内部路径）
-    const ek = splitExistingKey(body.key)
-    if (!ek) return json({ error: '仅支持已有 claude 会话' }, { status: 400 })
-    const { slug, sessionId } = ek
-    if (processManager.get(body.key) || liveSessionInfo(sessionId)) {
-      return json({ error: '会话正在运行，请在 CLI 退出后改名' }, { status: 409 })
-    }
-    const file = join(config.claudeConfigDir, 'projects', slug, `${sessionId}.jsonl`)
-    if (!existsSync(file)) return json({ error: 'transcript 不存在' }, { status: 404 })
-    try {
-      // 与官方 /rename 相同的条目形状；discovery 读取时后者优先
-      appendFileSync(file, JSON.stringify({ type: 'custom-title', sessionId, customTitle: title }) + '\n')
-      return json({ ok: true })
-    } catch (e) {
-      return json({ error: errorMessage(e) }, { status: 500 })
-    }
+    // codex 走官方 thread/name/set；claude 仅离线会话（transcript 追加 custom-title），
+    // 两路实现见各自适配器
+    const r = await portFor(body.key).rename(body.key, title)
+    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
   }
   if (url.pathname === '/api/handoff' && req.method === 'POST') {
     const body = await readJsonBody<{ fromKey?: string; toBackend?: string; detail?: HandoffDetail }>(req)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,17 +4,17 @@ import { appendFileSync, existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
 import { join, resolve } from 'node:path'
 import { hostAllowed, isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
-import { keyFor, keyForBranch, keyForNew, parseKey, splitExistingKey, type ParsedKey } from './backends/claude/backend'
+import { keyFor, keyForNew, parseKey, splitExistingKey } from './backends/claude/backend'
 import { listSessions, liveSessionInfo, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
 import { resolveTierModelNames } from './backends/claude/modelNames'
 import { processManager } from './backends/claude/processManager'
 import { isInternalUserMessage, type CliMessage } from './backends/claude/protocol'
-import { TranscriptTailer } from './backends/claude/tailer'
-import { isCodexKey, keyForNew as codexKeyForNew, listSessions as listCodexSessions, parseKey as codexParseKey, readHistory as readCodexHistory, splitThreadId } from './backends/codex/backend'
-import { codexRuntime, type CodexSession } from './backends/codex/runtime'
-import { portFor } from './backends/port'
+import type { TranscriptTailer } from './backends/claude/tailer'
+import { isCodexKey, keyForNew as codexKeyForNew, listSessions as listCodexSessions, readHistory as readCodexHistory, splitThreadId } from './backends/codex/backend'
+import { codexRuntime } from './backends/codex/runtime'
+import { initBackendPorts, portFor } from './backends/port'
 import type { ApprovalDecision, SpawnOptions } from './backends/types'
-import { config, defaultPermissionMode } from './config'
+import { config } from './config'
 import { isOwnServerProcess, takeoverStaleListeners } from './portTakeover'
 import { archiveClaudeSession, listTrash, restoreClaudeSession } from './archive'
 import { FsBrowseError, listDirectories, readGitBranch } from './fsbrowse'
@@ -32,9 +32,6 @@ import {
 } from './push'
 import {
   appendLineage,
-  briefPrompt,
-  generateClaudeBrief,
-  generateCodexBrief,
   lineageFor,
   seedMessage,
   type HandoffDetail,
@@ -104,6 +101,18 @@ export interface Hub {
 }
 
 const hubs = new Map<string, Hub>()
+
+// BackendPort 适配器的回调注入（装配层一次性注册；适配器禁止 import 本模块。
+// 被引用的均为函数声明，依赖 hoisting 而非 ESM 加载顺序）
+initBackendPorts({
+  broadcast,
+  broadcastError,
+  pushStatus,
+  sessionCallbacks,
+  getHub,
+  sessionNameOf,
+  rewindBusy,
+})
 
 // ---------- 全局收件箱（/ws/inbox）：跨会话审批/完成/错误汇总 ----------
 
@@ -381,28 +390,6 @@ function throttledPushStatus(hub: Hub): void {
   st.timer.unref?.()
 }
 
-/**
- * 官方 AI 标题（generate_session_title）：首条真实 user 消息 × 首个 init 双条件齐备即触发。
- * 两路调用——user 消息时（sessionId 已知）与 init 到达时（消息已记账）；按 sessionId 去重，
- * /clear 重键后的新会话自然再生成一次。CLI persist 把 ai-title 写进 transcript，
- * discovery 标题链（custom-title > ai-title > summary > 首条消息）自动接住，列表轮询内出现。
- */
-function maybeGenerateTitle(hub: Hub): void {
-  const sid = hub.sessionId
-  const text = hub.pendingTitleText
-  if (!sid || !text || hub.titleGeneratedFor === sid) return
-  const s = processManager.get(hub.key)
-  if (!s) return
-  hub.titleGeneratedFor = sid
-  hub.pendingTitleText = undefined
-  void s
-    .generateSessionTitle(text)
-    .then((title) => {
-      if (title) log.info(`[title] ${sessionNameOf(hub.key)} → ${title}`)
-    })
-    .catch(() => {}) // 标题失败无害：列表回退首条消息摘要
-}
-
 /** 两个后端共用的会话回调：CLI/翻译层消息广播、审批入 Hub 表、状态推动 */
 function sessionCallbacks(hub: Hub) {
   return {
@@ -446,7 +433,7 @@ function sessionCallbacks(hub: Hub) {
       // 每个 init 都更新会话身份（首次 spawn 与 /clear 重键共用；rekey 分支不落 return，会走到这里）
       if (msg.type === 'system' && msg.subtype === 'init') {
         hub.sessionId = String(msg.session_id ?? '') || undefined
-        maybeGenerateTitle(hub) // 首条消息可能已记账在等 sessionId
+        portFor(hub.key).maybeGenerateTitle(hub) // 首条消息可能已记账在等 sessionId（codex no-op）
       }
       broadcast(hub, { kind: 'cli', msg })
       // turn 收尾是收件箱的核心提醒信号（agent 跑完了）
@@ -499,150 +486,6 @@ function sessionCallbacks(hub: Hub) {
   }
 }
 
-/** codex 会话懒启动：attach(x|) 或首条 user 消息时 resume/start 线程 */
-async function ensureCodexSession(hub: Hub, opts?: Partial<SpawnOptions>): Promise<CodexSession | undefined> {
-  const parsed = codexParseKey(hub.key)
-  if (!parsed) {
-    broadcastError(hub, '无法解析 codex 会话 key')
-    return undefined
-  }
-  const spawnOpts = {
-    cwd: parsed.cwd,
-    resumeThreadId: parsed.resumeThreadId,
-    permissionMode: defaultPermissionMode(),
-    ...hub.spawnOpts,
-    ...opts,
-  }
-  hub.spawnOpts = spawnOpts
-  const s = codexRuntime.ensure(hub.key, spawnOpts, sessionCallbacks(hub))
-  s.syncClients(hub.clients.size)
-  try {
-    await s.start()
-  } catch (e) {
-    broadcastError(hub, errorMessage(e))
-    pushStatus(hub)
-    return undefined
-  }
-  pushStatus(hub)
-  return s
-}
-
-// ---------- transcript tailer（外部会话实时跟踪） ----------
-
-function stopTailer(hub: Hub): void {
-  hub.tailer?.stop()
-  hub.tailer = undefined
-}
-
-function throttledTailStatus(hub: Hub): void {
-  const now = Date.now()
-  if (now - (hub.tailStatusAt ?? 0) < 2000) return
-  hub.tailStatusAt = now
-  pushStatus(hub)
-}
-
-function startTailer(hub: Hub, from?: number): void {
-  if (hub.tailer) return
-  const ek = splitExistingKey(hub.key)
-  if (!ek) return // 新会话还没有 transcript
-  if (processManager.get(hub.key)) return // 已 spawn：live 流覆盖，无需 tail
-  const path = join(config.claudeConfigDir, 'projects', ek.slug, `${ek.sessionId}.jsonl`)
-  hub.tailer = new TranscriptTailer(path, from, {
-    onMessage: (msg) => {
-      broadcast(hub, { kind: 'tail', msg })
-      throttledTailStatus(hub)
-    },
-    onReset: () => {
-      stopTailer(hub)
-      broadcast(hub, { kind: 'tail_reset' })
-      pushStatus(hub)
-    },
-    onTick: () => throttledTailStatus(hub),
-  })
-  hub.tailer.start()
-  pushStatus(hub)
-}
-
-function rewindConversation(hub: Hub, userMessageId: string, scope: 'conversation' | 'both'): void {
-  const current = processManager.get(hub.key)
-  const parsed = parseKey(hub.key)
-  const sid = current?.sessionId ?? parsed?.resumeSessionId
-  if (!parsed || !sid) {
-    broadcastError(hub, '无法回滚：未知会话 ID')
-    return
-  }
-  // 先从 map 摘掉再 kill，避免旧 onExit 污染新会话。
-  processManager.dispose(hub.key)
-  hub.spawnOpts = { ...hub.spawnOpts, cwd: parsed.cwd, resumeSessionId: sid, resumeSessionAt: userMessageId }
-  ensureSpawned(hub, undefined, parsed)
-  const respawned = processManager.get(hub.key)
-  if (!respawned || respawned.exited) {
-    // ensureSpawned 已广播具体的 spawn 错误；不能向客户端虚报回滚成功。
-    return
-  }
-  broadcast(hub, { kind: 'rewound', userMessageId, scope })
-}
-
-function ensureSpawned(
-  hub: Hub,
-  opts?: Partial<SpawnOptions>,
-  parsedHint?: ParsedKey,
-): void {
-  // parseKey 会反查 listSessions()（一次文件系统扫描）；调用方已解析过时直接复用
-  const parsed = parsedHint ?? parseKey(hub.key)
-  if (!parsed) {
-    broadcastError(hub, '无法解析会话（项目目录不存在？）')
-    return
-  }
-  const spawnOpts: SpawnOptions = {
-    cwd: parsed.cwd,
-    resumeSessionId: parsed.resumeSessionId,
-    forkFromSessionId: parsed.forkFromSessionId,
-    permissionMode: defaultPermissionMode(),
-    ...hub.spawnOpts,
-    ...opts,
-  }
-  // b| 懒分叉的一次性语义：首个 init 已把分叉产出的新 sessionId 记入 hub.sessionId，
-  // 此后 respawn/rewind 必须 resume 分叉自身。否则 spawn() 里 fork 分支优先于 resume，
-  // 会从源会话重新 fork 出全新 sessionId，静默丢弃分叉后的全部对话；rewind 路径更致命——
-  // --resume-session-at 带的 messageId 在源 transcript 里根本不存在。
-  if (spawnOpts.forkFromSessionId && hub.sessionId) {
-    delete spawnOpts.forkFromSessionId
-    spawnOpts.resumeSessionId = hub.sessionId
-  }
-  hub.spawnOpts = spawnOpts
-  try {
-    const s = processManager.ensure(hub.key, spawnOpts, sessionCallbacks(hub))
-    // spawn 成功（或已有存活进程）：live 流接管，停掉 transcript tailer 避免重复推送
-    stopTailer(hub)
-    // 懒 spawn：WS 可能在进程创建前已 open，对齐客户端引用计数
-    s.syncClients(hub.clients.size)
-    // 自定义 env 必须排在首条 user 消息之前写入；stdin 保证顺序。
-    if (hub.pendingEnv && Object.keys(hub.pendingEnv).length > 0) {
-      s.write({ type: 'update_environment_variables', variables: hub.pendingEnv })
-      hub.pendingEnv = undefined
-    }
-  } catch (e) {
-    log.error(`[session ${hub.key}] spawn 失败:`, e) // 原对象打日志保留堆栈
-    broadcastError(hub, errorMessage(e))
-  }
-  // resumeSessionAt 是一次性 spawn 参数（命令行 args 已在 spawn() 内同步生成）。
-  // 无论本次成败都不能留在 hub.spawnOpts 里，否则之后空闲回收后的普通 respawn
-  // 会带着它再次截断同一条消息，静默丢弃回滚之后的新对话。
-  delete hub.spawnOpts.resumeSessionAt
-  pushStatus(hub)
-}
-
-/** claude 会话的就绪检查：未运行则触发懒 spawn；仍未就绪返回 undefined（ensureSpawned 已广播具体错误） */
-function ensureClaudeSession(hub: Hub): ReturnType<typeof processManager.get> {
-  let s = processManager.get(hub.key)
-  if (!s || s.exited) {
-    ensureSpawned(hub)
-    s = processManager.get(hub.key)
-  }
-  return s && !s.exited ? s : undefined
-}
-
 /** 回滚进行中拒绝新操作：返回 true 表示已拒绝（错误已广播） */
 function rewindBusy(hub: Hub, message = '已有回滚操作正在进行'): boolean {
   if (!hub.rewindPending) return false
@@ -665,23 +508,11 @@ function handleClientMessage(
     log.error(`[ws ${hub.key}] 上行非 JSON 帧，已丢弃`, { bytes: raw.length, head: raw.slice(0, 120), ...errFields(e) })
     return
   }
-  const session = () => processManager.get(hub.key)
   switch (data.kind) {
     case 'attach': {
       // 浏览历史只握手，不 spawn。发消息 / 切 model·mode·effort / rewind / btw 时再启动 CLI。
-      // 若客户端显式传 warm:true，则预热 resume（用于主动续聊）。
-      // codex：x| 会话 attach 即 resume（订阅实时事件）；xn| 新会话保持懒启动。
-      if (isCodexKey(hub.key)) {
-        if (data.warm === true || data.opts || hub.key.startsWith('x|')) {
-          void ensureCodexSession(hub, data.opts as Partial<SpawnOptions> | undefined)
-        } else {
-          pushStatus(hub)
-        }
-      } else if (data.warm === true || data.opts) {
-        ensureSpawned(hub, data.opts as Partial<SpawnOptions> | undefined)
-      } else {
-        pushStatus(hub)
-      }
+      // 各后端的 attach 策略（warm 预热、codex x| 即 resume）见适配器 onAttach。
+      portFor(hub.key).onAttach(hub, data)
       replayApprovals(hub, (p) => broadcast(hub, p))
       // 重连补发：客户端带上断线前的最高 seq，取回这期间错过的 cli 事件。
       // **必须单播**：走 broadcast 会让补发内容重新入环并分配新序号（自我污染），
@@ -705,11 +536,9 @@ function handleClientMessage(
       break
     }
     case 'tail_subscribe': {
-      // 客户端加载完历史后订阅 transcript 追加（from = 历史读取时的文件字节数，无缝衔接）
-      // codex 的实时流走 app-server 订阅，无 tailer 概念
-      if (!isCodexKey(hub.key)) {
-        startTailer(hub, typeof data.from === 'number' ? data.from : undefined)
-      }
+      // 客户端加载完历史后订阅 transcript 追加（from = 历史读取时的文件字节数，无缝衔接）；
+      // codex 的实时流走 app-server 订阅，无 tailer 概念（适配器内 no-op）
+      portFor(hub.key).startTailer(hub, typeof data.from === 'number' ? data.from : undefined)
       break
     }
     case 'user': {
@@ -723,55 +552,22 @@ function handleClientMessage(
         mediaType: String(a.mediaType ?? 'image/png'),
         dataBase64: String(a.dataBase64 ?? ''),
       }))
-      if (isCodexKey(hub.key)) {
-        void (async () => {
-          let s = codexRuntime.get(hub.key)
-          if (!s || s.exited || !s.sessionId) {
-            s = await ensureCodexSession(hub)
-          }
-          if (!s || s.exited) return // ensureCodexSession 已广播具体错误
-          try {
-            s.sendUserText(String(data.text ?? ''), sendMode, attachments)
-            pushStatus(hub)
-          } catch (e) {
-            broadcastError(hub, `发送失败: ${errorMessage(e)}`)
-            pushStatus(hub)
-          }
-        })()
-        return
-      }
-      const s = ensureClaudeSession(hub)
-      if (!s) return // ensureSpawned 已广播具体错误
-      try {
-        // sendMode 直通：claude 侧 steer=priority 'now'（中断处理）、queue=服务端排队
-        const text = String(data.text ?? '')
-        s.sendUserText(text, sendMode, attachments)
-        // /goal 是 claude 的本地斜杠命令（2.1.139+）：goal 状态不进 stream-json，
-        // 这里从出站文本跟踪 chip 状态；result 到达时清除（见 onMessage）
-        const goalMatch = text.match(/^\/goal\s*(.*)$/i)
-        if (goalMatch) {
-          const arg = goalMatch[1].trim()
-          if (!arg) {
-            // /goal 无参 = 查询状态，本地输出，不改变跟踪
-          } else if (/^(clear|stop|off|reset|none|cancel)$/i.test(arg)) {
-            hub.goal = undefined
-          } else {
-            hub.goal = { condition: arg, since: Date.now() }
-          }
+      const text = String(data.text ?? '')
+      void (async () => {
+        const port = portFor(hub.key)
+        const s = await port.ensureForSend(hub)
+        if (!s) return // 适配器已广播具体错误
+        try {
+          // sendMode 直通：claude 侧 steer=priority 'now'（中断处理）、queue=服务端排队
+          s.sendUserText(text, sendMode, attachments)
+          // 后端特定的发送后跟踪（claude：/goal 出站跟踪 + 标题素材记账；codex 无）
+          port.afterUserSent?.(hub, text)
+          pushStatus(hub)
+        } catch (e) {
+          broadcastError(hub, `发送失败: ${errorMessage(e)}`)
           pushStatus(hub)
         }
-        // 记录首条真实 user 消息作为标题素材（斜杠首消息不算会话主题，跳过）；
-        // 实际触发在 maybeGenerateTitle——需要 sessionId（init 可能尚未到达）。
-        // 条件显式写：titleGeneratedFor 与 sessionId 同 undefined 时也必须放行（全新 Hub）
-        if (text.trim() && !text.startsWith('/') && !(hub.titleGeneratedFor && hub.titleGeneratedFor === hub.sessionId)) {
-          hub.pendingTitleText ??= text
-          maybeGenerateTitle(hub)
-        }
-        pushStatus(hub)
-      } catch (e) {
-        broadcastError(hub, `发送失败: ${errorMessage(e)}`)
-        pushStatus(hub)
-      }
+      })()
       break
     }
     case 'control': {
@@ -790,46 +586,7 @@ function handleClientMessage(
       if (subtype === 'set_permission_mode' && extra.mode) {
         hub.spawnOpts = { ...hub.spawnOpts, permissionMode: String(extra.mode) }
       }
-      // codex：interrupt/set_model/set_permission_mode/compact 直接翻译；其余控制请求暂无对应物
-      if (isCodexKey(hub.key)) {
-        const s = codexRuntime.get(hub.key)
-        if (s && !s.exited) {
-          s.sendControl(subtype, extra)
-        }
-        pushStatus(hub)
-        return
-      }
-      // 中断：未启动则无需操作
-      if (subtype === 'interrupt') {
-        const s = session()
-        if (s && !s.exited) {
-          try {
-            s.sendControl(subtype, extra)
-          } catch (e) {
-            broadcastError(hub, `中断失败: ${errorMessage(e)}`)
-          }
-          pushStatus(hub)
-        }
-        return
-      }
-      let s = session()
-      if (!s || s.exited) {
-        if (subtype === 'set_model' || subtype === 'set_permission_mode') {
-          pushStatus(hub)
-          return
-        }
-        // 其他控制可能没有 CLI 参数等价物，仍需进程承接。
-        ensureSpawned(hub)
-        s = session()
-      }
-      if (!s || s.exited) return
-      try {
-        s.sendControl(subtype, extra)
-        pushStatus(hub)
-      } catch (e) {
-        broadcastError(hub, `控制请求失败: ${errorMessage(e)}`)
-        pushStatus(hub)
-      }
+      portFor(hub.key).deliverControl(hub, subtype, extra)
       break
     }
     case 'update_env': {
@@ -838,116 +595,27 @@ function handleClientMessage(
       const variables = (data.variables as Record<string, string>) ?? {}
       const effort = variables.CLAUDE_CODE_EFFORT_LEVEL
       if (effort) hub.spawnOpts = { ...hub.spawnOpts, effort }
-      if (isCodexKey(hub.key)) {
-        // codex：映射为 reasoning effort（CodexSession.write 内部翻译）
-        const s = codexRuntime.get(hub.key)
-        if (s && !s.exited) {
-          s.write({ type: 'update_environment_variables', variables })
-        }
-        pushStatus(hub)
-        return
-      }
-      const otherVariables = Object.fromEntries(
-        Object.entries(variables).filter(([key]) => key !== 'CLAUDE_CODE_EFFORT_LEVEL'),
-      )
-      const s = session()
-      if (!s || s.exited) {
-        if (Object.keys(otherVariables).length > 0) {
-          hub.pendingEnv = { ...hub.pendingEnv, ...otherVariables }
-        }
-        pushStatus(hub)
-        return
-      }
-      try {
-        s.write({ type: 'update_environment_variables', variables })
-        pushStatus(hub)
-      } catch (e) {
-        broadcastError(hub, `更新环境变量失败: ${errorMessage(e)}`)
-        pushStatus(hub)
-      }
+      portFor(hub.key).updateEnv(hub, variables)
       break
     }
     case 'branch': {
       // 分叉当前会话：claude 懒分叉（b| key，首条消息才 --fork-session），
-      // codex 走既有 thread/fork（RewindPicker 的"从此处分叉"）；这里只处理 claude。
-      if (isCodexKey(hub.key)) {
-        broadcastError(hub, 'Codex 请用回滚面板的「从此处分叉」')
-        return
-      }
-      const parsed = parseKey(hub.key)
-      const srcSid = session()?.sessionId ?? parsed?.resumeSessionId ?? parsed?.forkFromSessionId
-      if (!parsed || !srcSid) {
-        broadcastError(hub, '分叉需要已有会话（先发过至少一条消息）')
-        return
-      }
-      const branchKey = keyForBranch(parsed.cwd, srcSid)
-      // 预建 Hub 并缓存分叉源：首条 user 消息 ensureSpawned 时经 parseKey 拿到 forkFromSessionId
-      const branchHub = getHub(branchKey)
-      // /branch <名字>：透传给分叉 spawn 的 -n（列表页可区分分支用途）
-      const branchName = String(data.name ?? '').trim()
-      if (branchName) branchHub.spawnOpts = { ...branchHub.spawnOpts, sessionName: branchName }
-      broadcast(hub, { kind: 'forked', targetKey: branchKey, branchOf: srcSid, ...(branchName ? { name: branchName } : {}) })
+      // codex 走既有 thread/fork（RewindPicker 的"从此处分叉"，适配器内拒绝并引导）
+      portFor(hub.key).branch(hub, String(data.name ?? ''))
       break
     }
     case 'rewind_conversation': {
       const at = String(data.userMessageId ?? '')
       if (!at) return
-      if (isCodexKey(hub.key)) {
-        // codex：分叉语义——thread/fork(beforeTurnId) 复制该轮之前的历史为新线程，
-        // 原线程不动。userMessageId 即历史的轮首 userMessage 的 turnId。
-        const tid = codexRuntime.get(hub.key)?.sessionId ?? codexParseKey(hub.key)?.resumeThreadId
-        if (!tid) {
-          broadcastError(hub, 'codex 会话未就绪，无法分叉')
-          return
-        }
-        void codexRuntime
-          .forkAt(tid, at)
-          .then((newId) => {
-            broadcast(hub, {
-              kind: 'forked',
-              targetKey: `x|${newId}`,
-              targetSessionId: newId,
-              fromTurnId: at,
-            })
-          })
-          .catch((e) => broadcastError(hub, `分叉失败: ${errorMessage(e)}`))
-        return
-      }
-      if (rewindBusy(hub)) return
-      rewindConversation(hub, at, 'conversation')
+      // claude=原地截断重 spawn；codex=thread/fork 分叉语义（rewindPending 守卫在适配器内）
+      portFor(hub.key).rewindConversation(hub, at)
       break
     }
     case 'rewind_both': {
       const at = String(data.userMessageId ?? '')
       if (!at) return
-      if (isCodexKey(hub.key)) {
-        broadcastError(hub, 'Codex 没有文件检查点，不支持文件回滚（可用 git 管理代码历史）')
-        return
-      }
-      if (rewindBusy(hub)) return
-      const s = ensureClaudeSession(hub)
-      if (!s) return
-
-      // 官方 TUI 的“恢复代码和对话”也是两个动作。这里必须先收到文件
-      // checkpoint 成功响应，才允许销毁旧进程并以 resume-session-at 截断对话。
-      // rewind_files 没有 CLI 侧超时，大项目恢复可达分钟级，给足 120s。
-      hub.rewindPending = true
-      pushStatus(hub, { rewindPending: true })
-      void s.sendControlAndWait('rewind_files', { user_message_id: at }, 120_000)
-        .then(() => {
-          if (processManager.get(hub.key) !== s || s.exited) {
-            broadcastError(hub, '恢复文件后会话已变化，未回滚对话')
-            return
-          }
-          rewindConversation(hub, at, 'both')
-        })
-        .catch((error) => {
-          broadcastError(hub, `回滚文件失败，未回滚对话：${errorMessage(error)}`)
-        })
-        .finally(() => {
-          hub.rewindPending = false
-          pushStatus(hub, { rewindPending: false })
-        })
+      // 组合回滚：claude 先 rewind_files 再截断；codex 无文件检查点（适配器内拒绝）
+      portFor(hub.key).rewindBoth(hub, at)
       break
     }
     case 'btw': {
@@ -956,70 +624,19 @@ function handleClientMessage(
       // btw_pending 必须先于校验失败分支发出：前端卡片由它创建，
       // 否则校验失败的 btw_result 找不到卡（按 question 配对）被静默丢弃，用户零反馈
       if (question) broadcast(hub, { kind: 'btw_pending', question })
-      if (isCodexKey(hub.key)) {
-        const parsed = codexParseKey(hub.key)
-        const tid = codexRuntime.get(hub.key)?.sessionId ?? parsed?.resumeThreadId
-        if (!question || !tid) {
-          broadcast(hub, { kind: 'btw_result', ok: false, question, text: '侧问需要已有会话（先发过至少一条消息）' })
-          return
-        }
-        void codexRuntime
-          .runEphemeralQuestion(tid, question, 180_000, (delta, thinking) => {
-            broadcast(hub, { kind: 'btw_delta', question, delta, thinking: thinking || undefined })
-          })
-          .then((r) => broadcast(hub, { kind: 'btw_result', ok: true, question, text: r.text }))
-          .catch((e) =>
-            broadcast(hub, { kind: 'btw_result', ok: false, question, text: `侧问失败: ${errorMessage(e)}` }),
-          )
-        return
-      }
-      // claude：官方 side_question 控制通道（进程内轻量 fork，共享 prompt cache，
-      // 不产生磁盘 FORK 会话）。无流式增量，应答单次返回。
-      const parsed = parseKey(hub.key)
-      const sid = session()?.sessionId ?? parsed?.resumeSessionId ?? parsed?.forkFromSessionId
-      if (!question || !parsed || !sid) {
-        broadcast(hub, { kind: 'btw_result', ok: false, question, text: '侧问需要已有会话（先发过至少一条消息）' })
-        return
-      }
-      const s = ensureClaudeSession(hub)
-      if (!s) return // ensureSpawned 已广播具体错误
-      s.sideQuestion(question)
-        .then((text) => broadcast(hub, { kind: 'btw_result', ok: true, question, text }))
-        .catch((e) =>
-          broadcast(hub, { kind: 'btw_result', ok: false, question, text: `侧问失败: ${errorMessage(e)}` }),
-        )
+      portFor(hub.key).btw(hub, question)
       break
     }
     case 'query': {
       // 带应答的控制请求通道：只读查询（mcp_status / get_settings / get_context_usage）
       // 与 MCP 管理动作（mcp_reconnect / mcp_toggle，经 extra 传参）共用；
-      // codex 仅 mcp_status 有对应物 mcpServerStatus/list（动作类一律拒绝）
+      // codex 仅 mcp_status 有对应物 mcpServerStatus/list（动作类一律拒绝，见适配器）
       const id = String(data.id ?? '')
       const query = String(data.query ?? '')
       const extra = (data.extra as Record<string, unknown> | undefined) ?? {}
       const reply = (payload: Record<string, unknown>) => broadcast(hub, { kind: 'query_result', id, ...payload })
       if (!id || !query) return
-      if (isCodexKey(hub.key)) {
-        if (query !== 'mcp_status') {
-          reply({ ok: false, error: `codex 后端暂不支持 ${query}` })
-          return
-        }
-        void codexRuntime
-          .rpcRequest('mcpServerStatus/list', {})
-          .then((d) => reply({ ok: true, data: d }))
-          .catch((e) => reply({ ok: false, error: errorMessage(e) }))
-        return
-      }
-      const s = ensureClaudeSession(hub)
-      if (!s) {
-        reply({ ok: false, error: '进程未运行' })
-        return
-      }
-      // 重连/启用是完整 MCP 握手，慢于普通查询，给足超时
-      const timeoutMs = query === 'mcp_reconnect' || query === 'mcp_toggle' ? 30_000 : 15_000
-      s.sendControlAndWait(query, extra, timeoutMs)
-        .then((d) => reply({ ok: true, data: d }))
-        .catch((e) => reply({ ok: false, error: errorMessage(e) }))
+      portFor(hub.key).query(hub, query, extra, reply)
       break
     }
     case 'approval': {
@@ -1064,81 +681,33 @@ function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision
  */
 function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detail: HandoffDetail): string | undefined {
   const sourceHub = hubs.get(fromKey)
-  const fromBackend = isCodexKey(fromKey) ? ('codex' as const) : ('claude' as const)
+  const fromPort = portFor(fromKey)
+  const fromBackend = fromPort.name
   if (fromBackend === toBackend) return '接力目标必须与源会话是不同后端'
 
-  // 源解析：cwd + 会话 id（codex 的 x| key 不含 cwd，需在异步路径里 thread/read 解析）
-  let cwd: string | undefined
-  let sourceId: string | undefined
-  if (fromBackend === 'claude') {
-    const parsed = parseKey(fromKey)
-    cwd = parsed?.cwd
-    sourceId = processManager.get(fromKey)?.sessionId ?? parsed?.resumeSessionId
-    if (!cwd) return '无法确定源会话目录'
-  } else {
-    const parsed = codexParseKey(fromKey)
-    cwd = parsed?.cwd
-    sourceId = parsed?.resumeThreadId
-  }
-  if (!sourceId) return '源会话还没有任何消息，无法接力'
+  // 源解析：cwd + 会话 id（codex 的 x| key 不含 cwd，需在异步路径里惰性解析）
+  const src = fromPort.handoffSource(fromKey)
+  if (fromBackend === 'claude' && !src.cwd) return '无法确定源会话目录'
+  if (!src.sourceId) return '源会话还没有任何消息，无法接力'
 
-  const sid = sourceId
+  const sid = src.sourceId
   void (async () => {
     try {
       // codex x| key：cwd 需要 thread/read 惰性解析
-      const sourceCwd = cwd ?? (await codexRuntime.threadCwd(sid))
+      const sourceCwd = src.cwd ?? (await fromPort.handoffCwdOf(fromKey, sid))
       if (!sourceCwd) throw new Error('无法确定源会话目录（thread/read 未返回 cwd）')
       if (sourceHub) broadcast(sourceHub, { kind: 'handoff_pending', toBackend })
       // 1. 源会话 fork 自摘要
       //    claude 源在线时走 side_question 控制通道（进程内 fork，零冷启动、不留 FORK 会话）；
       //    离线才 spawn 一次性 --fork-session --bare 进程
-      const { text: brief, usage } = await (async () => {
-        if (fromBackend === 'claude') {
-          const live = processManager.get(fromKey)
-          if (live && !live.exited) {
-            try {
-              const text = await live.sideQuestion(briefPrompt(detail))
-              if (text.trim()) return { text, usage: undefined }
-            } catch {
-              // side_question 失败回落 fork spawn（如 CLI 版本过旧无此通道）
-            }
-          }
-          return generateClaudeBrief(sourceCwd, sid, detail)
-        }
-        return generateCodexBrief(sid, detail)
-      })()
+      const { text: brief, usage } = await fromPort.forkBriefForHandoff(fromKey, sourceCwd, sid, detail)
       if (sourceHub) broadcast(sourceHub, { kind: 'handoff_brief', brief })
 
-      // 2. 目标会话播种（服务端直接发送首条消息）
+      // 2. 目标会话播种（服务端直接发送首条消息；启动失败抛错）
       const targetKey = toBackend === 'codex' ? codexKeyForNew(sourceCwd) : keyForNew(sourceCwd)
       const targetHub = getHub(targetKey)
       const seed = seedMessage(sourceCwd, fromBackend, brief)
-      let targetSessionId: string | undefined
-      if (toBackend === 'codex') {
-        const s = await ensureCodexSession(targetHub)
-        if (!s || s.exited) throw new Error('目标 codex 会话启动失败')
-        s.sendUserText(seed)
-        targetSessionId = s.sessionId
-      } else {
-        ensureSpawned(targetHub)
-        const s = processManager.get(targetKey)
-        if (!s || s.exited) throw new Error('目标 claude 会话启动失败')
-        s.sendUserText(seed)
-        targetSessionId = s.sessionId
-      }
-      // claude 的 sessionId 在 init 时才就绪：短轮询等待，随后回填真实 key（血缘导航用）
-      if (toBackend === 'claude' && !targetSessionId) {
-        const deadline = Date.now() + 30_000
-        // 每轮重新取句柄：等待期间旧进程可能退出并被重生，旧引用拿不到新 sessionId
-        for (;;) {
-          const cur = processManager.get(targetKey)
-          if (!cur || cur.sessionId || cur.exited || Date.now() >= deadline) {
-            targetSessionId = cur?.sessionId
-            break
-          }
-          await Bun.sleep(500)
-        }
-      }
+      const targetSessionId = await portFor(targetKey).seedHandoffTarget(targetHub, seed)
       const toResolvedKey =
         toBackend === 'codex'
           ? targetSessionId
@@ -1150,11 +719,11 @@ function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detail: Hand
       const fromResolvedKey = (() => {
         if (fromBackend === 'claude') {
           if (fromKey.startsWith('s|')) return fromKey
-          const sidNow = processManager.get(fromKey)?.sessionId
+          const sidNow = fromPort.sessionOf(fromKey)?.sessionId
           return sidNow ? keyFor(sanitizePath(sourceCwd), sidNow) : undefined
         }
         if (fromKey.startsWith('x|')) return fromKey
-        const tidNow = codexRuntime.get(fromKey)?.sessionId
+        const tidNow = fromPort.sessionOf(fromKey)?.sessionId
         return tidNow ? `x|${tidNow}` : undefined
       })()
 
@@ -1731,7 +1300,7 @@ function createServer(): ReturnType<typeof Bun.serve<WSData>> {
         port.sessionOf(hub.key)?.detachClient()
         const alive = port.hasLiveSession(hub.key)
         if (hub.clients.size === 0) {
-          stopTailer(hub)
+          port.stopTailer(hub)
           if (!alive) hubs.delete(hub.key)
         }
       },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,14 +4,16 @@ import { appendFileSync, existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
 import { join, resolve } from 'node:path'
 import { hostAllowed, isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
-import { keyFor, keyForBranch, keyForNew, parseKey, splitExistingKey, hydratedContextOf, type ParsedKey } from './backends/claude/backend'
+import { keyFor, keyForBranch, keyForNew, parseKey, splitExistingKey, type ParsedKey } from './backends/claude/backend'
 import { listSessions, liveSessionInfo, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
 import { resolveTierModelNames } from './backends/claude/modelNames'
-import { processManager, type ApprovalDecision, type SpawnOptions } from './backends/claude/processManager'
+import { processManager } from './backends/claude/processManager'
 import { isInternalUserMessage, type CliMessage } from './backends/claude/protocol'
 import { TranscriptTailer } from './backends/claude/tailer'
 import { isCodexKey, keyForNew as codexKeyForNew, listSessions as listCodexSessions, parseKey as codexParseKey, readHistory as readCodexHistory, splitThreadId } from './backends/codex/backend'
 import { codexRuntime, type CodexSession } from './backends/codex/runtime'
+import { portFor } from './backends/port'
+import type { ApprovalDecision, SpawnOptions } from './backends/types'
 import { config, defaultPermissionMode } from './config'
 import { isOwnServerProcess, takeoverStaleListeners } from './portTakeover'
 import { archiveClaudeSession, listTrash, restoreClaudeSession } from './archive'
@@ -69,7 +71,7 @@ interface WSDataInbox {
 
 type WSData = WSDataSession | WSDataInbox
 
-interface Hub {
+export interface Hub {
   key: string
   clients: Set<import('bun').ServerWebSocket<WSData>>
   pendingApprovals: Map<string, PendingApproval>
@@ -337,70 +339,13 @@ function broadcastError(hub: Hub, message: string): void {
   broadcast(hub, { kind: 'error', message })
 }
 
-/** 两后端会话状态的公共字段（claude/codex 会话句柄结构化同形，契约见 backends/types.ts 末尾） */
-function baseStatusOf(
-  s:
-    | {
-        exited: boolean
-        busy: boolean
-        waiting: boolean
-        sessionState: string
-        sessionId: string | undefined
-        connectedClients: number
-        tokenUsage: unknown
-        contextUsage: unknown
-      }
-    | undefined,
-  hub: Hub | undefined,
-  waiting: boolean,
-): Record<string, unknown> {
-  return {
-    spawned: !!s && !s.exited,
-    busy: (s?.busy ?? false) || waiting,
-    waiting,
-    sessionState: s?.sessionState ?? 'idle',
-    sessionId: s?.sessionId,
-    clients: s?.connectedClients ?? hub?.clients.size ?? 0,
-    usage: s?.tokenUsage,
-    context: s?.contextUsage,
-    permissionMode: hub?.spawnOpts?.permissionMode,
-    effort: hub?.spawnOpts?.effort,
-  }
-}
-
 /** liveHint：调用方（/api/sessions）刚做过 pid 扫描时传入复用，避免每行各扫一次；
  *  显式 null 表示"已知不在线"（跳过扫描），undefined 才现扫。
  *  hydrateContext：仅单会话 attach/pushStatus 路径开启（离线时读 transcript 尾部补
- *  上下文占用）；列表端点禁止开启（N 行 × 文件读）。 */
+ *  上下文占用）；列表端点禁止开启（N 行 × 文件读）。
+ *  实现已按后端收敛进适配器（backends/port.ts 的 portFor 分发；公共字段见 baseStatusOf）。 */
 function statusOf(key: string, liveHint?: { status: string; pid: number } | null, hydrateContext = false): Record<string, unknown> {
-  if (isCodexKey(key)) return codexStatusOf(key)
-  const s = processManager.get(key)
-  const hub = hubs.get(key)
-  const pending = hub?.pendingApprovals.size ?? 0
-  // 未被本服务 spawn 的会话：读 pid 文件，把外部 CLI 的实时状态反映到 busy/waiting
-  let live: { status: string; pid: number } | undefined
-  if (!s || s.exited) {
-    const ek = splitExistingKey(key)
-    if (ek) live = liveHint === undefined ? liveSessionInfo(ek.sessionId) : (liveHint ?? undefined)
-  }
-  const waiting = (s?.waiting ?? false) || pending > 0 || live?.status === 'waiting'
-  const st = baseStatusOf(s, hub, waiting)
-  if (live?.status === 'busy') st.busy = true // 审批等待与外部进程 busy 都算 busy，防止误回收
-  // 离线/未 spawn 水合：直读 transcript 尾部，点开会话即有上下文环形（无需先发消息）；
-  // live 值存在时恒优先（spawn 内水合与实时跟踪是同源数据的更新版）
-  if (hydrateContext && st.context == null) st.context = hydratedContextOf(key)
-  return {
-    ...st,
-    activeTaskCount: s?.activeTaskCount ?? 0,
-    activeTasks: s?.backgroundTasks ?? [],
-    slashCommands: s?.slashCommands,
-    // spawnOpts.model 是用户显式选择（未 spawn 时的待应用值）；initModel 是进程 init 报告的解析后 ID。
-    // 后者让重连 attach 的页面不必等下一轮就能显示模型（StatusPill 再经 modelNames 映射成配置名）
-    model: hub?.spawnOpts?.model ?? s?.initModel,
-    tailing: !!hub?.tailer,
-    liveStatus: live?.status,
-    goal: hub?.goal ?? null,
-  }
+  return portFor(key).statusOf(key, { hub: hubs.get(key), liveHint, hydrateContext })
 }
 
 function pushStatus(hub: Hub, extra?: Record<string, unknown>): void {
@@ -434,21 +379,6 @@ function throttledPushStatus(hub: Hub): void {
     }
   }, STATUS_THROTTLE_MS)
   st.timer.unref?.()
-}
-
-/** codex 会话状态：与 statusOf 同形，供列表 managed 字段与 WS status 复用 */
-function codexStatusOf(key: string): Record<string, unknown> {
-  const s = codexRuntime.get(key)
-  const hub = hubs.get(key)
-  const waiting = (s?.waiting ?? false) || (hub?.pendingApprovals.size ?? 0) > 0
-  return {
-    ...baseStatusOf(s, hub, waiting),
-    // 不下发 activeTasks/activeTaskCount：codex 服务端不维护任务表，恒空数组会被
-    // hydrateTasks 误读为"权威空"而在空闲时判死 live 桶；字段缺席则前端跳过水合
-    model: hub?.spawnOpts?.model,
-    tailing: false,
-    goal: s?.goal ?? null,
-  }
 }
 
 /**
@@ -1431,7 +1361,7 @@ async function handleApi(req: Request, url: URL): Promise<Response | undefined> 
         backend: 'codex' as const,
         gitBranch: branchOfCached(t.cwd),
         key: t.key,
-        managed: codexStatusOf(t.key),
+        managed: statusOf(t.key),
       }))
     } catch (e) {
       log.warn('[api] codex thread/list 失败（仅返回 claude 会话）:', e instanceof Error ? e.message : e)
@@ -1760,8 +1690,7 @@ function createServer(): ReturnType<typeof Bun.serve<WSData>> {
         }
         const hub = getHub(ws.data.key)
         hub.clients.add(ws)
-        processManager.get(ws.data.key)?.attachClient()
-        codexRuntime.get(ws.data.key)?.attachClient()
+        portFor(ws.data.key).sessionOf(ws.data.key)?.attachClient()
         ws.send(JSON.stringify({ kind: 'status', state: statusOf(ws.data.key, undefined, true) }))
         replayApprovals(hub, (p) => ws.send(JSON.stringify(p)))
       },
@@ -1798,10 +1727,9 @@ function createServer(): ReturnType<typeof Bun.serve<WSData>> {
         // 不变量：任何后端的会话句柄存活期间，其 Hub 必须存活——
         // 否则重连时复用旧会话，其回调会把事件广播进已删除的 Hub（消息黑洞）。
         // 用 hub.key 而非 ws.data.key：重键后进程注册在新 key 下
-        const codex = isCodexKey(hub.key)
-        const s = codex ? codexRuntime.get(hub.key) : processManager.get(hub.key)
-        s?.detachClient()
-        const alive = codex ? !!s && !s.exited : !!s
+        const port = portFor(hub.key)
+        port.sessionOf(hub.key)?.detachClient()
+        const alive = port.hasLiveSession(hub.key)
         if (hub.clients.size === 0) {
           stopTailer(hub)
           if (!alive) hubs.delete(hub.key)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,24 +1,37 @@
 // anyplane 服务端入口：REST + WebSocket + 静态托管
+// S2 拆分后的职责边界：Hub 编排层在 hub/（registry/broadcast/status/callbacks/lifecycle/messages/handoff/socket），
+// 推送扇出在 push/（fanout/inbox）；本文件保留 REST 路由（handleApi）与进程装配（启动守卫/createServer/shutdown）。
 
 import { existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
 import { join, resolve } from 'node:path'
+import { listTrash } from './archive'
 import { hostAllowed, isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
-import { keyFor, keyForNew, parseKey } from './backends/claude/backend'
+import { keyFor, keyForNew } from './backends/claude/backend'
 import { listSessions, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
 import { resolveTierModelNames } from './backends/claude/modelNames'
 import { processManager } from './backends/claude/processManager'
-import { isInternalUserMessage, type CliMessage } from './backends/claude/protocol'
-import type { TranscriptTailer } from './backends/claude/tailer'
-import { keyForNew as codexKeyForNew, listSessions as listCodexSessions, readHistory as readCodexHistory } from './backends/codex/backend'
+import {
+  keyForNew as codexKeyForNew,
+  listSessions as listCodexSessions,
+  readHistory as readCodexHistory,
+} from './backends/codex/backend'
 import { codexRuntime } from './backends/codex/runtime'
 import { initBackendPorts, portFor } from './backends/port'
-import type { ApprovalDecision, SpawnOptions } from './backends/types'
 import { config } from './config'
-import { isOwnServerProcess, takeoverStaleListeners } from './portTakeover'
-import { listTrash } from './archive'
+import { startupVersionProbe } from './driftGuard'
 import { FsBrowseError, listDirectories, readGitBranch } from './fsbrowse'
-import { resolveUpload } from './uploads'
+import { lineageFor, type HandoffDetail } from './handoff'
+import { broadcast, broadcastError } from './hub/broadcast'
+import { sessionCallbacks } from './hub/callbacks'
+import { runHandoff } from './hub/handoff'
+import { resolveApproval, rewindBusy } from './hub/lifecycle'
+import { getHub, hubs } from './hub/registry'
+import { wsClose, wsMessage, wsOpen } from './hub/socket'
+import { pushStatus, statusOf } from './hub/status'
+import type { WSData } from './hub/types'
+import { log } from './log'
+import { isOwnServerProcess, takeoverStaleListeners } from './portTakeover'
 import {
   addSubscription,
   pushToAll,
@@ -30,80 +43,17 @@ import {
   webhookCount,
   type PushPayload,
 } from './push'
-import {
-  appendLineage,
-  lineageFor,
-  seedMessage,
-  type HandoffDetail,
-} from './handoff'
-import { errorMessage, escapeHtml, hasWindowsSocketFix } from './util'
-import { startupVersionProbe } from './driftGuard'
-import { decisionOfRule, matchApprovalRule } from './approvalRules'
-import { errFields, log } from './log'
-import { pushCliRing, replayCliSince } from './cliReplay'
+import { approvalPageHtml, sessionNameOf } from './push/fanout'
+import { initInbox } from './push/inbox'
+import { resolveUpload } from './uploads'
+import { errorMessage, hasWindowsSocketFix } from './util'
 
 // ---------- sessionKey ----------
 // 编码规则与解析见 backends/claude/backend.ts（s|slug|sid / n|cwd）
 
-// ---------- WS 枢纽 ----------
-
-interface PendingApproval {
-  requestId: string
-  toolName: string
-  input: unknown
-}
-
-interface WSDataSession {
-  key: string
-  inbox?: never
-  /** 下行保活定时器（见 websocket handler 注释） */
-  keepalive?: ReturnType<typeof setInterval>
-}
-
-interface WSDataInbox {
-  inbox: true
-  key?: never
-  keepalive?: ReturnType<typeof setInterval>
-}
-
-type WSData = WSDataSession | WSDataInbox
-
-export interface Hub {
-  key: string
-  clients: Set<import('bun').ServerWebSocket<WSData>>
-  pendingApprovals: Map<string, PendingApproval>
-  /** 下行 cli 事件的单调序号（重连补发用，见 cliReplay.ts） */
-  cliSeq?: number
-  /** 最近 CLI_RING_CAP 条可落盘 cli 事件的环形缓冲（不含 stream_event） */
-  cliRing?: Array<{ seq: number; payload: Record<string, unknown> }>
-  /** 未 spawn 时缓存启动偏好；已 spawn 时记录当前选择，供 UI 重连恢复 */
-  spawnOpts?: Partial<SpawnOptions>
-  /** 除 effort 外、需要在进程启动后按顺序写入 stdin 的环境变量 */
-  pendingEnv?: Record<string, string>
-  /** 组合回滚正在等待 rewind_files 的 CLI 确认，期间禁止再切断当前会话。 */
-  rewindPending?: boolean
-  /** 未 spawn 时对 transcript JSONL 的实时跟踪（外部运行中的会话） */
-  tailer?: TranscriptTailer
-  /** tail 状态推送的节流时间戳 */
-  tailStatusAt?: number
-  /** 当前目标（claude /goal 由出站消息解析跟踪；codex 由 thread/goal/* 通知驱动） */
-  goal?: { condition: string; since: number }
-  /** /clear 触发的对话重置：conversation_reset 到达后置位，紧随的 init 完成 Hub 重键 */
-  pendingRekey?: boolean
-  /** 当前会话的 sessionId（每次 system/init 更新；/clear 重键后是新值） */
-  sessionId?: string
-  /** 已为哪个 sessionId 生成过 AI 标题（按会话去重，/clear 后的新会话自然再触发一次） */
-  titleGeneratedFor?: string
-  /** 首条 user 消息原文（标题素材）：init 未到时先记账，maybeGenerateTitle 两路触发 */
-  pendingTitleText?: string
-  /** sessionNameOf 的 s|/x| key cwd 缓存：反查（listSessions / CodexSession.cwd）至多一次（'' = 已查过、未知） */
-  nameCwd?: string
-}
-
-const hubs = new Map<string, Hub>()
-
-// BackendPort 适配器的回调注入（装配层一次性注册；适配器禁止 import 本模块。
-// 被引用的均为函数声明，依赖 hoisting 而非 ESM 加载顺序）
+// ---------- 装配：适配器回调注入 + inbox sink 接线 ----------
+// BackendPort 适配器禁止 import hub/push 编排模块，回调经 HubServices 一次性注入；
+// inbox 事件经 hub/broadcast 的 InboxSink 出口流向 push/inbox 的真实实现（解 hub↔push 循环）。
 initBackendPorts({
   broadcast,
   broadcastError,
@@ -113,650 +63,7 @@ initBackendPorts({
   sessionNameOf,
   rewindBusy,
 })
-
-// ---------- 全局收件箱（/ws/inbox）：跨会话审批/完成/错误汇总 ----------
-
-const inboxClients = new Set<import('bun').ServerWebSocket<WSDataInbox>>()
-
-type InboxEvent =
-  | { type: 'approval'; key: string; requestId: string; toolName: string; input: unknown }
-  | { type: 'approval_resolved'; key: string; requestId: string }
-  | { type: 'done'; key: string; ok: boolean }
-  | { type: 'error'; key: string; message: string }
-
-function publishInbox(ev: InboxEvent): void {
-  if (inboxClients.size > 0) {
-    const text = JSON.stringify(ev)
-    for (const ws of inboxClients) {
-      try {
-        ws.send(text)
-      } catch {}
-    }
-  }
-  fanoutPush(ev)
-}
-
-// ---------- Web Push 分发（订阅为 0 时零开销） ----------
-
-/** 会话显示名：项目目录 basename（approval 只在 spawn 后发生，spawnOpts.cwd 必有）。
- *  s| 未 spawn 时经 parseKey 反查真实 cwd——每 Hub 至多一次（缓存在 hub.nameCwd，
- *  避免推送事件触发反复 listSessions 全盘扫描）；b|/n|/xn| 的 cwd 内嵌在 key 里直接取。
- *  parseKey 也查不到（slug 目录已删）时以 slug 末段近似。 */
-function sessionNameOf(key: string): string {
-  const base = (cwd: string) => cwd.replace(/\/+$/, '').split('/').pop() ?? cwd
-  const hub = hubs.get(key)
-  if (hub?.spawnOpts?.cwd) return base(hub.spawnOpts.cwd)
-  const parts = key.split('|')
-  try {
-    if ((parts[0] === 'b' || parts[0] === 'n' || parts[0] === 'xn') && parts[1]) {
-      return base(decodeURIComponent(parts[1]))
-    }
-  } catch {
-    // key 内嵌 cwd 不是合法 URI 编码（状态损坏/构造输入）：落 key 截断，不影响推送分发
-    return key.slice(0, 18)
-  }
-  if (parts[0] === 's') {
-    if (hub && hub.nameCwd === undefined) hub.nameCwd = parseKey(key)?.cwd ?? ''
-    if (hub?.nameCwd) return base(hub.nameCwd)
-    // slug 是 sanitizePath(cwd)：末段即目录名（近似，仅推送显示用）
-    if (parts[1]) return parts[1].split('-').pop() ?? key.slice(0, 18)
-  }
-  // x|：cwd 不在 key 里，取已加载 CodexSession 的 cwd（thread/read 解析后即有；
-  // 推送/审批页恰好在会话存活期触发）。取不到时落 key 截断，不做同步 RPC
-  if (parts[0] === 'x') {
-    if (hub && hub.nameCwd === undefined) hub.nameCwd = codexRuntime.get(key)?.cwd ?? ''
-    if (hub?.nameCwd) return base(hub.nameCwd)
-  }
-  return key.slice(0, 18)
-}
-
-/** 审批输入摘要（推送通知/审批页）：按工具挑裁决所需的关键字段，其余给 JSON 截断。
- *  与 web 端 toolSummary 同族但取舍不同——审批场景 Bash 必须给 command 本体
- *  （description 是作者给的说明文字，不能作为裁决依据；web 卡片下方另有详情区才可用它打头）。 */
-function summarizeInput(toolName: string, input: unknown): string {
-  const obj = (input ?? {}) as Record<string, unknown>
-  if (toolName === 'Bash') return String(obj.command ?? '').slice(0, 400)
-  if (toolName === 'Glob' || toolName === 'Grep') return String(obj.pattern ?? '')
-  if (toolName === 'WebSearch') return String(obj.query ?? '')
-  if (toolName === 'WebFetch') return String(obj.url ?? '')
-  if (toolName === 'Agent') return String(obj.description ?? obj.prompt ?? '').slice(0, 300)
-  if (obj.file_path) return String(obj.file_path)
-  if (obj.path) return String(obj.path)
-  if (obj.grantRoot) return String(obj.grantRoot)
-  const json = JSON.stringify(input ?? {})
-  return json.length > 300 ? json.slice(0, 300) + '…' : json
-}
-
-/**
- * webhook 审批确认页（GET /api/approval-page 的 HTML）。
- * 故意零依赖零外链（微信内置浏览器可达性）；k/r/s 由页面 JS 从自身 URL 读取，
- * 服务端只注入已转义的工具名与摘要，不把 secret 写进 HTML。
- */
-function approvalPageHtml(key: string, pending?: PendingApproval): string {
-  const session = escapeHtml(sessionNameOf(key))
-  const tool = pending ? escapeHtml(pending.toolName) : ''
-  const summary = pending ? escapeHtml(summarizeInput(pending.toolName, pending.input)) : ''
-  const inner = pending
-    ? `<p class="meta">${session}</p>
-  <h1>需要审批 · ${tool}</h1>
-  <pre>${summary}</pre>
-  <div class="row">
-    <button class="ok" onclick="act('allow')">允许</button>
-    <button class="no" onclick="act('deny')">拒绝</button>
-  </div>
-  <p id="st" class="meta"></p>`
-    : `<h1>审批已处理</h1>
-  <p class="meta">${session} · 该请求已被裁决或不存在，无需操作</p>`
-  return `<!doctype html>
-<html lang="zh-CN">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="robots" content="noindex">
-<title>审批 · AnyPlane</title>
-<style>
-  body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#16130f;color:#e8e2d9;font:14px/1.6 ui-monospace,SFMono-Regular,Menlo,monospace}
-  .card{box-sizing:border-box;width:100%;max-width:26rem;margin:1rem;padding:1.25rem;border:1px solid #3a332a;border-radius:.5rem;background:#1e1a15}
-  h1{font-size:1rem;margin:.25rem 0 .75rem}
-  .meta{color:#8a8175;font-size:.75rem;word-break:break-all}
-  pre{white-space:pre-wrap;word-break:break-all;background:#16130f;border:1px solid #3a332a;border-radius:.375rem;padding:.625rem;font-size:.75rem;max-height:40vh;overflow:auto}
-  .row{display:flex;gap:.625rem;margin-top:1rem}
-  button{flex:1;padding:.75rem;border-radius:.375rem;border:1px solid;font-size:.875rem;cursor:pointer;background:transparent;color:inherit}
-  button:disabled{opacity:.4;cursor:default}
-  .ok{border-color:#6f9f6f;color:#9fce9f}
-  .no{border-color:#9f6f6f;color:#ce9f9f}
-</style>
-</head>
-<body>
-<div class="card">${inner}</div>
-<script>
-async function act(d){
-  document.querySelectorAll('button').forEach(function(b){b.disabled=true})
-  var st=document.getElementById('st')
-  st.textContent='提交中…'
-  var p=new URL(location.href).searchParams
-  try{
-    var resp=await fetch('/api/approval-action?k='+encodeURIComponent(p.get('k')||'')+'&r='+encodeURIComponent(p.get('r')||'')+'&d='+d+'&s='+encodeURIComponent(p.get('s')||''),{method:'POST'})
-    var j=await resp.json()
-    st.textContent=j.ok?(d==='allow'?'✓ 已允许':'✓ 已拒绝'):('失败：'+(j.error||resp.status))
-    if(!j.ok)document.querySelectorAll('button').forEach(function(b){b.disabled=false})
-  }catch(e){
-    st.textContent='网络错误，请重试'
-    document.querySelectorAll('button').forEach(function(b){b.disabled=false})
-  }
-}
-</script>
-</body>
-</html>`
-}
-
-function fanoutPush(ev: InboxEvent): void {
-  if (subscriptionCount() === 0 && webhookCount() === 0) return
-  if (ev.type === 'approval_resolved') return // 审批已处理，无需推送（通知 tag 替换语义下保留现状即可）
-  const session = sessionNameOf(ev.key)
-  let payload: PushPayload
-  if (ev.type === 'approval') {
-    payload = {
-      type: 'approval',
-      title: `需要审批 · ${ev.toolName}`,
-      body: `${session}｜${summarizeInput(ev.toolName, ev.input)}`,
-      key: ev.key,
-      session,
-      requestId: ev.requestId,
-      // 能力 URL：secret 由 pushToAll 按订阅逐个补全（每个订阅一个能力密钥）
-      actions: {
-        allow: `/api/approval-action?k=${encodeURIComponent(ev.key)}&r=${encodeURIComponent(ev.requestId)}&d=allow&s=`,
-        deny: `/api/approval-action?k=${encodeURIComponent(ev.key)}&r=${encodeURIComponent(ev.requestId)}&d=deny&s=`,
-      },
-      tag: `ccr-a-${ev.requestId}`,
-    }
-  } else if (ev.type === 'done') {
-    payload = {
-      type: 'done',
-      title: `${ev.ok ? '✓ 完成' : '✗ 结束（有错）'} · ${session}`,
-      body: '会话已空闲，点击查看结果',
-      key: ev.key,
-      session,
-      tag: `ccr-d-${ev.key}`,
-    }
-  } else {
-    payload = {
-      type: 'error',
-      title: `⚠ 出错 · ${session}`,
-      body: ev.message.slice(0, 300),
-      key: ev.key,
-      session,
-      tag: `ccr-e-${ev.key}`,
-    }
-  }
-  void pushToAll(payload).catch((e) => log.warn('[push] fanout 异常:', e))
-  void pushWebhooksToAll(payload).catch((e) => log.warn('[push] webhook fanout 异常:', e))
-}
-
-/** inbox 快照：所有 Hub 的待审批与忙闲状态（新连接建立时下发） */
-function inboxSnapshot(): Record<string, unknown> {
-  const approvals: unknown[] = []
-  const states: Record<string, unknown>[] = []
-  for (const hub of hubs.values()) {
-    const st = statusOf(hub.key)
-    if (st.spawned || st.busy || st.waiting) states.push({ key: hub.key, ...st })
-    for (const a of hub.pendingApprovals.values()) {
-      approvals.push({ type: 'approval', key: hub.key, ...a })
-    }
-  }
-  return { type: 'snapshot', states, approvals }
-}
-
-
-function getHub(key: string): Hub {
-  let h = hubs.get(key)
-  if (!h) {
-    h = { key, clients: new Set(), pendingApprovals: new Map() }
-    hubs.set(key, h)
-  }
-  return h
-}
-
-/** 待审批重放：WS 接入（单播）与 attach（广播）共用——未裁决的审批补发给目标 */
-function replayApprovals(hub: Hub, send: (payload: unknown) => void): void {
-  for (const a of hub.pendingApprovals.values()) {
-    send({ kind: 'approval_request', ...a })
-  }
-}
-
-function broadcast(hub: Hub, payload: unknown): void {
-  const kindForRing = (payload as { kind?: string } | null | undefined)?.kind
-  if (kindForRing === 'cli') pushCliRing(hub, payload as Record<string, unknown>)
-  const text = JSON.stringify(payload)
-  for (const ws of hub.clients) {
-    try {
-      ws.send(text)
-    } catch (e) {
-      // 向刚关闭的连接发送是竞态常态（close 处理器尚未跑到），属预期内噪声——
-      // 降到 debug 而非吞掉：排查"消息没收到"时开 ANYPLANE_LOG_LEVEL=debug 就能看见
-      log.debug(`[ws ${hub.key}] 下行发送失败（连接可能已关闭）`, errFields(e))
-    }
-  }
-  // 错误事件同步进全局收件箱（审批/完成由各自路径单独发布）
-  const kind = (payload as { kind?: string } | null | undefined)?.kind
-  if (kind === 'error') {
-    publishInbox({ type: 'error', key: hub.key, message: String((payload as { message?: unknown }).message ?? '') })
-  }
-}
-
-function broadcastError(hub: Hub, message: string): void {
-  broadcast(hub, { kind: 'error', message })
-}
-
-/** liveHint：调用方（/api/sessions）刚做过 pid 扫描时传入复用，避免每行各扫一次；
- *  显式 null 表示"已知不在线"（跳过扫描），undefined 才现扫。
- *  hydrateContext：仅单会话 attach/pushStatus 路径开启（离线时读 transcript 尾部补
- *  上下文占用）；列表端点禁止开启（N 行 × 文件读）。
- *  实现已按后端收敛进适配器（backends/port.ts 的 portFor 分发；公共字段见 baseStatusOf）。 */
-function statusOf(key: string, liveHint?: { status: string; pid: number } | null, hydrateContext = false): Record<string, unknown> {
-  return portFor(key).statusOf(key, { hub: hubs.get(key), liveHint, hydrateContext })
-}
-
-function pushStatus(hub: Hub, extra?: Record<string, unknown>): void {
-  broadcast(hub, { kind: 'status', state: { ...statusOf(hub.key, undefined, true), ...extra } })
-}
-
-/** onStatusChange 的 leading+trailing 节流：并行后台任务的 task_progress 心跳每秒可触发多次，
- *  statusOf 构造+广播是纯派生数据，窗口内合并即可。leading 立即发（busy/idle 转移零延迟），
- *  窗口内后续变更合并为 trailing 一发——终态只是延迟 ≤300ms，不会丢失。
- *  仅挂 onStatusChange 一路；审批/退出/attach 等事件路径仍直调 pushStatus 保证即时。 */
-const STATUS_THROTTLE_MS = 300
-const statusThrottle = new WeakMap<Hub, { timer: ReturnType<typeof setTimeout> | null; dirty: boolean }>()
-
-function throttledPushStatus(hub: Hub): void {
-  let st = statusThrottle.get(hub)
-  if (!st) {
-    st = { timer: null, dirty: false }
-    statusThrottle.set(hub, st)
-  }
-  if (st.timer) {
-    st.dirty = true
-    return
-  }
-  pushStatus(hub)
-  st.timer = setTimeout(() => {
-    st.timer = null
-    // Hub 可能已回收删除：确认还是同一个 Hub 再补发
-    if (st.dirty && hubs.get(hub.key) === hub) {
-      st.dirty = false
-      pushStatus(hub)
-    }
-  }, STATUS_THROTTLE_MS)
-  st.timer.unref?.()
-}
-
-/** 两个后端共用的会话回调：CLI/翻译层消息广播、审批入 Hub 表、状态推动 */
-function sessionCallbacks(hub: Hub) {
-  return {
-    onMessage: (msg: CliMessage) => {
-      // 后台 Agent 完成通知会作为伪装成 user 的内部 XML 记录出现。
-      // 生命周期本身已由 ProcessManager 消费为 system/task_notification；
-      // 不再把原始内部载荷广播进主聊天或 rewind 历史。
-      if (isInternalUserMessage(msg)) return
-      // /clear（别名 /reset /new）：CLI 发 conversation_reset 并以新 session_id 续跑。
-      // Hub 随之重键到 s|slug|<newSid>——新会话页承载后续对话，旧 transcript 原样留存。
-      if (msg.type === 'conversation_reset') {
-        hub.pendingRekey = true
-        return // 原始事件不进主抄本，迁移以 moved 事件表达
-      }
-      if (hub.pendingRekey && msg.type === 'system' && msg.subtype === 'init') {
-        hub.pendingRekey = false
-        const newSid = String(msg.session_id ?? '')
-        const cwd = hub.spawnOpts?.cwd ?? parseKey(hub.key)?.cwd
-        if (newSid && cwd) {
-          const newKey = keyFor(sanitizePath(cwd), newSid)
-          const oldKey = hub.key
-          hubs.delete(oldKey)
-          hub.goal = undefined // 上下文已清，goal 与待审批随之失效
-          hub.pendingApprovals.clear()
-          hub.pendingTitleText = undefined // 旧会话的标题素材不带给新会话
-          hub.key = newKey
-          hubs.set(newKey, hub)
-          // 进程 map 同步重键：否则按新 key 查不到进程会再 spawn 一个（双进程同 transcript）
-          processManager.rekey(oldKey, newKey)
-          // 重键后同步改写存活连接的 data.key：message 路由（getHub(ws.data.key)）依赖它，
-          // 否则旧 key 上的后续消息会新建空 Hub（消息黑洞）
-          for (const ws of hub.clients) {
-            if (!ws.data.inbox) ws.data.key = newKey
-          }
-          // 已知限制：新 transcript 文件尚未落盘时 parseKey 无法反查 cwd（进程存活期间无影响，
-          // spawnOpts 持有 cwd；空闲回收后若文件仍未写则报"无法解析会话"）
-          broadcast(hub, { kind: 'moved', targetKey: newKey, targetSessionId: newSid, reason: 'clear' })
-          pushStatus(hub)
-        }
-      }
-      // 每个 init 都更新会话身份（首次 spawn 与 /clear 重键共用；rekey 分支不落 return，会走到这里）
-      if (msg.type === 'system' && msg.subtype === 'init') {
-        hub.sessionId = String(msg.session_id ?? '') || undefined
-        portFor(hub.key).maybeGenerateTitle(hub) // 首条消息可能已记账在等 sessionId（codex no-op）
-      }
-      broadcast(hub, { kind: 'cli', msg })
-      // turn 收尾是收件箱的核心提醒信号（agent 跑完了）
-      if (msg.type === 'result') {
-        publishInbox({ type: 'done', key: hub.key, ok: msg.is_error !== true })
-        // claude /goal：goal 激活期间 turn 只会因"条件达成"结束（Stop hook 拦截其余收尾），
-        // 所以 result 到达即视为目标完成（用户中断也会到此，chip 随之清除，语义可接受）
-        if (hub.goal) {
-          hub.goal = undefined
-          pushStatus(hub)
-        }
-      }
-    },
-    onApprovalRequest: (req: { requestId: string; toolName: string; input: unknown }) => {
-      // 审批规则引擎：按序首条命中即自动裁决——不进 pending、不推送、不打扰，
-      // 但广播 approval_auto 留痕事件（UI 灰底卡 + 服务端日志），审计可回溯。
-      // 规则只做服务端裁决，绝不进入推送能力 URL 路径。
-      const auto = matchApprovalRule(config.approvalRules ?? [], req.toolName, req.input)
-      if (auto) {
-        const label = auto.rule.note ?? `approvalRules[${auto.index}]`
-        log.info(`[approval] ${hub.key} 规则自动${auto.rule.action === 'allow' ? '放行' : '拒绝'} ${req.toolName}（${label}）`)
-        broadcast(hub, {
-          kind: 'approval_auto',
-          requestId: req.requestId,
-          toolName: req.toolName,
-          input: req.input,
-          action: auto.rule.action,
-          rule: label,
-        })
-        const s = portFor(hub.key).sessionOf(hub.key)
-        if (s) s.sendApproval(req.requestId, decisionOfRule(auto.rule, req.input))
-        else log.warn(`[approval] ${hub.key} 会话句柄已不存在，自动裁决无法送达`)
-        return
-      }
-      hub.pendingApprovals.set(req.requestId, req)
-      broadcast(hub, {
-        kind: 'approval_request',
-        requestId: req.requestId,
-        toolName: req.toolName,
-        input: req.input,
-      })
-      publishInbox({ type: 'approval', key: hub.key, requestId: req.requestId, toolName: req.toolName, input: req.input })
-      pushStatus(hub)
-      portFor(hub.key).notifyExternalGate(hub.key)
-    },
-    onStatusChange: () => throttledPushStatus(hub),
-    onExit: (code: number) => {
-      pushStatus(hub, { exited: true, exitCode: code, spawned: false, busy: false, waiting: false })
-    },
-  }
-}
-
-/** 回滚进行中拒绝新操作：返回 true 表示已拒绝（错误已广播） */
-function rewindBusy(hub: Hub, message = '已有回滚操作正在进行'): boolean {
-  if (!hub.rewindPending) return false
-  broadcastError(hub, message)
-  return true
-}
-
-function handleClientMessage(
-  hub: Hub,
-  raw: string,
-  /** 发起方连接：仅重连补发需要单播（其余一律 hub 级广播） */
-  ws?: import('bun').ServerWebSocket<WSData>,
-): void {
-  let data: Record<string, unknown>
-  try {
-    data = JSON.parse(raw)
-  } catch (e) {
-    // 曾是静默 return：协议漂移/帧截断时表现为"消息就是没了"，零线索。
-    // 客户端不可能合法发出非 JSON，这一定是 bug 或攻击面探测，按 error 留痕。
-    log.error(`[ws ${hub.key}] 上行非 JSON 帧，已丢弃`, { bytes: raw.length, head: raw.slice(0, 120), ...errFields(e) })
-    return
-  }
-  switch (data.kind) {
-    case 'attach': {
-      // 浏览历史只握手，不 spawn。发消息 / 切 model·mode·effort / rewind / btw 时再启动 CLI。
-      // 各后端的 attach 策略（warm 预热、codex x| 即 resume）见适配器 onAttach。
-      portFor(hub.key).onAttach(hub, data)
-      replayApprovals(hub, (p) => broadcast(hub, p))
-      // 重连补发：客户端带上断线前的最高 seq，取回这期间错过的 cli 事件。
-      // **必须单播**：走 broadcast 会让补发内容重新入环并分配新序号（自我污染），
-      // 且已在线的其他客户端会收到重复投递。
-      const fromSeq = typeof data.fromSeq === 'number' ? data.fromSeq : undefined
-      if (fromSeq !== undefined && ws) {
-        const unicast = (p: unknown) => {
-          try {
-            ws.send(JSON.stringify(p))
-          } catch (e) {
-            log.debug(`[ws ${hub.key}] 补发单播失败`, errFields(e))
-          }
-        }
-        // 环里已挤掉起点时告知缺口，由前端重载历史补全（transcript 是权威事实源）
-        const gap = replayCliSince(hub, fromSeq, unicast)
-        if (gap) {
-          log.info(`[ws ${hub.key}] 补发存在缺口，通知客户端重载历史`, { fromSeq, ringFrom: hub.cliRing?.[0]?.seq })
-          unicast({ kind: 'replay_gap', fromSeq })
-        }
-      }
-      break
-    }
-    case 'tail_subscribe': {
-      // 客户端加载完历史后订阅 transcript 追加（from = 历史读取时的文件字节数，无缝衔接）；
-      // codex 的实时流走 app-server 订阅，无 tailer 概念（适配器内 no-op）
-      portFor(hub.key).startTailer(hub, typeof data.from === 'number' ? data.from : undefined)
-      break
-    }
-    case 'user': {
-      if (rewindBusy(hub, '正在恢复文件，请等待回滚完成后再发送消息')) return
-      const sendMode = data.sendMode === 'steer' || data.sendMode === 'queue' ? data.sendMode : undefined
-      // 图片附件：服务端统一校验（类型/大小），claude 并 content blocks，codex 落盘走 localImage
-      const attachments = (
-        Array.isArray(data.attachments) ? (data.attachments as Array<Record<string, unknown>>) : []
-      ).map((a) => ({
-        name: String(a.name ?? 'image'),
-        mediaType: String(a.mediaType ?? 'image/png'),
-        dataBase64: String(a.dataBase64 ?? ''),
-      }))
-      const text = String(data.text ?? '')
-      void (async () => {
-        const port = portFor(hub.key)
-        const s = await port.ensureForSend(hub)
-        if (!s) return // 适配器已广播具体错误
-        try {
-          // sendMode 直通：claude 侧 steer=priority 'now'（中断处理）、queue=服务端排队
-          s.sendUserText(text, sendMode, attachments)
-          // 后端特定的发送后跟踪（claude：/goal 出站跟踪 + 标题素材记账；codex 无）
-          port.afterUserSent?.(hub, text)
-          pushStatus(hub)
-        } catch (e) {
-          broadcastError(hub, `发送失败: ${errorMessage(e)}`)
-          pushStatus(hub)
-        }
-      })()
-      break
-    }
-    case 'control': {
-      const subtype = String(data.subtype)
-      const extra = (data.extra as Record<string, unknown>) ?? {}
-      // 组合回滚等待期间，通用控制路径不得再发 rewind_files 与之竞争
-      if (hub.rewindPending && subtype === 'rewind_files') {
-        broadcastError(hub, '已有回滚操作正在进行')
-        return
-      }
-      // model/mode 都有等价启动参数：先缓存最终选择（未 spawn 时首条消息应用），
-      // 已 spawn 时再发运行时控制。两个后端同此序。
-      if (subtype === 'set_model' && extra.model) {
-        hub.spawnOpts = { ...hub.spawnOpts, model: String(extra.model) }
-      }
-      if (subtype === 'set_permission_mode' && extra.mode) {
-        hub.spawnOpts = { ...hub.spawnOpts, permissionMode: String(extra.mode) }
-      }
-      portFor(hub.key).deliverControl(hub, subtype, extra)
-      break
-    }
-    case 'update_env': {
-      // effort 有 --effort 启动参数。未 spawn 时只缓存，首条消息时应用；
-      // 已 spawn 时通过 update_environment_variables 影响后续 turn。
-      const variables = (data.variables as Record<string, string>) ?? {}
-      const effort = variables.CLAUDE_CODE_EFFORT_LEVEL
-      if (effort) hub.spawnOpts = { ...hub.spawnOpts, effort }
-      portFor(hub.key).updateEnv(hub, variables)
-      break
-    }
-    case 'branch': {
-      // 分叉当前会话：claude 懒分叉（b| key，首条消息才 --fork-session），
-      // codex 走既有 thread/fork（RewindPicker 的"从此处分叉"，适配器内拒绝并引导）
-      portFor(hub.key).branch(hub, String(data.name ?? ''))
-      break
-    }
-    case 'rewind_conversation': {
-      const at = String(data.userMessageId ?? '')
-      if (!at) return
-      // claude=原地截断重 spawn；codex=thread/fork 分叉语义（rewindPending 守卫在适配器内）
-      portFor(hub.key).rewindConversation(hub, at)
-      break
-    }
-    case 'rewind_both': {
-      const at = String(data.userMessageId ?? '')
-      if (!at) return
-      // 组合回滚：claude 先 rewind_files 再截断；codex 无文件检查点（适配器内拒绝）
-      portFor(hub.key).rewindBoth(hub, at)
-      break
-    }
-    case 'btw': {
-      // 侧问：借用当前会话上下文的一次性问答，不进主会话历史
-      const question = String(data.question ?? '').trim()
-      // btw_pending 必须先于校验失败分支发出：前端卡片由它创建，
-      // 否则校验失败的 btw_result 找不到卡（按 question 配对）被静默丢弃，用户零反馈
-      if (question) broadcast(hub, { kind: 'btw_pending', question })
-      portFor(hub.key).btw(hub, question)
-      break
-    }
-    case 'query': {
-      // 带应答的控制请求通道：只读查询（mcp_status / get_settings / get_context_usage）
-      // 与 MCP 管理动作（mcp_reconnect / mcp_toggle，经 extra 传参）共用；
-      // codex 仅 mcp_status 有对应物 mcpServerStatus/list（动作类一律拒绝，见适配器）
-      const id = String(data.id ?? '')
-      const query = String(data.query ?? '')
-      const extra = (data.extra as Record<string, unknown> | undefined) ?? {}
-      const reply = (payload: Record<string, unknown>) => broadcast(hub, { kind: 'query_result', id, ...payload })
-      if (!id || !query) return
-      portFor(hub.key).query(hub, query, extra, reply)
-      break
-    }
-    case 'approval': {
-      const requestId = String(data.requestId)
-      resolveApproval(hub, requestId, data.decision as ApprovalDecision)
-      break
-    }
-  }
-}
-
-/**
- * 审批解析共享路径：WS approval 消息与推送直接审批（/api/approval-action）共用。
- * 返回 false 表示 requestId 已不在 pending（重复点击/已在别处处理）。
- */
-function resolveApproval(hub: Hub, requestId: string, decision: ApprovalDecision): boolean {
-  if (!hub.pendingApprovals.delete(requestId)) return false
-  const port = portFor(hub.key)
-  const s = port.sessionOf(hub.key)
-  if (s && !s.exited) {
-    try {
-      s.sendApproval(requestId, decision)
-    } catch (e) {
-      broadcastError(hub, `审批回复失败: ${errorMessage(e)}`)
-    }
-  } else {
-    // 会话已退出/未就绪：决定无处投递（上游请求将自行超时），本地照常解析并告知用户
-    broadcastError(hub, '会话未在运行，审批未能送达（该请求会在上游自行超时）')
-  }
-  port.notifyExternalGate(hub.key)
-  broadcast(hub, { kind: 'approval_resolved', requestId })
-  publishInbox({ type: 'approval_resolved', key: hub.key, requestId })
-  pushStatus(hub)
-  return true
-}
-
-// ---------- 接力（handoff）编排 ----------
-
-/**
- * POST /api/handoff { fromKey, toBackend, detail } → 立即应答；进度事件推到 fromKey 所在 Hub：
- * handoff_pending → handoff_done { targetKey, brief } / handoff_error { message }。
- * 目标会话由服务端直接创建并播种首条消息（无需浏览器在场）。
- */
-function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detail: HandoffDetail): string | undefined {
-  const sourceHub = hubs.get(fromKey)
-  const fromPort = portFor(fromKey)
-  const fromBackend = fromPort.name
-  if (fromBackend === toBackend) return '接力目标必须与源会话是不同后端'
-
-  // 源解析：cwd + 会话 id（codex 的 x| key 不含 cwd，需在异步路径里惰性解析）
-  const src = fromPort.handoffSource(fromKey)
-  if (fromBackend === 'claude' && !src.cwd) return '无法确定源会话目录'
-  if (!src.sourceId) return '源会话还没有任何消息，无法接力'
-
-  const sid = src.sourceId
-  void (async () => {
-    try {
-      // codex x| key：cwd 需要 thread/read 惰性解析
-      const sourceCwd = src.cwd ?? (await fromPort.handoffCwdOf(fromKey, sid))
-      if (!sourceCwd) throw new Error('无法确定源会话目录（thread/read 未返回 cwd）')
-      if (sourceHub) broadcast(sourceHub, { kind: 'handoff_pending', toBackend })
-      // 1. 源会话 fork 自摘要
-      //    claude 源在线时走 side_question 控制通道（进程内 fork，零冷启动、不留 FORK 会话）；
-      //    离线才 spawn 一次性 --fork-session --bare 进程
-      const { text: brief, usage } = await fromPort.forkBriefForHandoff(fromKey, sourceCwd, sid, detail)
-      if (sourceHub) broadcast(sourceHub, { kind: 'handoff_brief', brief })
-
-      // 2. 目标会话播种（服务端直接发送首条消息；启动失败抛错）
-      const targetKey = toBackend === 'codex' ? codexKeyForNew(sourceCwd) : keyForNew(sourceCwd)
-      const targetHub = getHub(targetKey)
-      const seed = seedMessage(sourceCwd, fromBackend, brief)
-      const targetSessionId = await portFor(targetKey).seedHandoffTarget(targetHub, seed)
-      const toResolvedKey =
-        toBackend === 'codex'
-          ? targetSessionId
-            ? `x|${targetSessionId}`
-            : undefined
-          : targetSessionId
-            ? keyFor(sanitizePath(sourceCwd), targetSessionId)
-            : undefined
-      const fromResolvedKey = (() => {
-        if (fromBackend === 'claude') {
-          if (fromKey.startsWith('s|')) return fromKey
-          const sidNow = fromPort.sessionOf(fromKey)?.sessionId
-          return sidNow ? keyFor(sanitizePath(sourceCwd), sidNow) : undefined
-        }
-        if (fromKey.startsWith('x|')) return fromKey
-        const tidNow = fromPort.sessionOf(fromKey)?.sessionId
-        return tidNow ? `x|${tidNow}` : undefined
-      })()
-
-      // 3. 血缘
-      appendLineage({
-        id: `ho-${Date.now().toString(36)}`,
-        at: new Date().toISOString(),
-        fromKey,
-        toKey: targetKey,
-        fromResolvedKey,
-        toResolvedKey,
-        fromBackend,
-        toBackend,
-        cwd: sourceCwd,
-        detail,
-        brief,
-        briefUsage: usage,
-      })
-      if (sourceHub)
-        broadcast(sourceHub, {
-          kind: 'handoff_done',
-          targetKey: toResolvedKey ?? targetKey,
-          targetSessionId,
-          toBackend,
-          brief,
-        })
-    } catch (e) {
-      const message = errorMessage(e)
-      if (sourceHub) broadcast(sourceHub, { kind: 'handoff_error', message })
-    }
-  })()
-  return undefined
-}
+initInbox()
 
 // ---------- HTTP ----------
 
@@ -802,6 +109,13 @@ if (!hasWindowsSocketFix() && process.env.ANYPLANE_ALLOW_UNSAFE_BUN !== '1') {
     `[anyplane] Bun ${Bun.version} on Windows has the inherited-listener bug oven-sh/bun#36936.`,
   )
   log.error('[anyplane] Run `bun upgrade` (need >= 1.4.0) and restart the terminal. Server startup refused.')
+  process.exit(1)
+}
+
+// 绑定非回环地址却不配置 token = 把"任意目录起会话 + 任意命令执行"裸奔到网络上，拒绝启动
+if (!isLoopbackHost(config.host) && !config.authToken) {
+  log.error(`[anyplane] 拒绝启动：host=${config.host} 为非回环地址，但未配置 authToken。`)
+  log.error('[anyplane] 请在 anyplane.config.json 设置 "authToken" 或设置环境变量 ANYPLANE_TOKEN。')
   process.exit(1)
 }
 
@@ -1116,13 +430,6 @@ let server: ReturnType<typeof Bun.serve<WSData>>
 // 浏览器在 WS 握手与跨源 POST 时必定携带 Origin；非浏览器客户端（e2e 脚本/curl）不带。
 // 配置 authToken 后 token 即防线，这些检查不生效（行为与旧版完全一致）。
 
-// 绑定非回环地址却不配置 token = 把"任意目录起会话 + 任意命令执行"裸奔到网络上，拒绝启动
-if (!isLoopbackHost(config.host) && !config.authToken) {
-  log.error(`[anyplane] 拒绝启动：host=${config.host} 为非回环地址，但未配置 authToken。`)
-  log.error('[anyplane] 请在 anyplane.config.json 设置 "authToken" 或设置环境变量 ANYPLANE_TOKEN。')
-  process.exit(1)
-}
-
 function createServer(): ReturnType<typeof Bun.serve<WSData>> {
   return Bun.serve<WSData>({
     port: config.port,
@@ -1192,68 +499,11 @@ function createServer(): ReturnType<typeof Bun.serve<WSData>> {
       }
       return new Response('anyplane server (web 未构建，请用 vite dev 或 bun run build)', { status: 200 })
     },
+    // websocket handlers 的实现见 hub/socket.ts（keepalive 注释也在那里）
     websocket: {
-      // 30s 协议层下行 ping：前端 ReconnectingSocket 没有应用层心跳，空闲会话的 /ws 长连接
-      // 可能数分钟无任何消息——Bun.serve 默认 idleTimeout=120s 会把它静默掐断（前端重连虽无感，
-      // 但审批/事件推送会落在重连窗口里）；经 gateway 访问时也能为后端腿持续制造下行流量。
-      open(ws) {
-        ws.data.keepalive = setInterval(() => {
-          try {
-            ws.ping()
-          } catch {}
-        }, 30_000)
-        if (ws.data.inbox) {
-          inboxClients.add(ws as import('bun').ServerWebSocket<WSDataInbox>)
-          ws.send(JSON.stringify(inboxSnapshot()))
-          return
-        }
-        const hub = getHub(ws.data.key)
-        hub.clients.add(ws)
-        portFor(ws.data.key).sessionOf(ws.data.key)?.attachClient()
-        ws.send(JSON.stringify({ kind: 'status', state: statusOf(ws.data.key, undefined, true) }))
-        replayApprovals(hub, (p) => ws.send(JSON.stringify(p)))
-      },
-      message(ws, raw) {
-        if (ws.data.inbox) return // inbox 频道只发不收
-        const hub = getHub(ws.data.key)
-        try {
-          handleClientMessage(hub, typeof raw === 'string' ? raw : raw.toString(), ws as import('bun').ServerWebSocket<WSData>)
-        } catch (e) {
-          log.error(`[ws ${hub.key}] 处理消息异常:`, e) // 原对象打日志保留堆栈
-          try {
-            ws.send(JSON.stringify({ kind: 'error', message: errorMessage(e) }))
-          } catch {}
-        }
-      },
-      close(ws) {
-        if (ws.data.keepalive) clearInterval(ws.data.keepalive)
-        if (ws.data.inbox) {
-          inboxClients.delete(ws as import('bun').ServerWebSocket<WSDataInbox>)
-          return
-        }
-        let hub = hubs.get(ws.data.key)
-        if (!hub) {
-          // 会话可能因 /clear 重键（hub.key 已换成新 s| key）：按客户端成员资格找回
-          for (const h of hubs.values()) {
-            if (h.clients.has(ws)) {
-              hub = h
-              break
-            }
-          }
-        }
-        if (!hub) return
-        hub.clients.delete(ws)
-        // 不变量：任何后端的会话句柄存活期间，其 Hub 必须存活——
-        // 否则重连时复用旧会话，其回调会把事件广播进已删除的 Hub（消息黑洞）。
-        // 用 hub.key 而非 ws.data.key：重键后进程注册在新 key 下
-        const port = portFor(hub.key)
-        port.sessionOf(hub.key)?.detachClient()
-        const alive = port.hasLiveSession(hub.key)
-        if (hub.clients.size === 0) {
-          port.stopTailer(hub)
-          if (!alive) hubs.delete(hub.key)
-        }
-      },
+      open: wsOpen,
+      message: wsMessage,
+      close: wsClose,
     },
   })
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,51 +1,32 @@
-// anyplane 服务端入口：REST + WebSocket + 静态托管
-// S2 拆分后的职责边界：Hub 编排层在 hub/（registry/broadcast/status/callbacks/lifecycle/messages/handoff/socket），
-// 推送扇出在 push/（fanout/inbox）；本文件保留 REST 路由（handleApi）与进程装配（启动守卫/createServer/shutdown）。
+// anyplane 服务端入口（装配层）：启动守卫 + createServer + bindServer + 启动日志 + shutdown。
+// S2 拆分后的职责边界：
+//   hub/    Hub 编排层（registry/broadcast/status/callbacks/lifecycle/messages/handoff/socket）
+//   push/   推送扇出（fanout：显示名/摘要/确认页；inbox：/ws/inbox 频道与 InboxSink 实现）
+//   routes/ REST 路由（api.ts 聚合 pushRoutes/sessions/misc）
+//   backends/port.ts  后端能力契约（portFor 唯一分支点；适配器回调经下方 initBackendPorts 注入）
 
 import { existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
 import { join, resolve } from 'node:path'
-import { listTrash } from './archive'
 import { hostAllowed, isAuthorized, isLoopbackHost, jsonContentTypeRequired, originAllowed } from './auth'
-import { keyFor, keyForNew } from './backends/claude/backend'
-import { listSessions, readHistory, sanitizePath, type SessionInfo } from './backends/claude/discovery'
-import { resolveTierModelNames } from './backends/claude/modelNames'
 import { processManager } from './backends/claude/processManager'
-import {
-  keyForNew as codexKeyForNew,
-  listSessions as listCodexSessions,
-  readHistory as readCodexHistory,
-} from './backends/codex/backend'
 import { codexRuntime } from './backends/codex/runtime'
-import { initBackendPorts, portFor } from './backends/port'
+import { initBackendPorts } from './backends/port'
 import { config } from './config'
 import { startupVersionProbe } from './driftGuard'
-import { FsBrowseError, listDirectories, readGitBranch } from './fsbrowse'
-import { lineageFor, type HandoffDetail } from './handoff'
 import { broadcast, broadcastError } from './hub/broadcast'
 import { sessionCallbacks } from './hub/callbacks'
-import { runHandoff } from './hub/handoff'
-import { resolveApproval, rewindBusy } from './hub/lifecycle'
-import { getHub, hubs } from './hub/registry'
+import { rewindBusy } from './hub/lifecycle'
+import { getHub } from './hub/registry'
 import { wsClose, wsMessage, wsOpen } from './hub/socket'
-import { pushStatus, statusOf } from './hub/status'
+import { pushStatus } from './hub/status'
 import type { WSData } from './hub/types'
 import { log } from './log'
 import { isOwnServerProcess, takeoverStaleListeners } from './portTakeover'
-import {
-  addSubscription,
-  pushToAll,
-  pushWebhooksToAll,
-  removeSubscription,
-  subscriptionCount,
-  vapidPublicKey,
-  validSecret,
-  webhookCount,
-  type PushPayload,
-} from './push'
-import { approvalPageHtml, sessionNameOf } from './push/fanout'
+import { sessionNameOf } from './push/fanout'
 import { initInbox } from './push/inbox'
-import { resolveUpload } from './uploads'
+import { handleApi } from './routes/api'
+import { json } from './routes/http'
 import { errorMessage, hasWindowsSocketFix } from './util'
 
 // ---------- sessionKey ----------
@@ -64,20 +45,6 @@ initBackendPorts({
   rewindBusy,
 })
 initInbox()
-
-// ---------- HTTP ----------
-
-function json(data: unknown, init?: ResponseInit): Response {
-  return new Response(JSON.stringify(data), {
-    ...init,
-    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
-  })
-}
-
-/** POST JSON body：解析失败按 {} 处理（各 handler 自行做字段校验） */
-async function readJsonBody<T>(req: Request): Promise<T> {
-  return (await req.json().catch(() => ({}))) as T
-}
 
 function logWindowsPortState(stage: string, port: number): void {
   if (process.platform !== 'win32') return
@@ -117,309 +84,6 @@ if (!isLoopbackHost(config.host) && !config.authToken) {
   log.error(`[anyplane] 拒绝启动：host=${config.host} 为非回环地址，但未配置 authToken。`)
   log.error('[anyplane] 请在 anyplane.config.json 设置 "authToken" 或设置环境变量 ANYPLANE_TOKEN。')
   process.exit(1)
-}
-
-// ---------- /api/sessions 的 git 分支缓存 ----------
-// 列表被前端轮询，每个 cwd 的分支读取是 2-3 次同步文件 IO；分支变化不需要秒级新鲜度，30s TTL。
-const BRANCH_CACHE_TTL_MS = 30_000
-const branchCache = new Map<string, { branch: string | undefined; at: number }>()
-
-function branchOfCached(cwd?: string): string | undefined {
-  if (!cwd) return undefined
-  const hit = branchCache.get(cwd)
-  if (hit && Date.now() - hit.at < BRANCH_CACHE_TTL_MS) return hit.branch
-  const branch = readGitBranch(cwd) // 普通仓库与 worktree 都支持
-  branchCache.set(cwd, { branch, at: Date.now() })
-  return branch
-}
-
-async function handleApi(req: Request, url: URL): Promise<Response | undefined> {
-  // ---------- Web Push 订阅管理 ----------
-  if (url.pathname === '/api/push/public-key' && req.method === 'GET') {
-    return json({ publicKey: vapidPublicKey(), subscriptions: subscriptionCount(), webhooks: webhookCount() })
-  }
-  if (url.pathname === '/api/push/subscriptions' && req.method === 'POST') {
-    const body = await readJsonBody<{ endpoint?: string; keys?: { p256dh: string; auth: string } }>(req)
-    if (!body.endpoint || !body.keys?.p256dh || !body.keys?.auth) {
-      return json({ error: 'endpoint 与 keys.p256dh/auth 必填' }, { status: 400 })
-    }
-    let secret: string
-    try {
-      secret = addSubscription(
-        { endpoint: body.endpoint, keys: body.keys },
-        req.headers.get('user-agent') ?? undefined,
-      ).secret
-    } catch (e) {
-      return json({ error: errorMessage(e) }, { status: 400 })
-    }
-    log.info(`[push] 新订阅（共 ${subscriptionCount()}）：${body.endpoint.slice(0, 60)}…`)
-    return json({ ok: true, secret })
-  }
-  if (url.pathname === '/api/push/subscriptions' && req.method === 'DELETE') {
-    const body = await readJsonBody<{ endpoint?: string }>(req)
-    return json({ ok: body.endpoint ? removeSubscription(body.endpoint) : false })
-  }
-  // 推送通道自检：向全部订阅与 webhook 通道 fanout 一条测试通知（不带审批能力，点击落应用首页）
-  if (url.pathname === '/api/push/test' && req.method === 'POST') {
-    const payload: PushPayload = {
-      type: 'done',
-      title: '测试通知 · AnyPlane',
-      body: '推送链路可达：全部订阅与 webhook 通道会同时收到这一条。',
-      key: '',
-      session: 'anyplane',
-      tag: 'ccr-test',
-    }
-    const [push, hooks] = await Promise.all([pushToAll(payload), pushWebhooksToAll(payload)])
-    return json({
-      ok: true,
-      subscriptions: subscriptionCount(),
-      webhooks: webhookCount(),
-      sent: push.sent + hooks.sent,
-      pruned: push.pruned,
-    })
-  }
-  // 推送直接审批（能力 URL：secret 鉴权，不走 authToken——该 URL 只经加密推送投递到订阅设备）
-  if (url.pathname === '/api/approval-action' && req.method === 'POST') {
-    const key = url.searchParams.get('k') ?? ''
-    const requestId = url.searchParams.get('r') ?? ''
-    const decision = url.searchParams.get('d') ?? ''
-    const secret = url.searchParams.get('s') ?? ''
-    if (!validSecret(secret)) return json({ ok: false, error: '无效的能力密钥' }, { status: 403 })
-    if (decision !== 'allow' && decision !== 'deny') {
-      return json({ ok: false, error: 'd 只接受 allow/deny' }, { status: 400 })
-    }
-    const hub = hubs.get(key)
-    if (!hub || !hub.pendingApprovals.has(requestId)) {
-      return json({ ok: false, error: '该审批已处理或不存在' }, { status: 409 })
-    }
-    const pending = hub.pendingApprovals.get(requestId)!
-    const ok = resolveApproval(
-      hub,
-      requestId,
-      decision === 'allow'
-        ? { behavior: 'allow', updatedInput: pending.input }
-        : { behavior: 'deny', message: '用户在推送通知上拒绝了该操作' },
-    )
-    log.info(`[push] 通知直接审批 ${decision}：${sessionNameOf(key)} · ${pending.toolName}`)
-    return json({ ok })
-  }
-  // webhook 通知的审批确认页（Bark/Server酱 无原生按钮：点链接进此页，按钮再 POST 到 approval-action）。
-  // GET 只渲染不执行——通知链接被预览/抓取也不会误触审批。能力 URL 模型同 approval-action。
-  if (url.pathname === '/api/approval-page' && req.method === 'GET') {
-    const key = url.searchParams.get('k') ?? ''
-    const requestId = url.searchParams.get('r') ?? ''
-    const secret = url.searchParams.get('s') ?? ''
-    if (!validSecret(secret)) return new Response('无效的能力密钥', { status: 403 })
-    const pending = hubs.get(key)?.pendingApprovals.get(requestId)
-    return new Response(approvalPageHtml(key, pending), {
-      headers: { 'content-type': 'text/html; charset=utf-8' },
-    })
-  }
-  if (url.pathname === '/api/sessions' && req.method === 'GET') {
-    const sessions = listSessions()
-    const claudeRows = sessions.map((s: SessionInfo) => ({
-      ...s,
-      backend: 'claude' as const,
-      gitBranch: branchOfCached(s.cwd),
-      key: keyFor(s.slug, s.sessionId),
-      // listSessions 已扫过 pid 文件，复用其结果，不为每行再扫一次（null = 已知不在线）
-      managed: statusOf(
-        keyFor(s.slug, s.sessionId),
-        s.live ? { status: s.status, pid: s.live.pid } : null,
-      ),
-    }))
-    // codex 线程：app-server 未安装/未登录时静默降级为空列表，不拖垮 claude 列表
-    let codexRows: Record<string, unknown>[] = []
-    try {
-      const threads = await listCodexSessions()
-      codexRows = threads.map((t) => ({
-        sessionId: t.id,
-        cwd: t.cwd,
-        slug: 'codex',
-        title: t.title,
-        lastPrompt: t.lastPrompt,
-        mtime: t.mtime,
-        sizeBytes: 0,
-        status: t.status,
-        backend: 'codex' as const,
-        gitBranch: branchOfCached(t.cwd),
-        key: t.key,
-        managed: statusOf(t.key),
-      }))
-    } catch (e) {
-      log.warn('[api] codex thread/list 失败（仅返回 claude 会话）:', e instanceof Error ? e.message : e)
-    }
-    return json([...codexRows, ...claudeRows])
-  }
-  if (url.pathname === '/api/sessions' && req.method === 'POST') {
-    const body = await readJsonBody<{ cwd?: string; backend?: string }>(req)
-    if (!body.cwd) return json({ error: '缺少 cwd' }, { status: 400 })
-    if (body.backend === 'codex') {
-      return json({ key: codexKeyForNew(body.cwd), slug: 'codex', backend: 'codex' })
-    }
-    return json({ key: keyForNew(body.cwd), slug: sanitizePath(body.cwd), backend: 'claude' })
-  }
-  if (url.pathname === '/api/fs/list' && req.method === 'GET') {
-    // searchParams.get 已完成 URL 解码，禁止再 decodeURIComponent（含 % 的路径会被二次解码破坏）
-    const target = url.searchParams.get('path') ?? ''
-    try {
-      return json(listDirectories(target))
-    } catch (e) {
-      if (e instanceof FsBrowseError) return json({ error: e.message }, { status: e.status })
-      return json({ error: errorMessage(e) }, { status: 500 })
-    }
-  }
-  if (url.pathname === '/api/sessions/archive' && req.method === 'POST') {
-    const body = await readJsonBody<{ key?: string }>(req)
-    if (!body.key) return json({ error: '缺少 key' }, { status: 400 })
-    const r = await portFor(body.key).archive(body.key)
-    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
-  }
-  if (url.pathname === '/api/sessions/restore' && req.method === 'POST') {
-    const body = await readJsonBody<{ key?: string }>(req)
-    if (!body.key) return json({ error: '缺少 key' }, { status: 400 })
-    const r = await portFor(body.key).restore(body.key)
-    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
-  }
-  // 归档/回收站列表：codex archived + claude trash 合并
-  if (url.pathname === '/api/sessions/archived' && req.method === 'GET') {
-    const claudeTrash = listTrash().map((t) => ({
-      key: t.key,
-      sessionId: t.sessionId,
-      slug: t.slug,
-      backend: 'claude' as const,
-      trashedAt: t.trashedAt,
-      sizeBytes: t.sizeBytes,
-    }))
-    let codexArchived: Record<string, unknown>[] = []
-    try {
-      const res = (await codexRuntime.rpcRequest('thread/list', { archived: true, limit: 100 })) as {
-        data?: Array<Record<string, unknown>>
-      }
-      codexArchived = (res.data ?? []).map((t) => ({
-        key: `x|${String(t.id)}`,
-        sessionId: String(t.id),
-        slug: 'codex',
-        backend: 'codex' as const,
-        title: typeof t.name === 'string' ? t.name : undefined,
-        lastPrompt: typeof t.preview === 'string' ? t.preview : undefined,
-        cwd: typeof t.cwd === 'string' ? t.cwd : undefined,
-        mtime: Number(t.updatedAt ?? t.createdAt ?? 0) * 1000,
-      }))
-    } catch (e) {
-      log.warn('[api] codex archived 列表失败:', e instanceof Error ? e.message : e)
-    }
-    return json({ entries: [...codexArchived, ...claudeTrash] })
-  }
-  if (url.pathname === '/api/sessions/rename' && req.method === 'POST') {
-    const body = await readJsonBody<{ key?: string; title?: string }>(req)
-    const title = body.title?.trim()
-    if (!body.key || !title) return json({ error: '缺少 key 或 title' }, { status: 400 })
-    // codex 走官方 thread/name/set；claude 仅离线会话（transcript 追加 custom-title），
-    // 两路实现见各自适配器
-    const r = await portFor(body.key).rename(body.key, title)
-    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
-  }
-  if (url.pathname === '/api/handoff' && req.method === 'POST') {
-    const body = await readJsonBody<{ fromKey?: string; toBackend?: string; detail?: HandoffDetail }>(req)
-    if (!body.fromKey) return json({ error: '缺少 fromKey' }, { status: 400 })
-    if (body.toBackend !== 'claude' && body.toBackend !== 'codex') {
-      return json({ error: 'toBackend 必须是 claude 或 codex' }, { status: 400 })
-    }
-    const detail: HandoffDetail =
-      body.detail === 'brief' || body.detail === 'detailed' ? body.detail : 'standard'
-    const error = runHandoff(body.fromKey, body.toBackend, detail)
-    if (error) return json({ error }, { status: 400 })
-    return json({ ok: true })
-  }
-  if (url.pathname === '/api/lineage' && req.method === 'GET') {
-    const key = url.searchParams.get('key') ?? ''
-    const records = lineageFor(key)
-    // 为链上每个 key 附带导航所需的节点元数据（前端接力链渲染用）
-    const nodes: Record<string, Record<string, unknown>> = {}
-    for (const r of records) {
-      for (const k of [r.fromKey, r.toKey, r.fromResolvedKey, r.toResolvedKey]) {
-        if (!k || nodes[k]) continue
-        const parts = k.split('|')
-        if (parts[0] === 's' && parts.length === 3) {
-          nodes[k] = { key: k, backend: 'claude', slug: parts[1], sessionId: parts[2], cwd: r.cwd }
-        } else if (parts[0] === 'x' && parts.length === 2) {
-          nodes[k] = { key: k, backend: 'codex', slug: 'codex', sessionId: parts[1], cwd: r.cwd }
-        } else if (parts[0] === 'n' || parts[0] === 'xn') {
-          nodes[k] = {
-            key: k,
-            backend: parts[0] === 'xn' ? 'codex' : 'claude',
-            slug: parts[0] === 'xn' ? 'codex' : sanitizePath(decodeURIComponent(parts[1] ?? '')),
-            sessionId: 'new',
-            cwd: r.cwd,
-          }
-        } else if (parts[0] === 'b' && parts.length === 3) {
-          // 懒分叉源（分叉后从未 spawn 或被回收，fromResolvedKey 缺省时记录里仍是 b| key）：
-          // 缺节点会让前端接力链按钮 disabled（死按钮）；sessionId 内嵌的是分叉源 id
-          nodes[k] = {
-            key: k,
-            backend: 'claude',
-            slug: sanitizePath(decodeURIComponent(parts[1] ?? '')),
-            sessionId: parts[2],
-            cwd: r.cwd,
-          }
-        }
-      }
-    }
-    return json({ records, nodes })
-  }
-  // 上传图片：仅 ~/.anyplane/uploads/ 内的 hash 命名文件（resolveUpload 边界校验）
-  const uploadMatch = url.pathname.match(/^\/api\/uploads\/([^/]+)$/)
-  if (uploadMatch && req.method === 'GET') {
-    const path = resolveUpload(uploadMatch[1])
-    if (!path) return json({ error: 'not found' }, { status: 404 })
-    const ext = path.split('.').pop() ?? ''
-    const mime =
-      ({ jpg: 'image/jpeg', png: 'image/png', gif: 'image/gif', webp: 'image/webp' })[ext] ??
-      'application/octet-stream'
-    return new Response(Bun.file(path), {
-      headers: { 'content-type': mime, 'cache-control': 'public, max-age=31536000, immutable' },
-    })
-  }
-  const histMatch = url.pathname.match(/^\/api\/history\/([^/]+)\/([^/]+)$/)
-  if (histMatch && req.method === 'GET') {
-    const [, slug, sessionId] = histMatch
-    // fileBytes = 本次实际读取的字节数，前端拿它作为 tailer 的起始偏移
-    return json(readHistory(slug, sessionId))
-  }
-  // codex 历史：thread/read includeTurns（只读），无 tailer 偏移概念
-  const codexHistMatch = url.pathname.match(/^\/api\/codex\/history\/([^/]+)$/)
-  if (codexHistMatch && req.method === 'GET') {
-    try {
-      const messages = await readCodexHistory(codexHistMatch[1])
-      return json({ messages, fileBytes: 0 })
-    } catch (e) {
-      return json({ error: errorMessage(e) }, { status: 500 })
-    }
-  }
-  // codex 模型目录（model/list）：模型 id/显示名/effort 列表/默认 effort
-  if (url.pathname === '/api/codex/models' && req.method === 'GET') {
-    try {
-      const models = await codexRuntime.listModels()
-      return json({ models })
-    } catch (e) {
-      return json({ error: errorMessage(e) }, { status: 500 })
-    }
-  }
-  if (url.pathname === '/api/config' && req.method === 'GET') {
-    return json({
-      permissionPolicy: config.permissionPolicy,
-      permissionModes: ['default', 'acceptEdits', 'auto', 'plan', 'bypassPermissions'],
-      effortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
-      models: ['haiku', 'sonnet', 'opus', 'fable'],
-      authRequired: !!config.authToken,
-    })
-  }
-  // 各档实际配置的模型名（StatusPill 透传显示；每次调用实时读盘，配置改动即见）
-  if (url.pathname === '/api/claude/model-names' && req.method === 'GET') {
-    return json({ models: resolveTierModelNames(url.searchParams.get('cwd') ?? undefined) })
-  }
-  return undefined
 }
 
 let server: ReturnType<typeof Bun.serve<WSData>>
@@ -499,7 +163,7 @@ function createServer(): ReturnType<typeof Bun.serve<WSData>> {
       }
       return new Response('anyplane server (web 未构建，请用 vite dev 或 bun run build)', { status: 200 })
     },
-    // websocket handlers 的实现见 hub/socket.ts（keepalive 注释也在那里）
+    // websocket handlers 的实现见 hub/socket.ts（30s 下行 keepalive 的注释也在那里）
     websocket: {
       open: wsOpen,
       message: wsMessage,

--- a/server/src/push/fanout.ts
+++ b/server/src/push/fanout.ts
@@ -5,7 +5,7 @@ import { parseKey } from '../backends/claude/backend'
 import { portFor } from '../backends/port'
 import { log } from '../log'
 import { pushToAll, pushWebhooksToAll, subscriptionCount, webhookCount, type PushPayload } from '../push'
-import { escapeHtml } from '../util'
+import { escapeHtml, summarizeInput } from '../util'
 import { hubs } from '../hub/registry'
 import type { InboxEvent, PendingApproval } from '../hub/types'
 
@@ -41,22 +41,7 @@ export function sessionNameOf(key: string): string {
   return key.slice(0, 18)
 }
 
-/** 审批输入摘要（推送通知/审批页）：按工具挑裁决所需的关键字段，其余给 JSON 截断。
- *  与 web 端 toolSummary 同族但取舍不同——审批场景 Bash 必须给 command 本体
- *  （description 是作者给的说明文字，不能作为裁决依据；web 卡片下方另有详情区才可用它打头）。 */
-export function summarizeInput(toolName: string, input: unknown): string {
-  const obj = (input ?? {}) as Record<string, unknown>
-  if (toolName === 'Bash') return String(obj.command ?? '').slice(0, 400)
-  if (toolName === 'Glob' || toolName === 'Grep') return String(obj.pattern ?? '')
-  if (toolName === 'WebSearch') return String(obj.query ?? '')
-  if (toolName === 'WebFetch') return String(obj.url ?? '')
-  if (toolName === 'Agent') return String(obj.description ?? obj.prompt ?? '').slice(0, 300)
-  if (obj.file_path) return String(obj.file_path)
-  if (obj.path) return String(obj.path)
-  if (obj.grantRoot) return String(obj.grantRoot)
-  const json = JSON.stringify(input ?? {})
-  return json.length > 300 ? json.slice(0, 300) + '…' : json
-}
+/** 审批确认页与推送体的摘要口径已上移到 util.ts 的 summarizeInput（唯一正本，hub 层也用它）。 */
 
 /**
  * webhook 审批确认页（GET /api/approval-page 的 HTML）。

--- a/server/src/push/fanout.ts
+++ b/server/src/push/fanout.ts
@@ -1,0 +1,165 @@
+// Web Push / webhook 的通知载荷组装与扇出；会话显示名、审批摘要、审批确认页 HTML 的唯一正本。
+// 依赖方向：push → hub（registry）允许，反向禁止（hub 经 hub/broadcast 的 InboxSink 出口）。
+
+import { parseKey } from '../backends/claude/backend'
+import { portFor } from '../backends/port'
+import { log } from '../log'
+import { pushToAll, pushWebhooksToAll, subscriptionCount, webhookCount, type PushPayload } from '../push'
+import { escapeHtml } from '../util'
+import { hubs } from '../hub/registry'
+import type { InboxEvent, PendingApproval } from '../hub/types'
+
+/** 会话显示名：项目目录 basename（approval 只在 spawn 后发生，spawnOpts.cwd 必有）。
+ *  s| 未 spawn 时经 parseKey 反查真实 cwd——每 Hub 至多一次（缓存在 hub.nameCwd，
+ *  避免推送事件触发反复 listSessions 全盘扫描）；b|/n|/xn| 的 cwd 内嵌在 key 里直接取。
+ *  parseKey 也查不到（slug 目录已删）时以 slug 末段近似。 */
+export function sessionNameOf(key: string): string {
+  const base = (cwd: string) => cwd.replace(/\/+$/, '').split('/').pop() ?? cwd
+  const hub = hubs.get(key)
+  if (hub?.spawnOpts?.cwd) return base(hub.spawnOpts.cwd)
+  const parts = key.split('|')
+  try {
+    if ((parts[0] === 'b' || parts[0] === 'n' || parts[0] === 'xn') && parts[1]) {
+      return base(decodeURIComponent(parts[1]))
+    }
+  } catch {
+    // key 内嵌 cwd 不是合法 URI 编码（状态损坏/构造输入）：落 key 截断，不影响推送分发
+    return key.slice(0, 18)
+  }
+  if (parts[0] === 's') {
+    if (hub && hub.nameCwd === undefined) hub.nameCwd = parseKey(key)?.cwd ?? ''
+    if (hub?.nameCwd) return base(hub.nameCwd)
+    // slug 是 sanitizePath(cwd)：末段即目录名（近似，仅推送显示用）
+    if (parts[1]) return parts[1].split('-').pop() ?? key.slice(0, 18)
+  }
+  // x|：cwd 不在 key 里，取已加载会话句柄的 cwd（thread/read 解析后即有；
+  // 推送/审批页恰好在会话存活期触发）。取不到时落 key 截断，不做同步 RPC
+  if (parts[0] === 'x') {
+    if (hub && hub.nameCwd === undefined) hub.nameCwd = portFor(key).sessionOf(key)?.cwd ?? ''
+    if (hub?.nameCwd) return base(hub.nameCwd)
+  }
+  return key.slice(0, 18)
+}
+
+/** 审批输入摘要（推送通知/审批页）：按工具挑裁决所需的关键字段，其余给 JSON 截断。
+ *  与 web 端 toolSummary 同族但取舍不同——审批场景 Bash 必须给 command 本体
+ *  （description 是作者给的说明文字，不能作为裁决依据；web 卡片下方另有详情区才可用它打头）。 */
+export function summarizeInput(toolName: string, input: unknown): string {
+  const obj = (input ?? {}) as Record<string, unknown>
+  if (toolName === 'Bash') return String(obj.command ?? '').slice(0, 400)
+  if (toolName === 'Glob' || toolName === 'Grep') return String(obj.pattern ?? '')
+  if (toolName === 'WebSearch') return String(obj.query ?? '')
+  if (toolName === 'WebFetch') return String(obj.url ?? '')
+  if (toolName === 'Agent') return String(obj.description ?? obj.prompt ?? '').slice(0, 300)
+  if (obj.file_path) return String(obj.file_path)
+  if (obj.path) return String(obj.path)
+  if (obj.grantRoot) return String(obj.grantRoot)
+  const json = JSON.stringify(input ?? {})
+  return json.length > 300 ? json.slice(0, 300) + '…' : json
+}
+
+/**
+ * webhook 审批确认页（GET /api/approval-page 的 HTML）。
+ * 故意零依赖零外链（微信内置浏览器可达性）；k/r/s 由页面 JS 从自身 URL 读取，
+ * 服务端只注入已转义的工具名与摘要，不把 secret 写进 HTML。
+ */
+export function approvalPageHtml(key: string, pending?: PendingApproval): string {
+  const session = escapeHtml(sessionNameOf(key))
+  const tool = pending ? escapeHtml(pending.toolName) : ''
+  const summary = pending ? escapeHtml(summarizeInput(pending.toolName, pending.input)) : ''
+  const inner = pending
+    ? `<p class="meta">${session}</p>
+  <h1>需要审批 · ${tool}</h1>
+  <pre>${summary}</pre>
+  <div class="row">
+    <button class="ok" onclick="act('allow')">允许</button>
+    <button class="no" onclick="act('deny')">拒绝</button>
+  </div>
+  <p id="st" class="meta"></p>`
+    : `<h1>审批已处理</h1>
+  <p class="meta">${session} · 该请求已被裁决或不存在，无需操作</p>`
+  return `<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex">
+<title>审批 · AnyPlane</title>
+<style>
+  body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#16130f;color:#e8e2d9;font:14px/1.6 ui-monospace,SFMono-Regular,Menlo,monospace}
+  .card{box-sizing:border-box;width:100%;max-width:26rem;margin:1rem;padding:1.25rem;border:1px solid #3a332a;border-radius:.5rem;background:#1e1a15}
+  h1{font-size:1rem;margin:.25rem 0 .75rem}
+  .meta{color:#8a8175;font-size:.75rem;word-break:break-all}
+  pre{white-space:pre-wrap;word-break:break-all;background:#16130f;border:1px solid #3a332a;border-radius:.375rem;padding:.625rem;font-size:.75rem;max-height:40vh;overflow:auto}
+  .row{display:flex;gap:.625rem;margin-top:1rem}
+  button{flex:1;padding:.75rem;border-radius:.375rem;border:1px solid;font-size:.875rem;cursor:pointer;background:transparent;color:inherit}
+  button:disabled{opacity:.4;cursor:default}
+  .ok{border-color:#6f9f6f;color:#9fce9f}
+  .no{border-color:#9f6f6f;color:#ce9f9f}
+</style>
+</head>
+<body>
+<div class="card">${inner}</div>
+<script>
+async function act(d){
+  document.querySelectorAll('button').forEach(function(b){b.disabled=true})
+  var st=document.getElementById('st')
+  st.textContent='提交中…'
+  var p=new URL(location.href).searchParams
+  try{
+    var resp=await fetch('/api/approval-action?k='+encodeURIComponent(p.get('k')||'')+'&r='+encodeURIComponent(p.get('r')||'')+'&d='+d+'&s='+encodeURIComponent(p.get('s')||''),{method:'POST'})
+    var j=await resp.json()
+    st.textContent=j.ok?(d==='allow'?'✓ 已允许':'✓ 已拒绝'):('失败：'+(j.error||resp.status))
+    if(!j.ok)document.querySelectorAll('button').forEach(function(b){b.disabled=false})
+  }catch(e){
+    st.textContent='网络错误，请重试'
+    document.querySelectorAll('button').forEach(function(b){b.disabled=false})
+  }
+}
+</script>
+</body>
+</html>`
+}
+
+export function fanoutPush(ev: InboxEvent): void {
+  if (subscriptionCount() === 0 && webhookCount() === 0) return
+  if (ev.type === 'approval_resolved') return // 审批已处理，无需推送（通知 tag 替换语义下保留现状即可）
+  const session = sessionNameOf(ev.key)
+  let payload: PushPayload
+  if (ev.type === 'approval') {
+    payload = {
+      type: 'approval',
+      title: `需要审批 · ${ev.toolName}`,
+      body: `${session}｜${summarizeInput(ev.toolName, ev.input)}`,
+      key: ev.key,
+      session,
+      requestId: ev.requestId,
+      // 能力 URL：secret 由 pushToAll 按订阅逐个补全（每个订阅一个能力密钥）
+      actions: {
+        allow: `/api/approval-action?k=${encodeURIComponent(ev.key)}&r=${encodeURIComponent(ev.requestId)}&d=allow&s=`,
+        deny: `/api/approval-action?k=${encodeURIComponent(ev.key)}&r=${encodeURIComponent(ev.requestId)}&d=deny&s=`,
+      },
+      tag: `ccr-a-${ev.requestId}`,
+    }
+  } else if (ev.type === 'done') {
+    payload = {
+      type: 'done',
+      title: `${ev.ok ? '✓ 完成' : '✗ 结束（有错）'} · ${session}`,
+      body: '会话已空闲，点击查看结果',
+      key: ev.key,
+      session,
+      tag: `ccr-d-${ev.key}`,
+    }
+  } else {
+    payload = {
+      type: 'error',
+      title: `⚠ 出错 · ${session}`,
+      body: ev.message.slice(0, 300),
+      key: ev.key,
+      session,
+      tag: `ccr-e-${ev.key}`,
+    }
+  }
+  void pushToAll(payload).catch((e) => log.warn('[push] fanout 异常:', e))
+  void pushWebhooksToAll(payload).catch((e) => log.warn('[push] webhook fanout 异常:', e))
+}

--- a/server/src/push/inbox.ts
+++ b/server/src/push/inbox.ts
@@ -1,0 +1,51 @@
+// 全局收件箱频道（/ws/inbox）与 inbox 事件的真实出口。
+// hub 各模块经 hub/broadcast.publishInbox（InboxSink）流出事件；本模块是实现侧，
+// 由装配层 initInbox() 一次性接线（显式 init，不依赖 ESM 加载顺序副作用）。
+
+import type { ServerWebSocket } from 'bun'
+import { setInboxSink } from '../hub/broadcast'
+import { hubs } from '../hub/registry'
+import { statusOf } from '../hub/status'
+import type { InboxEvent, WSDataInbox } from '../hub/types'
+import { fanoutPush } from './fanout'
+
+const inboxClients = new Set<ServerWebSocket<WSDataInbox>>()
+
+export function addInboxClient(ws: ServerWebSocket<WSDataInbox>): void {
+  inboxClients.add(ws)
+}
+
+export function removeInboxClient(ws: ServerWebSocket<WSDataInbox>): void {
+  inboxClients.delete(ws)
+}
+
+function publish(ev: InboxEvent): void {
+  if (inboxClients.size > 0) {
+    const text = JSON.stringify(ev)
+    for (const ws of inboxClients) {
+      try {
+        ws.send(text)
+      } catch {}
+    }
+  }
+  fanoutPush(ev)
+}
+
+/** 装配层（index.ts）调用一次：把真实实现注册进 hub/broadcast 的 sink */
+export function initInbox(): void {
+  setInboxSink({ publish })
+}
+
+/** inbox 快照：所有 Hub 的待审批与忙闲状态（新连接建立时下发） */
+export function inboxSnapshot(): Record<string, unknown> {
+  const approvals: unknown[] = []
+  const states: Record<string, unknown>[] = []
+  for (const hub of hubs.values()) {
+    const st = statusOf(hub.key)
+    if (st.spawned || st.busy || st.waiting) states.push({ key: hub.key, ...st })
+    for (const a of hub.pendingApprovals.values()) {
+      approvals.push({ type: 'approval', key: hub.key, ...a })
+    }
+  }
+  return { type: 'snapshot', states, approvals }
+}

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -1,0 +1,14 @@
+// REST 路由聚合：子路由按原 handleApi 的检查顺序串联，首个命中者胜出。
+// 各路径互不相同（无重叠前缀匹配），顺序仅作可读性保留。
+
+import { handleMiscRoutes } from './misc'
+import { handlePushRoutes } from './pushRoutes'
+import { handleSessionRoutes } from './sessions'
+
+export async function handleApi(req: Request, url: URL): Promise<Response | undefined> {
+  return (
+    (await handlePushRoutes(req, url)) ??
+    (await handleSessionRoutes(req, url)) ??
+    (await handleMiscRoutes(req, url))
+  )
+}

--- a/server/src/routes/http.ts
+++ b/server/src/routes/http.ts
@@ -1,0 +1,13 @@
+// 路由共享的 HTTP 助手（独立成模块：api.ts 聚合各子路由，子路由若反向 import api.ts 即成环）
+
+export function json(data: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
+  })
+}
+
+/** POST JSON body：解析失败按 {} 处理（各 handler 自行做字段校验） */
+export async function readJsonBody<T>(req: Request): Promise<T> {
+  return (await req.json().catch(() => ({}))) as T
+}

--- a/server/src/routes/misc.ts
+++ b/server/src/routes/misc.ts
@@ -1,0 +1,127 @@
+// 其余 REST 路由：fs/list、handoff、lineage、uploads、history（claude/codex）、
+// codex/models、config、claude/model-names。
+
+import { readHistory, sanitizePath } from '../backends/claude/discovery'
+import { resolveTierModelNames } from '../backends/claude/modelNames'
+import { readHistory as readCodexHistory } from '../backends/codex/backend'
+import { codexRuntime } from '../backends/codex/runtime'
+import { config } from '../config'
+import { FsBrowseError, listDirectories } from '../fsbrowse'
+import { lineageFor, type HandoffDetail } from '../handoff'
+import { runHandoff } from '../hub/handoff'
+import { resolveUpload } from '../uploads'
+import { errorMessage } from '../util'
+import { json, readJsonBody } from './http'
+
+export async function handleMiscRoutes(req: Request, url: URL): Promise<Response | undefined> {
+  if (url.pathname === '/api/fs/list' && req.method === 'GET') {
+    // searchParams.get 已完成 URL 解码，禁止再 decodeURIComponent（含 % 的路径会被二次解码破坏）
+    const target = url.searchParams.get('path') ?? ''
+    try {
+      return json(listDirectories(target))
+    } catch (e) {
+      if (e instanceof FsBrowseError) return json({ error: e.message }, { status: e.status })
+      return json({ error: errorMessage(e) }, { status: 500 })
+    }
+  }
+  if (url.pathname === '/api/handoff' && req.method === 'POST') {
+    const body = await readJsonBody<{ fromKey?: string; toBackend?: string; detail?: HandoffDetail }>(req)
+    if (!body.fromKey) return json({ error: '缺少 fromKey' }, { status: 400 })
+    if (body.toBackend !== 'claude' && body.toBackend !== 'codex') {
+      return json({ error: 'toBackend 必须是 claude 或 codex' }, { status: 400 })
+    }
+    const detail: HandoffDetail =
+      body.detail === 'brief' || body.detail === 'detailed' ? body.detail : 'standard'
+    const error = runHandoff(body.fromKey, body.toBackend, detail)
+    if (error) return json({ error }, { status: 400 })
+    return json({ ok: true })
+  }
+  if (url.pathname === '/api/lineage' && req.method === 'GET') {
+    const key = url.searchParams.get('key') ?? ''
+    const records = lineageFor(key)
+    // 为链上每个 key 附带导航所需的节点元数据（前端接力链渲染用）
+    const nodes: Record<string, Record<string, unknown>> = {}
+    for (const r of records) {
+      for (const k of [r.fromKey, r.toKey, r.fromResolvedKey, r.toResolvedKey]) {
+        if (!k || nodes[k]) continue
+        const parts = k.split('|')
+        if (parts[0] === 's' && parts.length === 3) {
+          nodes[k] = { key: k, backend: 'claude', slug: parts[1], sessionId: parts[2], cwd: r.cwd }
+        } else if (parts[0] === 'x' && parts.length === 2) {
+          nodes[k] = { key: k, backend: 'codex', slug: 'codex', sessionId: parts[1], cwd: r.cwd }
+        } else if (parts[0] === 'n' || parts[0] === 'xn') {
+          nodes[k] = {
+            key: k,
+            backend: parts[0] === 'xn' ? 'codex' : 'claude',
+            slug: parts[0] === 'xn' ? 'codex' : sanitizePath(decodeURIComponent(parts[1] ?? '')),
+            sessionId: 'new',
+            cwd: r.cwd,
+          }
+        } else if (parts[0] === 'b' && parts.length === 3) {
+          // 懒分叉源（分叉后从未 spawn 或被回收，fromResolvedKey 缺省时记录里仍是 b| key）：
+          // 缺节点会让前端接力链按钮 disabled（死按钮）；sessionId 内嵌的是分叉源 id
+          nodes[k] = {
+            key: k,
+            backend: 'claude',
+            slug: sanitizePath(decodeURIComponent(parts[1] ?? '')),
+            sessionId: parts[2],
+            cwd: r.cwd,
+          }
+        }
+      }
+    }
+    return json({ records, nodes })
+  }
+  // 上传图片：仅 ~/.anyplane/uploads/ 内的 hash 命名文件（resolveUpload 边界校验）
+  const uploadMatch = url.pathname.match(/^\/api\/uploads\/([^/]+)$/)
+  if (uploadMatch && req.method === 'GET') {
+    const path = resolveUpload(uploadMatch[1])
+    if (!path) return json({ error: 'not found' }, { status: 404 })
+    const ext = path.split('.').pop() ?? ''
+    const mime =
+      ({ jpg: 'image/jpeg', png: 'image/png', gif: 'image/gif', webp: 'image/webp' })[ext] ??
+      'application/octet-stream'
+    return new Response(Bun.file(path), {
+      headers: { 'content-type': mime, 'cache-control': 'public, max-age=31536000, immutable' },
+    })
+  }
+  const histMatch = url.pathname.match(/^\/api\/history\/([^/]+)\/([^/]+)$/)
+  if (histMatch && req.method === 'GET') {
+    const [, slug, sessionId] = histMatch
+    // fileBytes = 本次实际读取的字节数，前端拿它作为 tailer 的起始偏移
+    return json(readHistory(slug, sessionId))
+  }
+  // codex 历史：thread/read includeTurns（只读），无 tailer 偏移概念
+  const codexHistMatch = url.pathname.match(/^\/api\/codex\/history\/([^/]+)$/)
+  if (codexHistMatch && req.method === 'GET') {
+    try {
+      const messages = await readCodexHistory(codexHistMatch[1])
+      return json({ messages, fileBytes: 0 })
+    } catch (e) {
+      return json({ error: errorMessage(e) }, { status: 500 })
+    }
+  }
+  // codex 模型目录（model/list）：模型 id/显示名/effort 列表/默认 effort
+  if (url.pathname === '/api/codex/models' && req.method === 'GET') {
+    try {
+      const models = await codexRuntime.listModels()
+      return json({ models })
+    } catch (e) {
+      return json({ error: errorMessage(e) }, { status: 500 })
+    }
+  }
+  if (url.pathname === '/api/config' && req.method === 'GET') {
+    return json({
+      permissionPolicy: config.permissionPolicy,
+      permissionModes: ['default', 'acceptEdits', 'auto', 'plan', 'bypassPermissions'],
+      effortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+      models: ['haiku', 'sonnet', 'opus', 'fable'],
+      authRequired: !!config.authToken,
+    })
+  }
+  // 各档实际配置的模型名（StatusPill 透传显示；每次调用实时读盘，配置改动即见）
+  if (url.pathname === '/api/claude/model-names' && req.method === 'GET') {
+    return json({ models: resolveTierModelNames(url.searchParams.get('cwd') ?? undefined) })
+  }
+  return undefined
+}

--- a/server/src/routes/pushRoutes.ts
+++ b/server/src/routes/pushRoutes.ts
@@ -1,0 +1,104 @@
+// Web Push 订阅管理与能力 URL 审批路由：
+// /api/push/*、/api/approval-action、/api/approval-page。
+
+import { resolveApproval } from '../hub/lifecycle'
+import { hubs } from '../hub/registry'
+import { log } from '../log'
+import {
+  addSubscription,
+  pushToAll,
+  pushWebhooksToAll,
+  removeSubscription,
+  subscriptionCount,
+  vapidPublicKey,
+  validSecret,
+  webhookCount,
+  type PushPayload,
+} from '../push'
+import { approvalPageHtml, sessionNameOf } from '../push/fanout'
+import { errorMessage } from '../util'
+import { json, readJsonBody } from './http'
+
+export async function handlePushRoutes(req: Request, url: URL): Promise<Response | undefined> {
+  if (url.pathname === '/api/push/public-key' && req.method === 'GET') {
+    return json({ publicKey: vapidPublicKey(), subscriptions: subscriptionCount(), webhooks: webhookCount() })
+  }
+  if (url.pathname === '/api/push/subscriptions' && req.method === 'POST') {
+    const body = await readJsonBody<{ endpoint?: string; keys?: { p256dh: string; auth: string } }>(req)
+    if (!body.endpoint || !body.keys?.p256dh || !body.keys?.auth) {
+      return json({ error: 'endpoint 与 keys.p256dh/auth 必填' }, { status: 400 })
+    }
+    let secret: string
+    try {
+      secret = addSubscription(
+        { endpoint: body.endpoint, keys: body.keys },
+        req.headers.get('user-agent') ?? undefined,
+      ).secret
+    } catch (e) {
+      return json({ error: errorMessage(e) }, { status: 400 })
+    }
+    log.info(`[push] 新订阅（共 ${subscriptionCount()}）：${body.endpoint.slice(0, 60)}…`)
+    return json({ ok: true, secret })
+  }
+  if (url.pathname === '/api/push/subscriptions' && req.method === 'DELETE') {
+    const body = await readJsonBody<{ endpoint?: string }>(req)
+    return json({ ok: body.endpoint ? removeSubscription(body.endpoint) : false })
+  }
+  // 推送通道自检：向全部订阅与 webhook 通道 fanout 一条测试通知（不带审批能力，点击落应用首页）
+  if (url.pathname === '/api/push/test' && req.method === 'POST') {
+    const payload: PushPayload = {
+      type: 'done',
+      title: '测试通知 · AnyPlane',
+      body: '推送链路可达：全部订阅与 webhook 通道会同时收到这一条。',
+      key: '',
+      session: 'anyplane',
+      tag: 'ccr-test',
+    }
+    const [push, hooks] = await Promise.all([pushToAll(payload), pushWebhooksToAll(payload)])
+    return json({
+      ok: true,
+      subscriptions: subscriptionCount(),
+      webhooks: webhookCount(),
+      sent: push.sent + hooks.sent,
+      pruned: push.pruned,
+    })
+  }
+  // 推送直接审批（能力 URL：secret 鉴权，不走 authToken——该 URL 只经加密推送投递到订阅设备）
+  if (url.pathname === '/api/approval-action' && req.method === 'POST') {
+    const key = url.searchParams.get('k') ?? ''
+    const requestId = url.searchParams.get('r') ?? ''
+    const decision = url.searchParams.get('d') ?? ''
+    const secret = url.searchParams.get('s') ?? ''
+    if (!validSecret(secret)) return json({ ok: false, error: '无效的能力密钥' }, { status: 403 })
+    if (decision !== 'allow' && decision !== 'deny') {
+      return json({ ok: false, error: 'd 只接受 allow/deny' }, { status: 400 })
+    }
+    const hub = hubs.get(key)
+    if (!hub || !hub.pendingApprovals.has(requestId)) {
+      return json({ ok: false, error: '该审批已处理或不存在' }, { status: 409 })
+    }
+    const pending = hub.pendingApprovals.get(requestId)!
+    const ok = resolveApproval(
+      hub,
+      requestId,
+      decision === 'allow'
+        ? { behavior: 'allow', updatedInput: pending.input }
+        : { behavior: 'deny', message: '用户在推送通知上拒绝了该操作' },
+    )
+    log.info(`[push] 通知直接审批 ${decision}：${sessionNameOf(key)} · ${pending.toolName}`)
+    return json({ ok })
+  }
+  // webhook 通知的审批确认页（Bark/Server酱 无原生按钮：点链接进此页，按钮再 POST 到 approval-action）。
+  // GET 只渲染不执行——通知链接被预览/抓取也不会误触审批。能力 URL 模型同 approval-action。
+  if (url.pathname === '/api/approval-page' && req.method === 'GET') {
+    const key = url.searchParams.get('k') ?? ''
+    const requestId = url.searchParams.get('r') ?? ''
+    const secret = url.searchParams.get('s') ?? ''
+    if (!validSecret(secret)) return new Response('无效的能力密钥', { status: 403 })
+    const pending = hubs.get(key)?.pendingApprovals.get(requestId)
+    return new Response(approvalPageHtml(key, pending), {
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    })
+  }
+  return undefined
+}

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -1,16 +1,21 @@
 // 会话列表与管理路由：/api/sessions（GET/POST）+ archive/restore/archived/rename。
 // git 分支缓存也在这里（仅列表端点使用）。
 
-import { listTrash } from '../archive'
 import { keyFor, keyForNew } from '../backends/claude/backend'
 import { listSessions, sanitizePath, type SessionInfo } from '../backends/claude/discovery'
 import { keyForNew as codexKeyForNew, listSessions as listCodexSessions } from '../backends/codex/backend'
-import { codexRuntime } from '../backends/codex/runtime'
-import { portFor } from '../backends/port'
+import { claudePort } from '../backends/claude/port'
+import { codexPort } from '../backends/codex/port'
+import { portFor, type RouteResult } from '../backends/port'
 import { readGitBranch } from '../fsbrowse'
 import { statusOf } from '../hub/status'
 import { log } from '../log'
 import { json, readJsonBody } from './http'
+
+/** RouteResult → HTTP 响应（状态码逐字保留） */
+function routeResultJson(r: RouteResult): Response {
+  return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
+}
 
 // ---------- /api/sessions 的 git 分支缓存 ----------
 // 列表被前端轮询，每个 cwd 的分支读取是 2-3 次同步文件 IO；分支变化不需要秒级新鲜度，30s TTL。
@@ -74,43 +79,20 @@ export async function handleSessionRoutes(req: Request, url: URL): Promise<Respo
   if (url.pathname === '/api/sessions/archive' && req.method === 'POST') {
     const body = await readJsonBody<{ key?: string }>(req)
     if (!body.key) return json({ error: '缺少 key' }, { status: 400 })
-    const r = await portFor(body.key).archive(body.key)
-    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
+    return routeResultJson(await portFor(body.key).archive(body.key))
   }
   if (url.pathname === '/api/sessions/restore' && req.method === 'POST') {
     const body = await readJsonBody<{ key?: string }>(req)
     if (!body.key) return json({ error: '缺少 key' }, { status: 400 })
-    const r = await portFor(body.key).restore(body.key)
-    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
+    return routeResultJson(await portFor(body.key).restore(body.key))
   }
-  // 归档/回收站列表：codex archived + claude trash 合并
+  // 归档/回收站列表：两后端各自经 port 提供（codex archived + claude trash），
+  // 单后端失败在适配器内降级为空数组，互不拖垮
   if (url.pathname === '/api/sessions/archived' && req.method === 'GET') {
-    const claudeTrash = listTrash().map((t) => ({
-      key: t.key,
-      sessionId: t.sessionId,
-      slug: t.slug,
-      backend: 'claude' as const,
-      trashedAt: t.trashedAt,
-      sizeBytes: t.sizeBytes,
-    }))
-    let codexArchived: Record<string, unknown>[] = []
-    try {
-      const res = (await codexRuntime.rpcRequest('thread/list', { archived: true, limit: 100 })) as {
-        data?: Array<Record<string, unknown>>
-      }
-      codexArchived = (res.data ?? []).map((t) => ({
-        key: `x|${String(t.id)}`,
-        sessionId: String(t.id),
-        slug: 'codex',
-        backend: 'codex' as const,
-        title: typeof t.name === 'string' ? t.name : undefined,
-        lastPrompt: typeof t.preview === 'string' ? t.preview : undefined,
-        cwd: typeof t.cwd === 'string' ? t.cwd : undefined,
-        mtime: Number(t.updatedAt ?? t.createdAt ?? 0) * 1000,
-      }))
-    } catch (e) {
-      log.warn('[api] codex archived 列表失败:', e instanceof Error ? e.message : e)
-    }
+    const [codexArchived, claudeTrash] = await Promise.all([
+      codexPort.listArchived(),
+      claudePort.listArchived(),
+    ])
     return json({ entries: [...codexArchived, ...claudeTrash] })
   }
   if (url.pathname === '/api/sessions/rename' && req.method === 'POST') {
@@ -119,8 +101,7 @@ export async function handleSessionRoutes(req: Request, url: URL): Promise<Respo
     if (!body.key || !title) return json({ error: '缺少 key 或 title' }, { status: 400 })
     // codex 走官方 thread/name/set；claude 仅离线会话（transcript 追加 custom-title），
     // 两路实现见各自适配器
-    const r = await portFor(body.key).rename(body.key, title)
-    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
+    return routeResultJson(await portFor(body.key).rename(body.key, title))
   }
   return undefined
 }

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -1,0 +1,126 @@
+// 会话列表与管理路由：/api/sessions（GET/POST）+ archive/restore/archived/rename。
+// git 分支缓存也在这里（仅列表端点使用）。
+
+import { listTrash } from '../archive'
+import { keyFor, keyForNew } from '../backends/claude/backend'
+import { listSessions, sanitizePath, type SessionInfo } from '../backends/claude/discovery'
+import { keyForNew as codexKeyForNew, listSessions as listCodexSessions } from '../backends/codex/backend'
+import { codexRuntime } from '../backends/codex/runtime'
+import { portFor } from '../backends/port'
+import { readGitBranch } from '../fsbrowse'
+import { statusOf } from '../hub/status'
+import { log } from '../log'
+import { json, readJsonBody } from './http'
+
+// ---------- /api/sessions 的 git 分支缓存 ----------
+// 列表被前端轮询，每个 cwd 的分支读取是 2-3 次同步文件 IO；分支变化不需要秒级新鲜度，30s TTL。
+const BRANCH_CACHE_TTL_MS = 30_000
+const branchCache = new Map<string, { branch: string | undefined; at: number }>()
+
+function branchOfCached(cwd?: string): string | undefined {
+  if (!cwd) return undefined
+  const hit = branchCache.get(cwd)
+  if (hit && Date.now() - hit.at < BRANCH_CACHE_TTL_MS) return hit.branch
+  const branch = readGitBranch(cwd) // 普通仓库与 worktree 都支持
+  branchCache.set(cwd, { branch, at: Date.now() })
+  return branch
+}
+
+export async function handleSessionRoutes(req: Request, url: URL): Promise<Response | undefined> {
+  if (url.pathname === '/api/sessions' && req.method === 'GET') {
+    const sessions = listSessions()
+    const claudeRows = sessions.map((s: SessionInfo) => ({
+      ...s,
+      backend: 'claude' as const,
+      gitBranch: branchOfCached(s.cwd),
+      key: keyFor(s.slug, s.sessionId),
+      // listSessions 已扫过 pid 文件，复用其结果，不为每行再扫一次（null = 已知不在线）
+      managed: statusOf(
+        keyFor(s.slug, s.sessionId),
+        s.live ? { status: s.status, pid: s.live.pid } : null,
+      ),
+    }))
+    // codex 线程：app-server 未安装/未登录时静默降级为空列表，不拖垮 claude 列表
+    let codexRows: Record<string, unknown>[] = []
+    try {
+      const threads = await listCodexSessions()
+      codexRows = threads.map((t) => ({
+        sessionId: t.id,
+        cwd: t.cwd,
+        slug: 'codex',
+        title: t.title,
+        lastPrompt: t.lastPrompt,
+        mtime: t.mtime,
+        sizeBytes: 0,
+        status: t.status,
+        backend: 'codex' as const,
+        gitBranch: branchOfCached(t.cwd),
+        key: t.key,
+        managed: statusOf(t.key),
+      }))
+    } catch (e) {
+      log.warn('[api] codex thread/list 失败（仅返回 claude 会话）:', e instanceof Error ? e.message : e)
+    }
+    return json([...codexRows, ...claudeRows])
+  }
+  if (url.pathname === '/api/sessions' && req.method === 'POST') {
+    const body = await readJsonBody<{ cwd?: string; backend?: string }>(req)
+    if (!body.cwd) return json({ error: '缺少 cwd' }, { status: 400 })
+    if (body.backend === 'codex') {
+      return json({ key: codexKeyForNew(body.cwd), slug: 'codex', backend: 'codex' })
+    }
+    return json({ key: keyForNew(body.cwd), slug: sanitizePath(body.cwd), backend: 'claude' })
+  }
+  if (url.pathname === '/api/sessions/archive' && req.method === 'POST') {
+    const body = await readJsonBody<{ key?: string }>(req)
+    if (!body.key) return json({ error: '缺少 key' }, { status: 400 })
+    const r = await portFor(body.key).archive(body.key)
+    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
+  }
+  if (url.pathname === '/api/sessions/restore' && req.method === 'POST') {
+    const body = await readJsonBody<{ key?: string }>(req)
+    if (!body.key) return json({ error: '缺少 key' }, { status: 400 })
+    const r = await portFor(body.key).restore(body.key)
+    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
+  }
+  // 归档/回收站列表：codex archived + claude trash 合并
+  if (url.pathname === '/api/sessions/archived' && req.method === 'GET') {
+    const claudeTrash = listTrash().map((t) => ({
+      key: t.key,
+      sessionId: t.sessionId,
+      slug: t.slug,
+      backend: 'claude' as const,
+      trashedAt: t.trashedAt,
+      sizeBytes: t.sizeBytes,
+    }))
+    let codexArchived: Record<string, unknown>[] = []
+    try {
+      const res = (await codexRuntime.rpcRequest('thread/list', { archived: true, limit: 100 })) as {
+        data?: Array<Record<string, unknown>>
+      }
+      codexArchived = (res.data ?? []).map((t) => ({
+        key: `x|${String(t.id)}`,
+        sessionId: String(t.id),
+        slug: 'codex',
+        backend: 'codex' as const,
+        title: typeof t.name === 'string' ? t.name : undefined,
+        lastPrompt: typeof t.preview === 'string' ? t.preview : undefined,
+        cwd: typeof t.cwd === 'string' ? t.cwd : undefined,
+        mtime: Number(t.updatedAt ?? t.createdAt ?? 0) * 1000,
+      }))
+    } catch (e) {
+      log.warn('[api] codex archived 列表失败:', e instanceof Error ? e.message : e)
+    }
+    return json({ entries: [...codexArchived, ...claudeTrash] })
+  }
+  if (url.pathname === '/api/sessions/rename' && req.method === 'POST') {
+    const body = await readJsonBody<{ key?: string; title?: string }>(req)
+    const title = body.title?.trim()
+    if (!body.key || !title) return json({ error: '缺少 key 或 title' }, { status: 400 })
+    // codex 走官方 thread/name/set；claude 仅离线会话（transcript 追加 custom-title），
+    // 两路实现见各自适配器
+    const r = await portFor(body.key).rename(body.key, title)
+    return r.ok ? json({ ok: true }) : json({ error: r.error }, { status: r.status })
+  }
+  return undefined
+}

--- a/server/src/util.test.ts
+++ b/server/src/util.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { chmodSync, mkdtempSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ensurePrivateDir, childEnv, errorMessage, pumpLines } from './util'
+import { ensurePrivateDir, childEnv, errorMessage, pumpLines, summarizeInput } from './util'
 
 function streamOf(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -128,5 +128,30 @@ describe('ensurePrivateDir（~/.anyplane 私有目录）', () => {
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
+  })
+})
+
+describe('summarizeInput（审批摘要唯一口径）', () => {
+  test('按工具分发到裁决关键字段', () => {
+    expect(summarizeInput('Bash', { command: 'ls -la', description: '列目录' })).toBe('ls -la')
+    expect(summarizeInput('Glob', { pattern: 'src/**/*.ts' })).toBe('src/**/*.ts')
+    expect(summarizeInput('Grep', { pattern: 'foo' })).toBe('foo')
+    expect(summarizeInput('WebSearch', { query: 'bun watch' })).toBe('bun watch')
+    expect(summarizeInput('WebFetch', { url: 'https://example.com' })).toBe('https://example.com')
+    expect(summarizeInput('Agent', { description: '查日志', prompt: '详细指令' })).toBe('查日志')
+  })
+  test('通用回退：file_path > path > grantRoot > JSON', () => {
+    expect(summarizeInput('Write', { file_path: '/tmp/a.txt', content: 'x' })).toBe('/tmp/a.txt')
+    expect(summarizeInput('Custom', { path: '/b' })).toBe('/b')
+    expect(summarizeInput('Custom', { grantRoot: '/c' })).toBe('/c')
+    expect(summarizeInput('Custom', { other: 1 })).toBe('{"other":1}')
+  })
+  test('长输入截断（Bash 400 / 其余 JSON 300）', () => {
+    expect(summarizeInput('Bash', { command: 'x'.repeat(500) })).toHaveLength(400)
+    expect(summarizeInput('Custom', { v: 'y'.repeat(400) }).length).toBeLessThanOrEqual(301)
+  })
+  test('空输入不炸', () => {
+    expect(summarizeInput('Bash', undefined)).toBe('')
+    expect(summarizeInput('Custom', null)).toBe('{}')
   })
 })

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -141,3 +141,21 @@ export async function pumpLines(
     else log.error('[pumpLines] 读取异常:', e)
   }
 }
+
+/** 审批输入摘要（推送通知/审批页/approval_auto 留痕卡共用唯一口径）：按工具挑裁决所需的
+ *  关键字段，其余给 JSON 截断。与 web 端 toolSummary 同族但取舍不同——审批场景 Bash 必须给
+ *  command 本体（description 是作者给的说明文字，不能作为裁决依据）。
+ *  家在本模块（叶子）而非 push/fanout：hub 层广播 approval_auto 也需要它，push→hub 单向红线不能破。 */
+export function summarizeInput(toolName: string, input: unknown): string {
+  const obj = (input ?? {}) as Record<string, unknown>
+  if (toolName === 'Bash') return String(obj.command ?? '').slice(0, 400)
+  if (toolName === 'Glob' || toolName === 'Grep') return String(obj.pattern ?? '')
+  if (toolName === 'WebSearch') return String(obj.query ?? '')
+  if (toolName === 'WebFetch') return String(obj.url ?? '')
+  if (toolName === 'Agent') return String(obj.description ?? obj.prompt ?? '').slice(0, 300)
+  if (obj.file_path) return String(obj.file_path)
+  if (obj.path) return String(obj.path)
+  if (obj.grantRoot) return String(obj.grantRoot)
+  const json = JSON.stringify(input ?? {})
+  return json.length > 300 ? json.slice(0, 300) + '…' : json
+}

--- a/web/src/components/ChatHeader.tsx
+++ b/web/src/components/ChatHeader.tsx
@@ -1,0 +1,361 @@
+// 聊天页顶栏：悬浮磨砂横带（返回/标题状态行/后台任务开关/更多菜单/goal 面板/接力链导航条）。
+// F2 从 pages/Chat.tsx 逐字切出——纯展示组件，状态经 props 平铺注入，无内部业务逻辑。
+// （moreBtnRef 与 idCopied 是本组件私有的展示态，随 JSX 一并下沉。）
+
+import { useRef, useState } from 'react'
+import type { LineageResponse, SessionInfo } from '../lib/api'
+import { copyText } from '../lib/chatText'
+import type { SessionState } from '../lib/ws'
+import { ClaudeMark } from './ClaudeMark'
+import { CodexMark } from './CodexMark'
+import { PopupPanel } from './PopupPanel'
+import type { TaskFeed } from './TasksPanel'
+
+const MORE_ITEM =
+  'flex w-full items-center gap-2 rounded-[10px] px-3 py-2 text-left font-mono text-[12px] text-muted transition-colors hover:bg-surface hover:text-ink'
+
+export function ChatHeader(props: {
+  session: SessionInfo
+  connected: boolean
+  statusLine: string
+  busy: boolean
+  phase?: string
+  onBack: () => void
+  tasks: TaskFeed[]
+  tasksOpen: boolean
+  onToggleTasks: () => void
+  isExisting: boolean
+  isCodex: boolean
+  /** state.sessionId（更多菜单与目标按钮的显隐判定） */
+  sessionId?: string
+  /** 当前会话权威 ID（复制按钮）；spawn 后以 status 广播为准 */
+  currentSessionId?: string
+  goal?: SessionState['goal']
+  usageLine?: string
+  moreOpen: boolean
+  setMoreOpen: (v: boolean | ((prev: boolean) => boolean)) => void
+  onSystemMessage: (text: string, kind?: 'info' | 'error') => void
+  /** 详情抽屉开关：含「打开时顺带发查询」的语义，实现在 Chat 组合层 */
+  onToggleDetail: () => void
+  goalOpen: boolean
+  onToggleGoal: () => void
+  onCloseGoal: () => void
+  goalDraft: string
+  onGoalDraftChange: (v: string) => void
+  onSendGoal: (condition?: string) => void
+  onBranch: () => void
+  handoffBusy: boolean
+  onHandoff: () => void
+  lineage?: LineageResponse
+  onNavigate?: (s: SessionInfo) => void
+  /** 玻璃横带内的尾部插槽（详情抽屉在 DOM 上与顶栏/接力链同属 glass-bar，由组合层传入） */
+  children?: React.ReactNode
+}) {
+  const {
+    session,
+    connected,
+    statusLine,
+    busy,
+    phase,
+    onBack,
+    tasks,
+    tasksOpen,
+    onToggleTasks,
+    isExisting,
+    isCodex,
+    sessionId,
+    currentSessionId,
+    goal,
+    usageLine,
+    moreOpen,
+    setMoreOpen,
+    onSystemMessage,
+    onToggleDetail,
+    goalOpen,
+    onToggleGoal,
+    onCloseGoal,
+    goalDraft,
+    onGoalDraftChange,
+    onSendGoal,
+    onBranch,
+    handoffBusy,
+    onHandoff,
+    lineage,
+    onNavigate,
+    children,
+  } = props
+  const moreBtnRef = useRef<HTMLButtonElement>(null)
+  const [idCopied, setIdCopied] = useState(false)
+
+  return (
+    <div className="glass-bar absolute inset-x-0 top-0 z-30">
+      <div className="px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <button
+            className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-surface2 text-muted transition-colors hover:text-ink md:hidden"
+            onClick={onBack}
+            title="返回列表"
+            aria-label="返回列表"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+              <path d="M19 12H5M12 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">{session.title ?? session.cwd ?? session.sessionId}</div>
+            <div className="flex items-center gap-2 font-mono text-[10px] tracking-wide text-faint">
+              <span className={connected ? 'text-ok' : 'text-accent'}>{connected ? '●' : '○'}</span>
+              <span className={busy || phase ? 'text-busy' : ''}>{statusLine}</span>
+            </div>
+          </div>
+          {/* 后台任务侧栏开关：有任务活动时出现；运行中带计数徽标与呼吸 */}
+          {tasks.length > 0 && (
+            <button
+              type="button"
+              className={`relative grid h-8 w-8 shrink-0 place-items-center rounded-full transition-colors ${
+                tasksOpen ? 'bg-surface2 text-ink' : 'bg-surface2 text-muted hover:text-ink'
+              }`}
+              title="后台任务"
+              aria-label="后台任务"
+              aria-expanded={tasksOpen}
+              onClick={onToggleTasks}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
+                <path d="M6 3v12" />
+                <circle cx="18" cy="6" r="3" />
+                <circle cx="6" cy="18" r="3" />
+                <path d="M18 9a9 9 0 0 1-9 9" />
+              </svg>
+              {tasks.some((s) => s.status === 'running') && (
+                <span className="absolute top-0.5 right-0.5 size-1.5 animate-pulse rounded-full bg-busy" aria-hidden />
+              )}
+            </button>
+          )}
+          {(isExisting || !isCodex || sessionId) && (
+            <>
+              <button
+                ref={moreBtnRef}
+                type="button"
+                className={`relative grid h-8 w-8 shrink-0 place-items-center rounded-full transition-colors ${
+                  moreOpen ? 'bg-surface2 text-ink' : 'bg-surface2 text-muted hover:text-ink'
+                }`}
+                title="更多"
+                aria-label="更多"
+                aria-haspopup="menu"
+                aria-expanded={moreOpen}
+                onClick={() => setMoreOpen((v) => !v)}
+              >
+                <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4" aria-hidden>
+                  <circle cx="5" cy="12" r="1.8" />
+                  <circle cx="12" cy="12" r="1.8" />
+                  <circle cx="19" cy="12" r="1.8" />
+                </svg>
+                {goal && (
+                  <span className="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-ok" aria-hidden />
+                )}
+              </button>
+              <PopupPanel
+                open={moreOpen}
+                anchor={moreBtnRef.current}
+                onClose={() => setMoreOpen(false)}
+                placement="bottom-end"
+                offset={6}
+                className="min-w-44"
+              >
+                {currentSessionId && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`${MORE_ITEM} ${idCopied ? 'text-ok hover:text-ok' : ''}`}
+                    title={`${isCodex ? 'thread id' : 'session id'}：${currentSessionId}（点击复制完整 ID）`}
+                    onClick={() => {
+                      void copyText(currentSessionId).then((ok) => {
+                        if (!ok) {
+                          setMoreOpen(false)
+                          onSystemMessage(`⚠ 复制失败，请手动复制：${currentSessionId}`, 'error')
+                          return
+                        }
+                        setIdCopied(true)
+                        setTimeout(() => {
+                          setIdCopied(false)
+                          setMoreOpen(false)
+                        }, 900)
+                      })
+                    }}
+                  >
+                    {idCopied ? '✓ 已复制' : `⧉ ${currentSessionId.slice(0, 8)}…`}
+                  </button>
+                )}
+                {isExisting && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={MORE_ITEM}
+                    title="会话详情：context 用量 / MCP 状态 / 设置"
+                    onClick={() => {
+                      setMoreOpen(false)
+                      onToggleDetail()
+                    }}
+                  >
+                    ▤ 详情
+                  </button>
+                )}
+                {(!isCodex || sessionId) && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`${MORE_ITEM} ${goal ? 'text-ok hover:text-ok' : ''}`}
+                    title={
+                      goal
+                        ? `当前目标：${goal.condition}（点击管理）`
+                        : '设定目标：agent 会持续工作直到条件达成（claude /goal · codex thread/goal）'
+                    }
+                    onClick={() => {
+                      setMoreOpen(false)
+                      onToggleGoal()
+                    }}
+                  >
+                    {goal
+                      ? `◎ ${goal.condition.slice(0, 16)}${goal.condition.length > 16 ? '…' : ''}`
+                      : '◎ 目标'}
+                  </button>
+                )}
+                {isExisting && !isCodex && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={MORE_ITEM}
+                    title="分叉当前会话：新分支携带全部历史，原会话保持不动"
+                    onClick={() => {
+                      setMoreOpen(false)
+                      onBranch()
+                    }}
+                  >
+                    ⎇ 分叉
+                  </button>
+                )}
+                {isExisting && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={`${MORE_ITEM} disabled:opacity-40`}
+                    disabled={handoffBusy}
+                    title="让另一个 agent 接续本目录的工作（源会话 fork 自写简报，目标会话带简报进场）"
+                    onClick={() => {
+                      setMoreOpen(false)
+                      onHandoff()
+                    }}
+                  >
+                    {handoffBusy ? '接力中…' : `⇄ 接力给${isCodex ? ' Claude' : ' Codex'}`}
+                  </button>
+                )}
+              </PopupPanel>
+            </>
+          )}
+        </div>
+        {usageLine && (
+          <div className="mt-1 font-mono text-[10px] tracking-wide text-faint/80">{usageLine}</div>
+        )}
+        {goalOpen && (
+          <div className="mt-2 rounded-[14px] bg-surface2/80 p-2.5 backdrop-blur-xl">
+            <div className="mb-1.5 flex items-center justify-between">
+              <span className="font-mono text-[10px] tracking-wide text-faint">
+                ◎ 会话目标{goal ? '（进行中）' : ''}——agent 会持续工作直到条件达成
+              </span>
+              <button className="font-mono text-[10px] text-faint hover:text-muted" onClick={onCloseGoal}>
+                ✕
+              </button>
+            </div>
+            {goal && (
+              <div className="mb-1.5 font-mono text-[11px] leading-relaxed text-ok">
+                当前：{goal.condition}
+                {goal.tokensUsed != null && (
+                  <span className="text-faint"> · {goal.tokensUsed} tok</span>
+                )}
+              </div>
+            )}
+            <div className="flex gap-1.5">
+              <input
+                className="min-w-0 flex-1 rounded-full bg-bg/60 px-3 py-1.5 font-mono text-[11px] text-ink outline-none placeholder:text-faint/60"
+                placeholder={isCodex ? '如：迁移完所有调用点并通过测试' : '如：test/auth 全部通过且 lint 干净'}
+                value={goalDraft}
+                onChange={(e) => onGoalDraftChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && goalDraft.trim()) {
+                    onSendGoal(goalDraft.trim())
+                    onCloseGoal()
+                  }
+                }}
+              />
+              <button
+                className="shrink-0 rounded-full bg-ink px-3 py-1.5 font-mono text-[11px] text-bg disabled:opacity-40"
+                disabled={!goalDraft.trim()}
+                onClick={() => {
+                  if (!goalDraft.trim()) return
+                  onSendGoal(goalDraft.trim())
+                  onCloseGoal()
+                }}
+              >
+                设定
+              </button>
+              {goal && (
+                <button
+                  className="shrink-0 rounded-full px-3 py-1.5 font-mono text-[11px] text-accent hover:bg-accent/10"
+                  onClick={() => {
+                    onSendGoal()
+                    onCloseGoal()
+                  }}
+                >
+                  清除
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 接力链导航条：仅在当前会话参与血缘时出现 */}
+      {lineage && (
+        <div className="flex items-center gap-1.5 overflow-x-auto px-3 py-1.5 font-mono text-[10px]">
+          <span className="shrink-0 text-faint">⇄ 接力链:</span>
+          {lineage.records
+            .map((r) => {
+              const fromKey = r.fromResolvedKey ?? r.fromKey
+              const toKey = r.toResolvedKey ?? r.toKey
+              const node = (k: string, backend: 'claude' | 'codex') => {
+                const info = lineage.nodes[k]
+                const current = k === session.key
+                return (
+                  <button
+                    key={k}
+                    disabled={!info}
+                    onClick={() => info && onNavigate?.(info)}
+                    className={`flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 ${
+                      current
+                        ? 'bg-surface2 text-ink'
+                        : 'text-faint hover:text-muted'
+                    }`}
+                    title={k}
+                  >
+                    {backend === 'codex' ? <CodexMark size={10} /> : <ClaudeMark className="h-2.5 w-2.5" />}
+                    {new Date(r.at).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })}
+                  </button>
+                )
+              }
+              return (
+                <span key={r.id} className="flex shrink-0 items-center gap-1.5">
+                  {node(fromKey, r.fromBackend)}
+                  <span className="text-faint/60">→</span>
+                  {node(toKey, r.toBackend)}
+                </span>
+              )
+            })}
+        </div>
+      )}
+
+      {/* 后台任务 Chips 已并入右侧「后台任务」面板（运行中卡片上有停止按钮） */}
+
+      {children}
+    </div>
+  )
+}

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,0 +1,418 @@
+// 输入区：悬浮磨砂圆角块（斜杠命令面板 / 发送方式切换 / 图片预览 / textarea /
+// 模型胶囊 ×2 / 上下文环 / 添加图片 / 发送·中断按钮）。
+// F2 从 pages/Chat.tsx 切出——斜杠面板全套状态（slashIdx/滚动跟随/键盘导航）、
+// 输入框自适应高度、图片挑选均随 JSX 下沉为组件内部实现；codex 模型目录的派生
+//（codexCfg/codexModelId/codexEffortLevels/codexModeOf）也一并内聚进来。
+
+import { useEffect, useRef, useState } from 'react'
+import type { CodexModelInfo, ServerConfigInfo, TierModelName } from '../lib/api'
+import { COMMAND_DESC, filterSlashHints, mergeSlashCommands, type SlashEntry } from '../lib/slashCommands'
+import type { SessionState } from '../lib/ws'
+import { ContextRing } from './ContextRing'
+import { StatusPill } from './StatusPill'
+
+/** claude 权限模式名 → codex 预设档位（显示用） */
+function codexModeOf(m?: string): string {
+  switch (m) {
+    case 'bypassPermissions':
+      return 'fullAccess'
+    case 'acceptEdits':
+    case 'auto':
+      return 'workspaceAuto'
+    case 'plan':
+      return 'readOnly'
+    case 'readOnly':
+    case 'workspace':
+    case 'workspaceAuto':
+    case 'fullAccess':
+      return m
+    default:
+      return 'workspace'
+  }
+}
+
+export interface PendingImage {
+  name: string
+  mediaType: string
+  dataBase64: string
+}
+
+/** 预览 src：dataURL 与传输用 base64 本是一份数据，渲染时派生 */
+export function imgPreviewSrc(img: { mediaType: string; dataBase64: string }): string {
+  return `data:${img.mediaType};base64,${img.dataBase64}`
+}
+
+export function Composer(props: {
+  input: string
+  onInputChange: (v: string) => void
+  busy: boolean
+  connected: boolean
+  sendMode: 'steer' | 'queue'
+  onSendModeChange: (m: 'steer' | 'queue') => void
+  isCodex: boolean
+  pendingImages: PendingImage[]
+  onPendingImagesChange: React.Dispatch<React.SetStateAction<PendingImage[]>>
+  onSend: () => void
+  onInterrupt: () => void
+  atBottom: boolean
+  onScrollToBottom: () => void
+  /** 斜杠命令清单来源：status 的 slashCommands 优先，init 消息的命令名兜底 */
+  slashCommands?: SessionState['slashCommands']
+  initSlashCommands?: string[]
+  // --- claude StatusPill ---
+  cfg?: ServerConfigInfo
+  claudeModel?: string
+  permMode?: string
+  effort?: string
+  modelNames: Record<string, TierModelName> | null
+  onPanelOpen: () => void
+  onSetClaudeModel: (m: string) => void
+  onSetMode: (m: string) => void
+  onSetEffort: (e: string) => void
+  // --- codex StatusPill ---
+  codexModels?: CodexModelInfo[]
+  stateModel?: string
+  statePermissionMode?: string
+  stateEffort?: string
+  onSetCodexModel: (m: string) => void
+  // --- ContextRing ---
+  context?: SessionState['context']
+  usage?: SessionState['usage']
+  onOpenFullDetail?: () => void
+}) {
+  const {
+    input,
+    onInputChange,
+    busy,
+    connected,
+    sendMode,
+    onSendModeChange,
+    isCodex,
+    pendingImages,
+    onPendingImagesChange,
+    onSend,
+    onInterrupt,
+    atBottom,
+    onScrollToBottom,
+    slashCommands,
+    initSlashCommands,
+    cfg,
+    claudeModel,
+    permMode,
+    effort,
+    modelNames,
+    onPanelOpen,
+    onSetClaudeModel,
+    onSetMode,
+    onSetEffort,
+    codexModels,
+    stateModel,
+    statePermissionMode,
+    stateEffort,
+    onSetCodexModel,
+    context,
+    usage,
+    onOpenFullDetail,
+  } = props
+
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // 优先 initialize 握手返回的命令（含描述），其次 init 消息的命令名，最后空清单（合并层用自有命令兜底）
+  const cliEntries: SlashEntry[] = slashCommands?.length
+    ? slashCommands.map((c) => ({ name: c.name, desc: c.description }))
+    : (initSlashCommands ?? []).map((n) => ({ name: n, desc: COMMAND_DESC[n] }))
+  // anyplane 自有命令置顶（中文描述优先于 CLI 同名命令），其后是 CLI 报告的完整清单
+  const allEntries = mergeSlashCommands(cliEntries)
+  const slashHints = filterSlashHints(input, allEntries)
+  // 键盘导航：↑↓ 移动，Tab/Enter 采纳，Esc 关闭（索引随清单变化钳位）
+  const [slashIdx, setSlashIdx] = useState(0)
+  const slashActive = slashHints.length > 0 ? Math.min(slashIdx, slashHints.length - 1) : 0
+  /** 面板滚动容器：键盘导航时保证高亮行在视口内 */
+  const slashScrollRef = useRef<HTMLDivElement>(null)
+
+  // 高亮行跟随滚动：只滚面板容器（getBoundingClientRect 相对数学），不动页面滚动条
+  useEffect(() => {
+    const c = slashScrollRef.current
+    if (!c || slashHints.length === 0) return
+    const row = c.querySelectorAll('button')[slashActive]
+    if (!row) return
+    const cRect = c.getBoundingClientRect()
+    const rRect = row.getBoundingClientRect()
+    if (rRect.top < cRect.top) c.scrollTop -= cRect.top - rRect.top
+    else if (rRect.bottom > cRect.bottom) c.scrollTop += rRect.bottom - cRect.bottom
+  }, [slashActive, slashHints.length])
+
+  // 输入框自适应高度：随内容增长，超过 200px 后不再扩大、内部滚动。
+  // 注意 border-box：style.height 包含边框，需补回上下边框宽，否则单行时内容被裁出滚动条
+  useEffect(() => {
+    const el = inputRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    const h = el.scrollHeight + (el.offsetHeight - el.clientHeight)
+    el.style.height = `${Math.min(h, 200)}px`
+    el.style.overflowY = h > 200 ? 'auto' : 'hidden'
+  }, [input])
+
+  const pickImages = (files: FileList | null) => {
+    if (!files) return
+    for (const f of Array.from(files)) {
+      if (!f.type.startsWith('image/')) continue
+      const reader = new FileReader()
+      reader.onload = () => {
+        const url = String(reader.result ?? '')
+        const comma = url.indexOf(',')
+        if (comma < 0) return
+        onPendingImagesChange((prev) => [
+          ...prev,
+          { name: f.name, mediaType: f.type, dataBase64: url.slice(comma + 1) },
+        ])
+      }
+      reader.readAsDataURL(f)
+    }
+  }
+
+  // codex 模型目录派生（model/list）：模型/effort 档位/默认值
+  const codexDefaultModel = codexModels?.find((m) => m.isDefault) ?? codexModels?.[0]
+  const codexModelId = stateModel ?? codexDefaultModel?.id
+  const codexCurrentModel = codexModels?.find((m) => m.id === codexModelId) ?? codexDefaultModel
+  const codexEffortLevels: readonly string[] = codexCurrentModel?.efforts.map((e) => e.value) ?? ['low', 'high', 'max']
+  const codexCfg: ServerConfigInfo = {
+    permissionPolicy: 'ask',
+    permissionModes: ['readOnly', 'workspace', 'workspaceAuto', 'fullAccess'],
+    effortLevels: [...codexEffortLevels],
+    models: (codexModels ?? []).map((m) => m.id),
+  }
+
+  return (
+    <div className="absolute inset-x-0 bottom-0 z-30 px-3 pb-3 pt-2">
+      <div className="mx-auto max-w-3xl">
+        {slashHints.length > 0 && (
+          <div className="mb-2 rounded-[14px] bg-surface2/85 p-1 shadow-[0_16px_40px_-12px_rgba(0,0,0,0.5)] backdrop-blur-xl">
+            {/* 完整清单可滚动（CLI initialize 握手报告多少就列多少），自有命令置顶；键盘导航时高亮行跟随滚动 */}
+            <div ref={slashScrollRef} className="max-h-60 overflow-y-auto">
+              {slashHints.map((c, i) => (
+                <button
+                  key={c.name}
+                  className={`flex w-full items-center gap-2 rounded-[10px] px-2.5 py-1.5 text-left ${
+                    i === slashActive ? 'bg-surface' : 'hover:bg-surface'
+                  }`}
+                  onMouseEnter={() => setSlashIdx(i)}
+                  onClick={() => {
+                    onInputChange(`/${c.name} `)
+                    setSlashIdx(0)
+                    inputRef.current?.focus()
+                  }}
+                >
+                  <span className="font-mono text-[12px] text-ink">/{c.name}</span>
+                  {c.desc && <span className="truncate text-xs text-faint">{c.desc}</span>}
+                </button>
+              ))}
+            </div>
+            <div className="px-2.5 py-1 font-mono text-[9px] tracking-wide text-faint">
+              {slashHints.length} 个命令 · ↑↓ 移动 · Tab 补全
+              {input.trim() === '/' && ' · 继续输入可过滤'}
+            </div>
+          </div>
+        )}
+        <div className="relative">
+          {/* ↓ 与输入块同列、贴在正上方；不放进磨砂块内，否则 backdrop 只能糊到父级内部 */}
+          {!atBottom && (
+            <button
+              className="absolute bottom-full right-0 z-40 mb-2 grid h-9 w-9 place-items-center rounded-full bg-surface2/85 text-ink shadow-lg backdrop-blur-xl hover:bg-surface2"
+              onClick={onScrollToBottom}
+              title="回到底部"
+              aria-label="回到底部"
+            >
+              ↓
+            </button>
+          )}
+          <div className="rounded-[14px] bg-surface2/80 px-3 pb-2 pt-2.5 shadow-[0_16px_40px_-12px_rgba(0,0,0,0.5)] backdrop-blur-xl">
+          {/* busy 时发送方式：插队（steer，下一边界被模型看到）/ 排队（queue，当前轮结束后） */}
+          {busy && (
+            <div className="mb-1.5 flex items-center gap-1.5 font-mono text-[10px]">
+              <span className="text-faint">工作中，发送：</span>
+              {(['steer', 'queue'] as const).map((m) => (
+                <button
+                  key={m}
+                  className={`rounded-full px-2.5 py-0.5 ${
+                    sendMode === m ? 'bg-surface text-ink' : 'text-faint hover:text-muted'
+                  }`}
+                  onClick={() => onSendModeChange(m)}
+                >
+                  {m === 'steer' ? '插队' : '排队'}
+                </button>
+              ))}
+              <span className="text-faint/70">
+                {sendMode === 'steer'
+                  ? isCodex
+                    ? '追加进当前轮'
+                    : '打断当前并立即处理'
+                  : '当前轮结束后自动开始'}
+              </span>
+            </div>
+          )}
+          {/* 待发送图片预览 */}
+          {pendingImages.length > 0 && (
+            <div className="mb-2 flex flex-wrap gap-2">
+              {pendingImages.map((img, i) => (
+                <span key={i} className="relative">
+                  <img src={imgPreviewSrc(img)} alt={img.name} className="h-14 w-14 rounded-[10px] object-cover" />
+                  <button
+                    className="absolute -right-1.5 -top-1.5 grid h-4 w-4 place-items-center rounded-full bg-accent text-[9px] leading-none text-white"
+                    onClick={() => onPendingImagesChange((prev) => prev.filter((_, j) => j !== i))}
+                  >
+                    ✕
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            multiple
+            className="hidden"
+            onChange={(e) => {
+              pickImages(e.target.files)
+              e.target.value = ''
+            }}
+          />
+          <textarea
+            ref={inputRef}
+            className="max-h-[200px] min-h-[1.5rem] w-full resize-none overflow-hidden bg-transparent px-1 text-[15px] leading-snug text-ink outline-none placeholder:text-faint"
+            rows={1}
+            placeholder={busy ? '工作中…' : 'ᕕ( ◠ڼ◠ )ᕗ'}
+            value={input}
+            onChange={(e) => {
+              onInputChange(e.target.value)
+              setSlashIdx(0)
+            }}
+            onKeyDown={(e) => {
+              // 斜杠命令面板打开时的键盘导航
+              if (slashHints.length > 0) {
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault()
+                  setSlashIdx((i) => Math.min(i + 1, slashHints.length - 1))
+                  return
+                }
+                if (e.key === 'ArrowUp') {
+                  e.preventDefault()
+                  setSlashIdx((i) => Math.max(i - 1, 0))
+                  return
+                }
+                if (e.key === 'Tab') {
+                  e.preventDefault()
+                  onInputChange(`/${slashHints[slashActive].name} `)
+                  setSlashIdx(0)
+                  return
+                }
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  onInputChange('')
+                  setSlashIdx(0)
+                  return
+                }
+              }
+              if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+                e.preventDefault()
+                // 输入还是高亮命令的真前缀时先补全不发送；完整命令名（如 /compact）才直接发送
+                const trimmed = input.trim()
+                const active = slashHints[slashActive]
+                if (slashHints.length > 0 && active && `/${active.name}` !== trimmed) {
+                  onInputChange(`/${active.name} `)
+                  setSlashIdx(0)
+                  return
+                }
+                onSend()
+              }
+            }}
+          />
+          <div className="mt-1 flex min-w-0 items-center gap-1.5">
+            <div className="min-w-0 flex-1">
+            {cfg && !isCodex && (
+              <StatusPill
+                cfg={cfg}
+                model={claudeModel}
+                permissionMode={permMode}
+                effort={effort}
+                modelNames={modelNames}
+                onPanelOpen={onPanelOpen}
+                onSetModel={onSetClaudeModel}
+                onSetMode={onSetMode}
+                onSetEffort={onSetEffort}
+              />
+            )}
+            {isCodex && codexModels && codexModels.length > 0 && (
+              <StatusPill
+                cfg={codexCfg}
+                model={codexModelId}
+                permissionMode={codexModeOf(permMode ?? statePermissionMode)}
+                effort={effort ?? stateEffort ?? codexCurrentModel?.defaultEffort}
+                effortLevels={codexEffortLevels}
+                onSetModel={onSetCodexModel}
+                onSetMode={onSetMode}
+                onSetEffort={onSetEffort}
+              />
+            )}
+            </div>
+            {/* 上下文窗口占用环：首个 API 应答/首个 turn 前（state.context 缺省）不渲染 */}
+            <ContextRing
+              backend={isCodex ? 'codex' : 'claude'}
+              context={context}
+              usage={usage}
+              modelLabel={
+                isCodex
+                  ? (codexCurrentModel?.label ?? codexModelId)
+                  : (modelNames?.[claudeModel ?? '']?.name ?? claudeModel)
+              }
+              onOpenFullDetail={onOpenFullDetail}
+            />
+            <button
+              type="button"
+              className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-muted transition-colors hover:bg-surface hover:text-ink"
+              title="添加图片（jpg/png/gif/webp，≤5MB）"
+              aria-label="添加图片"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden="true">
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <circle cx="8.5" cy="8.5" r="1.5" />
+                <path d="m21 15-5-5L5 21" />
+              </svg>
+            </button>
+            {busy ? (
+              <button
+                type="button"
+                className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-accent text-white transition-opacity hover:opacity-85"
+                onClick={onInterrupt}
+                title="中断当前回合"
+                aria-label="中断当前回合"
+              >
+                <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4" aria-hidden="true">
+                  <rect x="5" y="5" width="14" height="14" rx="3" />
+                </svg>
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-ink text-bg transition-opacity hover:opacity-85 disabled:pointer-events-none disabled:opacity-25"
+                disabled={(!input.trim() && pendingImages.length === 0) || !connected}
+                onClick={onSend}
+                title="发送"
+                aria-label="发送"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden="true">
+                  <path d="M12 19V5" />
+                  <path d="m5 12 7-7 7 7" />
+                </svg>
+              </button>
+            )}
+          </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/DetailDrawer.tsx
+++ b/web/src/components/DetailDrawer.tsx
@@ -1,0 +1,211 @@
+// 会话详情抽屉：tab 头（context 用量 / MCP 状态 / 设置）+ 结构化面板 + 原始 JSON 兜底。
+// F2 从 pages/Chat.tsx 逐字切出——纯展示组件；查询由 onRunQuery 回调发回组合层
+//（query_result 应答在 Chat 的 WS 分发里落到 detailContent/mcpServers/contextData/settingsData）。
+
+import type { TierModelName } from '../lib/api'
+import { fmtTokens } from '../lib/blocks'
+
+/** claude mcp_status 应答里的单个服务器（buildMcpServerStatuses 形状） */
+export interface McpServerInfo {
+  name: string
+  /** connected / failed / disabled / pending / needs-auth 等（CLI 的 connection.type 直出） */
+  status: string
+  error?: string
+  config?: { type?: string; command?: string; args?: string[]; url?: string }
+  scope?: string
+  tools?: { name: string }[]
+}
+
+/** claude get_context_usage 应答的取用子集（analyzeContext 的 ContextData 里我们渲染的部分） */
+export interface ContextDataLite {
+  categories: { name: string; tokens: number; isDeferred?: boolean }[]
+  totalTokens: number
+  maxTokens: number
+  percentage: number
+  model?: string
+}
+
+/** claude get_settings 应答的取用子集（settings 全量不枚举——applied + sources 概览 + 原始 JSON 折叠） */
+export interface SettingsDataLite {
+  applied?: { model?: string; effort?: string | null }
+  sources?: { source: string; settings: Record<string, unknown> }[]
+}
+
+export function DetailDrawer(props: {
+  detailTitle: string
+  detailContent: string
+  isCodex: boolean
+  mcpServers: McpServerInfo[] | null
+  mcpBusy: string | null
+  onMcpAction: (serverName: string, action: 'mcp_reconnect' | 'mcp_toggle', enabled?: boolean) => void
+  contextData: ContextDataLite | null
+  settingsData: SettingsDataLite | null
+  modelNames: Record<string, TierModelName> | null
+  onRunQuery: (query: string, title: string) => void
+  onClose: () => void
+}) {
+  const {
+    detailTitle,
+    detailContent,
+    isCodex,
+    mcpServers,
+    mcpBusy,
+    onMcpAction,
+    contextData,
+    settingsData,
+    modelNames,
+    onRunQuery,
+    onClose,
+  } = props
+  return (
+    <div className="px-3 py-2">
+      <div className="mb-1.5 flex items-center gap-2 font-mono text-[11px]">
+        <span className="text-muted">{detailTitle}</span>
+        {/* codex 只有 mcp_status 有对应物（mcpServerStatus/list）；context/设置是 claude 控制请求 */}
+        {(isCodex ? (['mcp_status'] as const) : (['get_context_usage', 'mcp_status', 'get_settings'] as const)).map((q) => (
+          <button
+            key={q}
+            className="rounded-full bg-surface px-2.5 py-1 text-[10px] text-faint hover:text-ink"
+            onClick={() =>
+              onRunQuery(q, q === 'get_context_usage' ? 'context 用量' : q === 'mcp_status' ? 'MCP 状态' : '设置')
+            }
+          >
+            {q === 'get_context_usage' ? 'context' : q === 'mcp_status' ? 'MCP' : '设置'}
+          </button>
+        ))}
+        <button className="ml-auto text-faint hover:text-muted" onClick={onClose}>
+          ✕
+        </button>
+      </div>
+      {detailTitle === 'MCP 状态' && !isCodex && mcpServers ? (
+        /* claude MCP 管理面板：状态 + 重连/启停（toggle 持久化到 settings，与 TUI 同语义） */
+        <div className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5">
+          {mcpServers.length === 0 && (
+            <div className="py-1 font-mono text-[10px] text-faint">无 MCP 服务器（在 claude 配置里添加后出现）</div>
+          )}
+          {mcpServers.map((srv) => {
+            const meta =
+              srv.status === 'connected'
+                ? { dot: 'bg-ok', label: '已连接' }
+                : srv.status === 'failed'
+                  ? { dot: 'bg-danger', label: '失败' }
+                  : srv.status === 'disabled'
+                    ? { dot: 'bg-faint', label: '已禁用' }
+                    : { dot: 'bg-wait', label: srv.status }
+            const configLine = srv.config?.url
+              ? srv.config.url
+              : srv.config?.command
+                ? `${srv.config.command} ${(srv.config.args ?? []).join(' ')}`.trim()
+                : (srv.config?.type ?? '')
+            const reconnecting = mcpBusy === `${srv.name}:mcp_reconnect`
+            const toggling = mcpBusy === `${srv.name}:mcp_toggle`
+            return (
+              <div key={srv.name} className="flex items-center gap-2 py-1">
+                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${meta.dot}`} />
+                <div className="min-w-0 flex-1">
+                  <div className="font-mono text-[11px] text-ink">
+                    {srv.name}
+                    <span className="text-faint">
+                      {' '}
+                      {meta.label}
+                      {srv.status === 'connected' && srv.tools ? ` · ${srv.tools.length} 工具` : ''}
+                      {srv.scope ? ` · ${srv.scope}` : ''}
+                    </span>
+                  </div>
+                  {configLine && <div className="truncate font-mono text-[10px] text-faint">{configLine}</div>}
+                  {srv.error && <div className="truncate font-mono text-[10px] text-danger">{srv.error}</div>}
+                </div>
+                <button
+                  className="shrink-0 rounded-full bg-surface2 px-2.5 py-1 font-mono text-[10px] text-faint hover:text-ink disabled:opacity-40"
+                  disabled={!!mcpBusy || srv.status === 'disabled'}
+                  title="重新连接（mcp_reconnect）"
+                  onClick={() => onMcpAction(srv.name, 'mcp_reconnect')}
+                >
+                  {reconnecting ? '…' : '重连'}
+                </button>
+                <button
+                  className="shrink-0 rounded-full bg-surface2 px-2.5 py-1 font-mono text-[10px] text-faint hover:text-ink disabled:opacity-40"
+                  disabled={!!mcpBusy}
+                  title={srv.status === 'disabled' ? '启用并连接（写入 settings）' : '禁用并断开（写入 settings）'}
+                  onClick={() => onMcpAction(srv.name, 'mcp_toggle', srv.status === 'disabled')}
+                >
+                  {toggling ? '…' : srv.status === 'disabled' ? '启用' : '禁用'}
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      ) : detailTitle === 'context 用量' && !isCodex && contextData ? (
+        /* claude context 结构化：总量条 + 分类占比（deferred 类别淡显） */
+        <div className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5">
+          <div className="mb-1.5 flex items-baseline justify-between font-mono text-[11px] text-ink">
+            <span>
+              {fmtTokens(contextData.totalTokens)} / {fmtTokens(contextData.maxTokens)} tok ·{' '}
+              {contextData.percentage.toFixed(1)}%
+            </span>
+            {contextData.model && (
+              <span className="text-[10px] text-faint">
+                {modelNames?.[contextData.model]?.name ?? contextData.model}
+              </span>
+            )}
+          </div>
+          <div className="mb-2 h-1 overflow-hidden rounded-full bg-surface2">
+            <div
+              className="h-full bg-ink/60"
+              style={{ width: `${Math.min(100, contextData.percentage)}%` }}
+            />
+          </div>
+          {contextData.categories.map((c) => (
+            <div key={c.name} className={`flex items-center gap-2 py-0.5 ${c.isDeferred ? 'opacity-50' : ''}`}>
+              <span className="w-28 shrink-0 truncate font-mono text-[10px] text-muted" title={c.name}>
+                {c.name}
+              </span>
+              <div className="h-1 flex-1 overflow-hidden rounded-full bg-surface2">
+                <div
+                  className={`h-full ${c.isDeferred ? 'bg-faint' : 'bg-muted'}`}
+                  style={{
+                    width: `${Math.min(100, (c.tokens / Math.max(1, contextData.maxTokens)) * 100)}%`,
+                  }}
+                />
+              </div>
+              <span className="w-12 shrink-0 text-right font-mono text-[10px] text-faint">
+                {fmtTokens(c.tokens)}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : detailTitle === '设置' && !isCodex && settingsData ? (
+        /* claude 设置轻结构：生效值 + 来源概览；全量设置不枚举，原始 JSON 折叠兜底 */
+        <div className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5">
+          {settingsData.applied && (
+            <div className="mb-1.5 font-mono text-[11px] text-ink">
+              当前生效：
+              <span className="text-muted">
+                {modelNames?.[settingsData.applied.model ?? '']?.name ?? settingsData.applied.model ?? 'default'}
+              </span>
+              <span className="text-faint"> · effort {settingsData.applied.effort ?? '默认'}</span>
+            </div>
+          )}
+          {(settingsData.sources ?? []).map((s) => (
+            <div key={s.source} className="flex items-center gap-2 py-0.5 font-mono text-[10px]">
+              <span className="text-muted">{s.source}</span>
+              <span className="text-faint">{Object.keys(s.settings ?? {}).length} 项</span>
+            </div>
+          ))}
+          <details className="mt-1.5">
+            <summary className="cursor-pointer font-mono text-[10px] text-faint hover:text-muted">
+              原始 JSON
+            </summary>
+            <pre className="mt-1 max-h-40 overflow-auto rounded-[10px] bg-bg/60 p-2 font-mono text-[10px] whitespace-pre-wrap text-muted">
+              {detailContent}
+            </pre>
+          </details>
+        </div>
+      ) : (
+        <pre className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5 font-mono text-[10px] whitespace-pre-wrap text-muted">
+          {detailContent}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/web/src/hooks/useSessionSocket.ts
+++ b/web/src/hooks/useSessionSocket.ts
@@ -91,16 +91,10 @@ export function useSessionSocket(opts: {
             break
           case 'approval_auto': {
             // 规则引擎自动裁决的审计留痕：不进审批队列，只落一条系统卡。
-            // 摘要字段提取与服务端 summarizeInput 同口径（command / file_path / url）。
-            const inp = ev.input as Record<string, unknown> | undefined
-            const detail =
-              (typeof inp?.command === 'string' && inp.command) ||
-              (typeof inp?.file_path === 'string' && inp.file_path) ||
-              (typeof inp?.grantRoot === 'string' && inp.grantRoot) ||
-              (typeof inp?.url === 'string' && inp.url) ||
-              ''
+            // 摘要直接用服务端下发的 detail（summarizeInput 唯一口径，前端不另起一套）。
+            const detail = typeof ev.detail === 'string' ? ev.detail : ''
             ingestApi.pushSystem(
-              `规则自动${ev.action === 'allow' ? '放行' : '拒绝'}：${ev.toolName}${detail ? ` ${detail.slice(0, 120)}` : ''}（${ev.rule}）`,
+              `规则自动${ev.action === 'allow' ? '放行' : '拒绝'}：${ev.toolName}${detail ? ` ${detail}` : ''}（${ev.rule}）`,
             )
             break
           }

--- a/web/src/hooks/useSessionSocket.ts
+++ b/web/src/hooks/useSessionSocket.ts
@@ -1,0 +1,347 @@
+// 会话 WS 连接 hook：SessionSocket 生命周期 + ServerEvent 全量分发。
+// F5 从 pages/Chat.tsx 切出。
+// 转发纪律（与现状逐字同构）：effect deps 仅 [session.key]——事件处理器在渲染外触发，
+// 一律走 ingestApi/taskApi 的 ref 出口与稳定 setState；props 回调（onNavigate 等）
+// 会话内语义不变，捕获首渲染值即现状语义。
+// 详情抽屉域（query_result 的 MCP/context/设置结构化分发）留组合层，经 onQueryResult 回调；
+// fetchConfig 与 socket 生命周期无关，同在组合层独立 effect（原 effect 内同步先后执行，
+// 拆开后同 commit 按声明序执行，行为等价）。
+
+import { useEffect, useState } from 'react'
+import { fetchHistory, makeSessionInfo, type HistoryResponse, type SessionInfo } from '../lib/api'
+import { nextId, type Block } from '../lib/blocks'
+import { appendHistoryMsg, flushStrayResults, type IngestState } from '../lib/ingest'
+import { SessionSocket, type ServerEvent, type SessionState } from '../lib/ws'
+import type { TaskBucketsApi } from './useTaskBuckets'
+import type { TranscriptIngestApi } from './useTranscriptIngest'
+
+export interface Approval {
+  requestId: string
+  toolName: string
+  input: unknown
+}
+
+export type QueryResultEvent = Extract<ServerEvent, { kind: 'query_result' }>
+
+export function useSessionSocket(opts: {
+  session: SessionInfo
+  sockRef: React.RefObject<SessionSocket | undefined>
+  ingestApi: TranscriptIngestApi
+  taskApi: TaskBucketsApi
+  loadSessionHistory: () => Promise<HistoryResponse>
+  onNavigate?: (s: SessionInfo) => void
+  /** codex 分叉完成时收起回滚面板 */
+  onCloseRewind: () => void
+  /** query_result 详情域分发（MCP 动作应答辨认 + 结构化面板），实现在组合层 */
+  onQueryResult: (ev: QueryResultEvent) => void
+}): {
+  state: SessionState
+  connected: boolean
+  approvals: Approval[]
+  setApprovals: React.Dispatch<React.SetStateAction<Approval[]>>
+} {
+  const { session, sockRef, ingestApi, taskApi, loadSessionHistory, onNavigate, onCloseRewind, onQueryResult } = opts
+  const [state, setState] = useState<SessionState>({ spawned: false, busy: false })
+  const [connected, setConnected] = useState(false)
+  const [approvals, setApprovals] = useState<Approval[]>([])
+
+  // ---------- WS 连接 ----------
+  useEffect(() => {
+    const sock = new SessionSocket(
+      session.key,
+      (ev: ServerEvent) => {
+        switch (ev.kind) {
+          case 'status':
+            setState(ev.state)
+            if (typeof ev.state.model === 'string') {
+              ingestApi.setInitInfo((prev) => ({ ...prev, model: ev.state.model }))
+            }
+            if (typeof ev.state.permissionMode === 'string') ingestApi.setPermMode(ev.state.permissionMode)
+            if (typeof ev.state.effort === 'string') ingestApi.setEffort(ev.state.effort)
+            // 服务端权威运行任务表水合任务桶（中途接入补建 / 断线丢通知判死）
+            taskApi.hydrateTasks(ev.state)
+            // 进程已退出时固化/清理未完成的流式草稿，避免半截内容悬挂
+            if (ev.state.exited) {
+              ingestApi.commitDraft()
+              ingestApi.setPhase(undefined)
+            } else if (ev.state.sessionState === 'idle' && !ev.state.busy && !ev.state.waiting && ingestApi.draftRef.current) {
+              // 自愈：权威 idle 到达时清掉陈旧流式草稿。服务端重启/断线期间 turn 终结时
+              // 客户端拿不到终结事件，"生成中"会永远挂着（实测：watch 重载后复现）。
+              // 等审批（waiting/requires_action）期间草稿是合法的，不在此清理。
+              ingestApi.setDraftBoth(null)
+              ingestApi.setPhase(undefined)
+              // turn 已终结：此刻仍未配对的 tool_result 不会再等到它的调用了，
+              // 浮现为孤立提示而非静默丢弃（旧实现直接 clear，用户零反馈）
+              ingestApi.setMsgs((prev) => {
+                const st: IngestState = { msgs: prev, toolIdx: ingestApi.toolPosRef.current, pending: ingestApi.pendingResultsRef.current }
+                flushStrayResults(st)
+                return st.msgs
+              })
+            }
+            break
+          case 'approval_request':
+            setApprovals((prev) =>
+              prev.some((a) => a.requestId === ev.requestId)
+                ? prev
+                : [...prev, { requestId: ev.requestId, toolName: ev.toolName, input: ev.input }],
+            )
+            break
+          case 'approval_resolved':
+            setApprovals((prev) => prev.filter((a) => a.requestId !== ev.requestId))
+            break
+          case 'approval_auto': {
+            // 规则引擎自动裁决的审计留痕：不进审批队列，只落一条系统卡。
+            // 摘要字段提取与服务端 summarizeInput 同口径（command / file_path / url）。
+            const inp = ev.input as Record<string, unknown> | undefined
+            const detail =
+              (typeof inp?.command === 'string' && inp.command) ||
+              (typeof inp?.file_path === 'string' && inp.file_path) ||
+              (typeof inp?.grantRoot === 'string' && inp.grantRoot) ||
+              (typeof inp?.url === 'string' && inp.url) ||
+              ''
+            ingestApi.pushSystem(
+              `规则自动${ev.action === 'allow' ? '放行' : '拒绝'}：${ev.toolName}${detail ? ` ${detail.slice(0, 120)}` : ''}（${ev.rule}）`,
+            )
+            break
+          }
+          case 'error':
+            ingestApi.pushSystem(`⚠ ${ev.message}`, 'error')
+            break
+          case 'btw_pending':
+            // 创建侧问卡片（发送方与其他客户端都以此为准）
+            if (!ingestApi.messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
+              ingestApi.pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: true, blocks: [] })
+            }
+            break
+          case 'btw_delta': {
+            const target = ingestApi.messagesRef.current.find((m) => m.btw === ev.question && m.btwPending)
+            if (!target) break
+            ingestApi.setMsgs((prev) =>
+              prev.map((m) => {
+                if (m.id !== target.id) return m
+                const blocks = [...m.blocks]
+                const kind = ev.thinking ? 'thinking' : 'text'
+                const i = blocks.findIndex((b) => b.kind === kind)
+                if (i >= 0) {
+                  const b = blocks[i]
+                  if (b.kind === 'text' || b.kind === 'thinking') {
+                    blocks[i] = { ...b, text: b.text + ev.delta }
+                  }
+                } else {
+                  blocks.push({ kind, text: ev.delta })
+                }
+                // thinking 在 text 之前
+                blocks.sort((a, b) => (a.kind === 'thinking' ? -1 : 0) - (b.kind === 'thinking' ? -1 : 0))
+                return { ...m, blocks }
+              }),
+            )
+            break
+          }
+          case 'btw_result': {
+            // 找不到 pending 卡（如校验失败路径或漏收 btw_pending）时自行建卡落地结果——
+            // 配对不变量由数据保证，不依赖服务端的消息时序
+            if (!ingestApi.messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
+              const blocks: Block[] = ev.ok
+                ? ev.text.trim()
+                  ? [{ kind: 'text', text: ev.text }]
+                  : []
+                : [{ kind: 'text', text: `⚠ ${ev.text}` }]
+              ingestApi.pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: false, blocks })
+              break
+            }
+            ingestApi.setMsgs((prev) =>
+              prev.map((m) => {
+                if (m.btw !== ev.question || !m.btwPending) return m
+                if (ev.ok) {
+                  // 用完整结果替换正文（增量可能因快照归并而不全）
+                  const thinking = m.blocks.find((b) => b.kind === 'thinking')
+                  const blocks: Block[] = []
+                  if (thinking) blocks.push(thinking)
+                  if (ev.text.trim()) blocks.push({ kind: 'text', text: ev.text })
+                  return { ...m, blocks, btwPending: false }
+                }
+                return { ...m, blocks: [...m.blocks, { kind: 'text', text: `⚠ ${ev.text}` }], btwPending: false }
+              }),
+            )
+            break
+          }
+          case 'forked': {
+            if (ev.branchOf) {
+              // claude 懒分叉：b| key 导航，首条消息才真正 --fork-session；
+              // 历史视图直接读源会话 transcript（分支将原样继承它）
+              ingestApi.pushSystem(
+                `⎇ 已创建分支${ev.name ? `「${ev.name}」` : ''}：新会话携带当前全部历史，原会话保持不动`,
+              )
+              onNavigate?.(
+                makeSessionInfo({
+                  key: ev.targetKey,
+                  slug: session.slug,
+                  sessionId: ev.branchOf,
+                  cwd: session.cwd,
+                  backend: 'claude',
+                }),
+              )
+              break
+            }
+            // codex 分叉回滚完成：原线程不动，跳到携带截断历史的新线程
+            ingestApi.pushSystem('⎇ 已分叉：新会话携带所选消息之前的历史，原会话保持不动')
+            onCloseRewind()
+            onNavigate?.(
+              makeSessionInfo({
+                key: ev.targetKey,
+                slug: 'codex',
+                // codex 分叉路径服务端始终携带 targetSessionId（branchOf 不存在时）
+                sessionId: ev.targetSessionId ?? '',
+                cwd: session.cwd,
+                backend: 'codex',
+                managed: { spawned: true, busy: false, clients: 0 },
+              }),
+            )
+            break
+          }
+          case 'handoff_pending':
+            ingestApi.pushSystem(`⇄ 源会话正在生成交接简报（→ ${ev.toBackend === 'codex' ? 'Codex' : 'Claude'}）…`)
+            break
+          case 'handoff_brief':
+            break // 简报在 handoff_done 时一并展示
+          case 'handoff_done': {
+            ingestApi.pushMsg({
+              id: nextId(),
+              role: 'system',
+              systemKind: 'info',
+              blocks: [{ kind: 'text', text: `⇄ 接力简报（已播种给 ${ev.toBackend === 'codex' ? 'Codex' : 'Claude'} 新会话）：\n\n${ev.brief}` }],
+            })
+            onNavigate?.(
+              makeSessionInfo({
+                key: ev.targetKey,
+                slug: ev.toBackend === 'codex' ? 'codex' : session.slug,
+                // 目标已 spawn 时 targetKey 是 resolved key（s|/x|）：必须带真实 id，
+                // 否则 codex 侧 fetchCodexHistory('new') 必失败、历史视图永远空白
+                sessionId: ev.targetSessionId ?? 'new',
+                cwd: session.cwd,
+                backend: ev.toBackend,
+                status: 'busy',
+                managed: { spawned: true, busy: true, clients: 0 },
+              }),
+            )
+            break
+          }
+          case 'handoff_error':
+            ingestApi.pushSystem(`⚠ 接力失败: ${ev.message}`, 'error')
+            break
+          case 'query_result':
+            // 详情抽屉域（MCP 动作应答辨认 + 结构化面板分发）在组合层
+            onQueryResult(ev)
+            break
+          case 'rewound':
+            // 回滚会销毁并重生 CLI 进程（dispose 先摘 map 再 kill，onExit 不会触发），
+            // 进行中的流式草稿/待配对工具结果/相位指示全部失效，必须一并清理，
+            // 否则陈旧草稿会挂在回滚标签之下。
+            ingestApi.setDraftBoth(null)
+            ingestApi.pendingResultsRef.current.clear()
+            ingestApi.setPhase(undefined)
+            ingestApi.setMsgs((prev) => {
+              const idx = prev.findIndex((m) => m.id === ev.userMessageId)
+              const base = idx >= 0 ? prev.slice(0, idx + 1) : prev
+              const label = ev.scope === 'both' ? '↩ 对话和文件已回滚' : '↩ 对话已回滚'
+              return [...base, { id: nextId(), role: 'system', blocks: [{ kind: 'text', text: label }] }]
+            })
+            break
+          case 'cli':
+            if (ingestApi.gapReloadingRef.current) break
+            ingestApi.handleCli(ev.msg, ev.replay === true)
+            break
+          case 'tail': {
+            // 外部会话 transcript 追加：与历史共用同一套归并；uuid 去重兜底（重连续订可能重放）
+            const h = ev.msg
+            if (h.uuid && ingestApi.messagesRef.current.some((m) => m.id === h.uuid)) break
+            ingestApi.setMsgs((prev) => {
+              const st: IngestState = { msgs: prev, toolIdx: ingestApi.toolPosRef.current, pending: ingestApi.pendingResultsRef.current }
+              appendHistoryMsg(st, h)
+              // 不在此 flush：tail 是逐条到达，tool_use 可能在后续行；孤儿在权威 idle 时统一浮现
+              return st.msgs
+            })
+            // 尾到的主线 tool_result 给已存在桶补终态——外部会话（tailer 路径）没有
+            // task_notification，这是它唯一的终态信号；与历史回填同规则：终态挂 30s 驱逐
+            for (const blk of h.blocks) {
+              if (blk.kind !== 'tool_result' || !blk.id) continue
+              taskApi.settleBucketFromResult(blk.id, blk.text ?? '', blk.isError === true)
+            }
+            break
+          }
+          case 'moved': {
+            // /clear 对话重置：进程已换新 sessionId 续跑，Hub 重键完毕——跳到新会话页
+            //（旧 transcript 在磁盘原样保留，列表页可见）
+            const parts = ev.targetKey.split('|')
+            onNavigate?.(
+              makeSessionInfo({
+                key: ev.targetKey,
+                slug: parts[1] ?? session.slug,
+                sessionId: ev.targetSessionId ?? 'new',
+                cwd: session.cwd,
+                backend: 'claude',
+                managed: { spawned: true, busy: false, clients: 0 },
+              }),
+            )
+            break
+          }
+          case 'replay_gap': {
+            // 断线太久，服务端环形缓冲已挤掉起点：补发会留空洞，直接重载历史。
+            // transcript 是权威事实源，重载一定能补齐（代价只是一次 HTTP）。
+            // 必须与初次加载走同一 loader——Codex 没有 Claude transcript 路径。
+            // 先挡住 cli 再清草稿：环里残留的 stream/assistant 不能在重载完成前改抄本。
+            ingestApi.gapReloadingRef.current = true
+            ingestApi.setDraftBoth(null)
+            ingestApi.pendingResultsRef.current.clear()
+            ingestApi.setPhase(undefined)
+            const gapKey = session.key
+            loadSessionHistory()
+              .then((resp) => {
+                if (sockRef.current?.key !== gapKey) return // 异步返回时已切走
+                ingestApi.applyHistory(resp)
+                ingestApi.pushSystem('↻ 断线较久，已重新载入对话')
+              })
+              .catch(() => {
+                if (sockRef.current?.key !== gapKey) return
+                ingestApi.pushSystem('⚠ 重新载入对话失败，请手动刷新', 'error')
+              })
+              .finally(() => {
+                if (sockRef.current?.key === gapKey) ingestApi.gapReloadingRef.current = false
+              })
+            break
+          }
+          case 'tail_reset': {
+            // 外部会话截断了 transcript（rewind / clear）：重载历史并用新偏移重新订阅
+            ingestApi.setDraftBoth(null)
+            ingestApi.pendingResultsRef.current.clear()
+            const keyAtFetch = session.key
+            fetchHistory(session.slug, session.sessionId)
+              .then((resp) => {
+                // 异步返回时用户可能已切走：socket 已换成新会话的，弃掉过期结果
+                if (sockRef.current?.key !== keyAtFetch) return
+                ingestApi.applyHistory(resp)
+              })
+              .catch(() => {})
+            break
+          }
+        }
+      },
+      (open) => {
+        setConnected(open)
+        if (!open) return
+        // 重连必须 attach：Codex x| 靠它 resume；fromSeq 为 0 也要带上，
+        // 才能取回「一条可落盘 cli 都没收到就断线」期间的环。首连走下面的 attach。
+        if (sock.reconnecting) sock.send({ kind: 'attach', fromSeq: sock.replayFrom })
+        // 重连后服务端的 tailer 已随连接断开被回收，用已知的偏移重新订阅（重放部分由 uuid 去重）
+        if (ingestApi.historyOffsetRef.current != null) {
+          sock.send({ kind: 'tail_subscribe', from: ingestApi.historyOffsetRef.current })
+        }
+      },
+    )
+    sockRef.current = sock
+    sock.send({ kind: 'attach' })
+    return () => sock.close()
+  }, [session.key])
+
+  return { state, connected, approvals, setApprovals }
+}

--- a/web/src/hooks/useTaskBuckets.ts
+++ b/web/src/hooks/useTaskBuckets.ts
@@ -1,0 +1,292 @@
+// 后台任务桶 hook：与主线并行的 agent/task/shell 的建桶、归并、终态、TTL 驱逐。
+// F3 从 pages/Chat.tsx 切出。
+// 纪律：事件处理器在 React 渲染外触发（WS 回调），内部一律走 ref + setState + 会话内常量
+//（isCodex 由 session.key 派生，会话内不变），因此 api 对象无需稳定引用——
+// 过期闭包读到的仍是同一批 ref。重置（clear/resetFromHistory）由组合层在
+// session.key 变化 effect 与历史加载里显式调用（reset 先于建连的顺序纪律在 Chat）。
+
+import { useEffect, useRef, useState } from 'react'
+import { fetchCodexHistory, type HistoryMessage, type HistoryResponse } from '../lib/api'
+import type { ChatMsg } from '../lib/blocks'
+import { cliSidechainToHistory } from '../lib/chatText'
+import { appendHistoryMsg, type IngestState, type PendingResult, type ToolPos } from '../lib/ingest'
+import type { SessionState } from '../lib/ws'
+import type { TaskFeed } from '../components/TasksPanel'
+
+/** 后台任务桶：TaskFeed + 归并用的 tool 配对索引与去重集合（不发布给渲染） */
+interface TaskBucket extends TaskFeed {
+  toolIdx: Map<string, ToolPos>
+  /** 桶内乱序 tool_result 缓冲（与主线同规则，见 lib/ingest） */
+  pending: Map<string, PendingResult>
+  seen: Set<string>
+  /** codex 子线程转录已懒取过（防重取） */
+  transcriptFetched?: boolean
+}
+
+/**
+ * 终态卡片的展示宽限期：镜像官方协调器面板的 PANEL_GRACE_MS
+ *（claude-code src/utils/task/framework.ts:28）——完成后留 30s 供扫一眼报告，随后驱逐。
+ * 报告摘要仍留在主线 Agent 工具卡与系统消息里，驱逐不丢信息。
+ */
+const PANEL_GRACE_MS = 30_000
+
+export interface TaskBucketsApi {
+  /** sidechain 落桶；无 parent_tool_use_id 时返回 false（调用方按主线处理） */
+  appendSidechain(rec: Record<string, unknown>): boolean
+  /** 主线 tool_result 给运行中桶补终态 */
+  settleBucketFromResult(toolUseId: string | undefined, text: string, isError: boolean): void
+  /** 服务端权威 activeTasks 水合 */
+  hydrateTasks(st: SessionState): void
+  taskStarted(rec: Record<string, unknown>): void
+  taskProgress(rec: Record<string, unknown>): void
+  taskUpdated(rec: Record<string, unknown>): void
+  taskNotification(rec: Record<string, unknown>): void
+  /** 历史加载时的桶重建：清桶 + 未完成的 subagent 回填（msgs = 刚加载的主线消息） */
+  resetFromHistory(msgs: ChatMsg[], resp: HistoryResponse): void
+  /** 会话切换重置 */
+  clear(): void
+}
+
+export function useTaskBuckets(opts: { isCodex: boolean }): {
+  tasks: TaskFeed[]
+  tasksOpen: boolean
+  setTasksOpen: React.Dispatch<React.SetStateAction<boolean>>
+  api: TaskBucketsApi
+} {
+  const { isCodex } = opts
+  const taskMapRef = useRef(new Map<string, TaskBucket>())
+  const [tasks, setTasks] = useState<TaskFeed[]>([])
+  const [tasksOpen, setTasksOpen] = useState(false)
+
+  /** 发布桶快照：浅拷贝桶对象与消息数组，让 React 感知变化（事件为逐 turn 粒度，量小） */
+  const pubTasks = () =>
+    setTasks([...taskMapRef.current.values()].map((b) => ({ ...b, messages: [...b.messages] })))
+
+  const taskBucket = (toolUseId: string): TaskBucket => {
+    let b = taskMapRef.current.get(toolUseId)
+    if (!b) {
+      b = { toolUseId, status: 'running', messages: [], toolIdx: new Map(), pending: new Map(), seen: new Set() }
+      taskMapRef.current.set(toolUseId, b)
+    }
+    return b
+  }
+
+  const appendTaskMsg = (toolUseId: string, h: HistoryMessage) => {
+    const b = taskBucket(toolUseId)
+    // 历史加载与 live 追加可能重叠（落盘与 WS 投递交界），按 uuid 去重
+    if (h.uuid) {
+      if (b.seen.has(h.uuid)) return
+      b.seen.add(h.uuid)
+    }
+    const st: IngestState = { msgs: b.messages, toolIdx: b.toolIdx, pending: b.pending }
+    appendHistoryMsg(st, h)
+    b.messages = st.msgs
+  }
+
+  /** sidechain（子代理内部消息）不进主抄本——落进对应后台任务桶，右侧栏展示。
+   *  assistant（子代理输出）与 user（子代理 prompt / tool_result，桶内配对）两路同规则。 */
+  const appendSidechain = (rec: Record<string, unknown>): boolean => {
+    const ptui = rec.parent_tool_use_id as string | undefined
+    if (!ptui) return false
+    const h = cliSidechainToHistory(rec)
+    if (h) {
+      appendTaskMsg(ptui, h)
+      pubTasks()
+    }
+    return true
+  }
+
+  /** 统一终态：状态 + 清心跳 + 挂驱逐倒计时（宽限期后 1s 滴答自动移除卡片）。
+   *  live 与历史终态一视同仁——历史卡默示展示 30s 即足，长期驻留会让老会话侧栏越堆越多。 */
+  const markTerminal = (b: TaskBucket, status: TaskFeed['status']) => {
+    b.status = status
+    b.activity = undefined
+    b.evictAfter = Date.now() + PANEL_GRACE_MS
+    maybeFetchCodexTranscript(b)
+  }
+
+  /** 主线 tool_result 给运行中桶补终态：task_notification 未到的兜底，
+   *  也是外部会话（tailer 路径，无 task_notification）唯一的终态信号。 */
+  const settleBucketFromResult = (toolUseId: string | undefined, text: string, isError: boolean) => {
+    const b = toolUseId ? taskMapRef.current.get(toolUseId) : undefined
+    if (!b || b.status !== 'running') return
+    markTerminal(b, isError ? 'error' : 'done')
+    if (!b.summary && text) b.summary = text.slice(0, 500)
+    pubTasks()
+  }
+
+  /** codex 子代理转录懒取：子线程不被父通知流转发，终态后经 thread/read 拉回填充 */
+  const maybeFetchCodexTranscript = (b: TaskBucket) => {
+    if (!isCodex || !b.agentId || b.transcriptFetched || b.messages.length > 0) return
+    b.transcriptFetched = true
+    fetchCodexHistory(b.agentId)
+      .then((resp) => {
+        for (const h of resp.messages) appendTaskMsg(b.toolUseId, h)
+        pubTasks()
+      })
+      .catch(() => {})
+  }
+
+  /**
+   * 用 SessionState.activeTasks（服务端权威运行任务表）水合桶：
+   * 中途接入的客户端错过 live-only 的 task_started，没有这一步桶的首绘就会是终态。
+   * 反方向：桶还 running 却不在任务表且会话空闲 → 通知在断线间隙丢了，判终态。
+   * codex 服务端不维护任务表（状态里不带 activeTasks 字段），首行守卫直接跳过。
+   */
+  const hydrateTasks = (st: SessionState) => {
+    if (!Array.isArray(st.activeTasks)) return
+    let dirty = false
+    const live = new Set<string>()
+    for (const t of st.activeTasks) {
+      if (!t.toolUseId) continue
+      live.add(t.toolUseId)
+      const existing = taskMapRef.current.get(t.toolUseId)
+      if (existing) {
+        // 终态不被水合覆盖；running 的补心跳信息
+        if (existing.status === 'running' && t.lastToolName && existing.lastToolName !== t.lastToolName) {
+          existing.lastToolName = t.lastToolName
+          dirty = true
+        }
+        continue
+      }
+      const b = taskBucket(t.toolUseId)
+      b.status = 'running'
+      b.agentId = t.id // stop_task 需要 task_id，水合路径此前只建桶不记 agentId
+      b.description = t.description ?? b.description
+      b.agentType = t.taskType ?? b.agentType
+      b.kind = t.taskType ?? b.kind
+      b.lastToolName = t.lastToolName ?? b.lastToolName
+      b.depth = t.depth ?? b.depth
+      b.parentToolUseId = t.parentToolUseId ?? b.parentToolUseId
+      dirty = true
+    }
+    if (!st.busy) {
+      for (const b of taskMapRef.current.values()) {
+        if (b.status === 'running' && !live.has(b.toolUseId)) {
+          markTerminal(b, 'done')
+          dirty = true
+        }
+      }
+    }
+    if (dirty) pubTasks()
+  }
+
+  /** 生命周期事件是桶的主注册点（tool_use_id ↔ task_id 映射在此建立）。
+   *  桌面端自动拉开侧栏（移动端屏幕小，只亮顶栏按钮）。 */
+  const taskStarted = (rec: Record<string, unknown>) => {
+    const toolUseId = rec.tool_use_id as string | undefined
+    if (!toolUseId) return
+    const b = taskBucket(toolUseId)
+    // claude 用 task_id；codex 合成事件经 agent_thread_id 携带子线程 id（终态后懒拉转录用），后者优先
+    b.agentId =
+      (rec.agent_thread_id as string | undefined) ?? (rec.task_id as string | undefined) ?? b.agentId
+    b.description = (rec.description as string | undefined) ?? b.description
+    b.agentType = (rec.subagent_type as string | undefined) ?? (rec.task_type as string | undefined) ?? b.agentType
+    b.kind = (rec.task_type as string | undefined) ?? b.kind
+    b.depth = (rec.spawn_depth as number | undefined) ?? b.depth
+    b.status = 'running'
+    pubTasks()
+    if (window.matchMedia('(min-width: 768px)').matches) setTasksOpen(true)
+  }
+
+  /** 心跳：拟人化动作描述 + 用量，解决"长 turn 安静期像卡住"的体感。
+   *  桶不存在也补建——中途接入错过 task_started 时，心跳就是首个可见信号。 */
+  const taskProgress = (rec: Record<string, unknown>) => {
+    const toolUseId = rec.tool_use_id as string | undefined
+    if (!toolUseId) return
+    const b = taskBucket(toolUseId)
+    b.activity = (rec.description as string | undefined) ?? b.activity
+    b.lastToolName = (rec.last_tool_name as string | undefined) ?? b.lastToolName
+    b.usage = (rec.usage as TaskFeed['usage'] | undefined) ?? b.usage
+    pubTasks()
+  }
+
+  /** 终态 patch（completed/stopped/failed）；只带 task_id，经 agentId 映射回桶 */
+  const taskUpdated = (rec: Record<string, unknown>) => {
+    const taskId = rec.task_id as string | undefined
+    const patch = rec.patch as { status?: string } | undefined
+    const b = [...taskMapRef.current.values()].find((x) => x.agentId === taskId)
+    if (b && patch?.status && patch.status !== 'running' && b.status === 'running') {
+      markTerminal(b, patch.status === 'completed' ? 'done' : patch.status === 'stopped' ? 'stopped' : 'error')
+      pubTasks()
+    }
+  }
+
+  const taskNotification = (rec: Record<string, unknown>) => {
+    const summary = typeof rec.summary === 'string' ? rec.summary : ''
+    const toolUseId = rec.tool_use_id as string | undefined
+    if (!toolUseId) return
+    const b = taskBucket(toolUseId)
+    markTerminal(b, rec.status === 'completed' ? 'done' : rec.status === 'stopped' ? 'stopped' : 'error')
+    b.summary = summary || b.summary
+    b.usage = (rec.usage as TaskFeed['usage'] | undefined) ?? b.usage
+    pubTasks()
+  }
+
+  /** 历史加载的桶重建：清桶 → 只回填「转录落盘但主线 tool_result 缺失」的未完成 subagent。
+   *  已完成的不建桶——老会话重进复活一堆历史卡 30s 后齐消失是纯噪声；翻旧账走主线 Agent 工具卡。 */
+  const resetFromHistory = (msgs: ChatMsg[], resp: HistoryResponse) => {
+    taskMapRef.current.clear()
+    // 先扫主线找「已完成」的 Agent 调用（转录落盘即终态），它们在历史加载时不建桶
+    const finished = new Set<string>()
+    for (const m of msgs) {
+      for (const blk of m.blocks) {
+        if (blk.kind === 'tool' && (blk.name === 'Agent' || blk.name === 'Task') && blk.pending === false && blk.id) {
+          finished.add(blk.id)
+        }
+      }
+    }
+    for (const s of resp.subagents ?? []) {
+      const id = s.toolUseId ?? s.agentId
+      if (!id || finished.has(id)) continue // 已完成的在历史里不复活
+      const b = taskBucket(id)
+      b.agentId = s.agentId ?? b.agentId
+      b.agentType = s.agentType ?? b.agentType
+      b.description = s.description ?? b.description
+      for (const h of s.messages) appendTaskMsg(b.toolUseId, h)
+    }
+    pubTasks()
+  }
+
+  const clear = () => {
+    taskMapRef.current.clear()
+    setTasks([])
+    setTasksOpen(false)
+  }
+
+  // ---------- 终态卡片的 TTL 驱逐（仿官方协调器面板：1s 滴答扫 evictAfter） ----------
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const now = Date.now()
+      let dirty = false
+      for (const [id, b] of taskMapRef.current) {
+        if (b.evictAfter != null && now >= b.evictAfter) {
+          // 报告摘要仍留在主线 Agent 工具卡与「⚙ 后台任务完成」系统消息里，驱逐不丢信息
+          taskMapRef.current.delete(id)
+          dirty = true
+        }
+      }
+      if (dirty) pubTasks()
+      // 桶清空时收起侧栏——此时会话无运行中任务（running 桶永不驱逐），收起的都是终态卡
+      if (dirty && taskMapRef.current.size === 0) setTasksOpen(false)
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [])
+
+  return {
+    tasks,
+    tasksOpen,
+    setTasksOpen,
+    api: {
+      appendSidechain,
+      settleBucketFromResult,
+      hydrateTasks,
+      taskStarted,
+      taskProgress,
+      taskUpdated,
+      taskNotification,
+      resetFromHistory,
+      clear,
+    },
+  }
+}

--- a/web/src/hooks/useTranscriptIngest.ts
+++ b/web/src/hooks/useTranscriptIngest.ts
@@ -1,9 +1,10 @@
 // 主抄本 ingest hook：消息列表 + 流式草稿 + 7 个配对/去重 ref + handleCli/applyHistory。
-// F4 从 pages/Chat.tsx 切出。
-// 纪律：事件处理器在 React 渲染外触发（WS 回调），内部一律走 ref + setState +
-// opts 注入的稳定 setter（React setState 引用恒定）——api 对象每渲染重建但永不过期。
-// E3（session.key 历史加载 effect）留 Chat 组合层：reset 先于建连的顺序纪律在那；
-// phase/initInfo/permMode 是 cli 流驱动的会话元数据，状态留 Chat、setter 注入本 hook。
+// F4 从 pages/Chat.tsx 切出；F5 把 cli 流驱动的会话元数据（phase/initInfo/permMode/effort）
+// 一并内化——主要写入方本来就是本 hook 的 init/status/result 分支，setter 经 api 暴露给
+// WS status 事件（useSessionSocket）与 E3 清空段（组合层）共用。
+// 纪律：事件处理器在 React 渲染外触发（WS 回调），内部一律走 ref + setState——
+// api 对象每渲染重建但永不过期。
+// E3（session.key 历史加载 effect）留 Chat 组合层：reset 先于建连的顺序纪律在那。
 
 import { useRef, useState } from 'react'
 import type { HistoryResponse } from '../lib/api'
@@ -39,6 +40,11 @@ export interface Draft {
 }
 
 export interface TranscriptIngestApi {
+  // cli 流驱动的会话元数据 setter（WS status 事件与组合层清空段共用）
+  setPhase: React.Dispatch<React.SetStateAction<string | undefined>>
+  setPermMode: React.Dispatch<React.SetStateAction<string | undefined>>
+  setInitInfo: React.Dispatch<React.SetStateAction<{ model?: string; slashCommands?: string[] }>>
+  setEffort: React.Dispatch<React.SetStateAction<string | undefined>>
   setMsgs(up: (prev: ChatMsg[]) => ChatMsg[]): void
   setDraftBoth(d: Draft | null): void
   pushMsg(m: ChatMsg): void
@@ -64,13 +70,23 @@ export function useTranscriptIngest(opts: {
   isCodex: boolean
   sockRef: React.RefObject<SessionSocket | undefined>
   taskApi: TaskBucketsApi
-  setPhase: React.Dispatch<React.SetStateAction<string | undefined>>
-  setPermMode: React.Dispatch<React.SetStateAction<string | undefined>>
-  setInitInfo: React.Dispatch<React.SetStateAction<{ model?: string; slashCommands?: string[] }>>
-}): { messages: ChatMsg[]; draft: Draft | null; api: TranscriptIngestApi } {
-  const { isCodex, sockRef, taskApi, setPhase, setPermMode, setInitInfo } = opts
+}): {
+  messages: ChatMsg[]
+  draft: Draft | null
+  phase: string | undefined
+  initInfo: { model?: string; slashCommands?: string[] }
+  permMode: string | undefined
+  effort: string | undefined
+  api: TranscriptIngestApi
+} {
+  const { isCodex, sockRef, taskApi } = opts
   const [messages, setMessages] = useState<ChatMsg[]>([])
   const [draft, setDraft] = useState<Draft | null>(null)
+  // cli 流驱动的会话元数据（init/status 分支写入；WS status 事件与 E3 清空经 api setter 共用）
+  const [phase, setPhase] = useState<string>()
+  const [initInfo, setInitInfo] = useState<{ model?: string; slashCommands?: string[] }>({})
+  const [permMode, setPermMode] = useState<string>()
+  const [effort, setEffort] = useState<string>()
 
   // ref 镜像：事件处理器在 React 渲染外触发，直接基于 ref 计算，避免过期闭包/updater 双重调用
   const messagesRef = useRef<ChatMsg[]>([])
@@ -397,7 +413,15 @@ export function useTranscriptIngest(opts: {
   return {
     messages,
     draft,
+    phase,
+    initInfo,
+    permMode,
+    effort,
     api: {
+      setPhase,
+      setPermMode,
+      setInitInfo,
+      setEffort,
       setMsgs,
       setDraftBoth,
       pushMsg,

--- a/web/src/hooks/useTranscriptIngest.ts
+++ b/web/src/hooks/useTranscriptIngest.ts
@@ -1,0 +1,418 @@
+// 主抄本 ingest hook：消息列表 + 流式草稿 + 7 个配对/去重 ref + handleCli/applyHistory。
+// F4 从 pages/Chat.tsx 切出。
+// 纪律：事件处理器在 React 渲染外触发（WS 回调），内部一律走 ref + setState +
+// opts 注入的稳定 setter（React setState 引用恒定）——api 对象每渲染重建但永不过期。
+// E3（session.key 历史加载 effect）留 Chat 组合层：reset 先于建连的顺序纪律在那；
+// phase/initInfo/permMode 是 cli 流驱动的会话元数据，状态留 Chat、setter 注入本 hook。
+
+import { useRef, useState } from 'react'
+import type { HistoryResponse } from '../lib/api'
+import { nextId, toolResultText, type Block, type ChatMsg } from '../lib/blocks'
+import {
+  appendHistoryMsg,
+  createIngestState,
+  flushStrayResults,
+  hitsSeen,
+  indexToolBlocks,
+  liveMessageKeys,
+  pairToolResultIn,
+  rememberKeys,
+  transcriptKeys,
+  type IngestState,
+} from '../lib/ingest'
+import type { CliMsg, SessionSocket } from '../lib/ws'
+import type { TaskBucketsApi } from './useTaskBuckets'
+
+/** 流式草稿：一轮 assistant 输出的增量块（按 message.id + block index 归并） */
+interface DraftBlock {
+  idx: number
+  kind: 'text' | 'thinking' | 'tool'
+  text: string
+  name?: string
+  toolId?: string
+  jsonBuf?: string
+  finalized?: boolean
+}
+export interface Draft {
+  msgId?: string
+  blocks: DraftBlock[]
+}
+
+export interface TranscriptIngestApi {
+  setMsgs(up: (prev: ChatMsg[]) => ChatMsg[]): void
+  setDraftBoth(d: Draft | null): void
+  pushMsg(m: ChatMsg): void
+  pushSystem(text: string, kind?: 'info' | 'error'): void
+  /** message_stop / result 时把草稿固化为一条 assistant 消息 */
+  commitDraft(): void
+  handleCli(msg: CliMsg, replay?: boolean): void
+  /** 历史响应落到消息列表 + 从读取位置续订 tail（初次加载与 tail_reset 重载共用） */
+  applyHistory(resp: HistoryResponse): void
+  /** 会话切换重置（E3 组合层调用；顺序即原 E3 清空段前 7 步） */
+  reset(): void
+  // ref 出口：WS 事件分发（F5 前留 Chat）需要直接读写
+  messagesRef: React.RefObject<ChatMsg[]>
+  draftRef: React.RefObject<Draft | null>
+  pendingResultsRef: React.RefObject<Map<string, { text: string; isError: boolean }>>
+  toolPosRef: React.RefObject<Map<string, { mi: number; bi: number }>>
+  historyOffsetRef: React.RefObject<number | undefined>
+  gapReloadingRef: React.RefObject<boolean>
+  seenIdsRef: React.RefObject<Set<string>>
+}
+
+export function useTranscriptIngest(opts: {
+  isCodex: boolean
+  sockRef: React.RefObject<SessionSocket | undefined>
+  taskApi: TaskBucketsApi
+  setPhase: React.Dispatch<React.SetStateAction<string | undefined>>
+  setPermMode: React.Dispatch<React.SetStateAction<string | undefined>>
+  setInitInfo: React.Dispatch<React.SetStateAction<{ model?: string; slashCommands?: string[] }>>
+}): { messages: ChatMsg[]; draft: Draft | null; api: TranscriptIngestApi } {
+  const { isCodex, sockRef, taskApi, setPhase, setPermMode, setInitInfo } = opts
+  const [messages, setMessages] = useState<ChatMsg[]>([])
+  const [draft, setDraft] = useState<Draft | null>(null)
+
+  // ref 镜像：事件处理器在 React 渲染外触发，直接基于 ref 计算，避免过期闭包/updater 双重调用
+  const messagesRef = useRef<ChatMsg[]>([])
+  const draftRef = useRef<Draft | null>(null)
+  const pendingResultsRef = useRef(new Map<string, { text: string; isError: boolean }>())
+  /** toolUseId → 落地位置索引：tool_result 配对的 O(1) 快路径（失效时回退线性扫描） */
+  const toolPosRef = useRef(new Map<string, { mi: number; bi: number }>())
+  /** 历史加载时服务端读到的 transcript 字节数，tail_subscribe 的起始偏移 */
+  const historyOffsetRef = useRef<number | undefined>(undefined)
+  /** replay_gap 正在重载历史：丢弃这段窗口内的 cli，避免和 applyHistory 对抄本抢写 */
+  const gapReloadingRef = useRef(false)
+  /** 已见消息身份（uuid / message.id / tool:id）。HTTP 历史与 live/补发重叠时靠它去重 */
+  const seenIdsRef = useRef(new Set<string>())
+
+  const setMsgs = (up: (prev: ChatMsg[]) => ChatMsg[]) => {
+    messagesRef.current = up(messagesRef.current)
+    setMessages(messagesRef.current)
+  }
+  const setDraftBoth = (d: Draft | null) => {
+    draftRef.current = d
+    setDraft(d)
+  }
+  const pushMsg = (m: ChatMsg) => {
+    setMsgs((prev) => {
+      // 建索引的同时消费乱序缓冲：结果早于工具块落地时（live 流常见）在此补齐
+      const st: IngestState = { msgs: [...prev, m], toolIdx: toolPosRef.current, pending: pendingResultsRef.current }
+      indexToolBlocks(st, st.msgs.length - 1)
+      rememberKeys(seenIdsRef.current, [...transcriptKeys([m])])
+      return st.msgs
+    })
+  }
+  const pushSystem = (text: string, kind: 'info' | 'error' = 'info') =>
+    pushMsg({ id: nextId(), role: 'system', systemKind: kind, blocks: [{ kind: 'text', text }] })
+
+  /** 历史响应落到消息列表 + 从读取位置续订 tail（初次加载与 tail_reset 重载共用） */
+  const applyHistory = (resp: HistoryResponse) => {
+    historyOffsetRef.current = resp.fileBytes
+    const st = createIngestState()
+    for (const h of resp.messages) appendHistoryMsg(st, h)
+    // 批次收尾：整批读完仍未配对的才是真孤儿（批内乱序此时已修复）
+    flushStrayResults(st)
+    const out = st.msgs
+    setMsgs(() => out)
+    // 实时配对索引与乱序缓冲直接沿用历史加载建好的（out 已成为新 state）
+    toolPosRef.current = st.toolIdx
+    pendingResultsRef.current = st.pending
+    seenIdsRef.current = transcriptKeys(out)
+
+    // 子代理侧链进桶；终态/报告以主线 Agent 工具卡的配对结果为准（tool_result 已落盘 = 已完成）
+    //（清桶 + 未完成 subagent 回填的实现已随桶下沉 hooks/useTaskBuckets.ts）
+    taskApi.resetFromHistory(out, resp)
+
+    // 从历史读取位置续订 transcript 追加（外部会话的实时更新）；socket 未 open 时会排队
+    // codex 的实时流走 app-server 订阅（attach 即 resume），无 tailer
+    if (!isCodex) sockRef.current?.send({ kind: 'tail_subscribe', from: resp.fileBytes })
+  }
+
+  /** 会话切换重置（E3 组合层调用；顺序即原 E3 清空段前 7 步） */
+  const reset = () => {
+    setMsgs(() => [])
+    setDraftBoth(null)
+    pendingResultsRef.current.clear()
+    toolPosRef.current.clear()
+    seenIdsRef.current.clear()
+    historyOffsetRef.current = undefined
+    gapReloadingRef.current = false
+  }
+
+  // ---------- 流式草稿 ----------
+
+  /** message_stop / result 时把草稿固化为一条 assistant 消息 */
+  const commitDraft = () => {
+    const d = draftRef.current
+    if (!d) return
+    setDraftBoth(null)
+    if (d.blocks.length === 0) return
+    const blocks: Block[] = []
+    for (const b of d.blocks) {
+      if (b.kind === 'tool') {
+        let input: unknown
+        try {
+          input = b.jsonBuf ? JSON.parse(b.jsonBuf) : undefined
+        } catch {}
+        const toolId = b.toolId ?? nextId()
+        const held = pendingResultsRef.current.get(toolId)
+        if (held) pendingResultsRef.current.delete(toolId)
+        blocks.push({
+          kind: 'tool',
+          id: toolId,
+          name: b.name ?? '?',
+          input,
+          pending: !held,
+          resultText: held?.text,
+          resultError: held?.isError,
+        })
+      } else if (b.text.trim()) {
+        blocks.push({ kind: b.kind, text: b.text })
+      }
+    }
+    if (blocks.length > 0) pushMsg({ id: d.msgId ?? nextId(), role: 'assistant', blocks })
+  }
+
+  /** tool_result 配对到已渲染的工具卡片；工具块还在草稿里则暂存（归并实现见 lib/ingest） */
+  const pairToolResult = (toolUseId: string | undefined, text: string, isError: boolean) => {
+    if (!toolUseId) return
+    setMsgs((prev) => {
+      const r = pairToolResultIn(prev, toolPosRef.current, toolUseId, text, isError)
+      if (!r.paired) pendingResultsRef.current.set(toolUseId, { text, isError })
+      return r.msgs
+    })
+  }
+
+  // ---------- CLI 消息处理 ----------
+  const handleCli = (msg: CliMsg, replay = false) => {
+    const rec = msg as Record<string, unknown>
+
+    // 流式增量事件（Anthropic API SSE 透传）
+    if (msg.type === 'stream_event') {
+      const ev = rec.event as
+        | {
+            type?: string
+            index?: number
+            message?: { id?: string }
+            content_block?: { type?: string; id?: string; name?: string }
+            delta?: { type?: string; text?: string; thinking?: string; partial_json?: string }
+          }
+        | undefined
+      if (!ev?.type) return
+      switch (ev.type) {
+        case 'message_start':
+          setDraftBoth({ msgId: ev.message?.id, blocks: [] })
+          break
+        case 'content_block_start': {
+          const t = ev.content_block?.type
+          const d: Draft = draftRef.current ?? { blocks: [] }
+          const idx = ev.index ?? d.blocks.length
+          if (!d.blocks.some((b) => b.idx === idx)) {
+            d.blocks.push({
+              idx,
+              kind: t === 'thinking' ? 'thinking' : t === 'tool_use' ? 'tool' : 'text',
+              text: '',
+              toolId: ev.content_block?.id,
+              name: ev.content_block?.name,
+              jsonBuf: t === 'tool_use' ? '' : undefined,
+            })
+            d.blocks.sort((a, b) => a.idx - b.idx)
+            setDraftBoth({ ...d })
+          }
+          break
+        }
+        case 'content_block_delta': {
+          const delta = ev.delta
+          if (!delta) break
+          const d: Draft = draftRef.current ?? { blocks: [] }
+          const idx = ev.index ?? d.blocks.length - 1
+          let b = d.blocks.find((x) => x.idx === idx)
+          if (!b) {
+            b = { idx, kind: 'text', text: '' }
+            d.blocks.push(b)
+            d.blocks.sort((a, z) => a.idx - z.idx)
+          }
+          if (delta.type === 'text_delta' && delta.text) b.text += delta.text
+          else if (delta.type === 'thinking_delta' && delta.thinking) {
+            b.kind = 'thinking'
+            b.text += delta.thinking
+          } else if (delta.type === 'input_json_delta' && delta.partial_json) b.jsonBuf = (b.jsonBuf ?? '') + delta.partial_json
+          // signature_delta 永不展示
+          setDraftBoth({ ...d, blocks: [...d.blocks] })
+          break
+        }
+        case 'message_stop':
+          commitDraft()
+          break
+        // content_block_stop / message_delta 无需处理（assistant 快照与 result 会收尾）
+      }
+      return
+    }
+
+    if (msg.type === 'control_response') {
+      const resp = rec.response as { subtype?: string; error?: string } | undefined
+      if (resp?.subtype === 'error') pushSystem(`⚠ ${resp.error ?? '控制请求失败'}`, 'error')
+      return
+    }
+
+    if (msg.type === 'assistant') {
+      if (taskApi.appendSidechain(rec)) return
+      const content = msg.message?.content
+      const blocks = Array.isArray(content) ? content : []
+      const msgId = (rec.message as { id?: string } | undefined)?.id
+      const d = draftRef.current
+      if (!d || msgId !== d.msgId) {
+        const toolIds = blocks.filter((c) => c?.type === 'tool_use' && c.id).map((c) => String(c.id))
+        const keys = liveMessageKeys({ uuid: msg.uuid, messageId: msgId, toolIds })
+        // uuid / message.id / 工具块 id 任一已在抄本（HTTP 历史或先前 live）即跳过——
+        // 旧实现只比 message.id，而落盘 id 是 uuid，Codex 甚至没有 uuid，重连补发会重复气泡
+        if (hitsSeen(seenIdsRef.current, keys)) return
+        // 没有对应草稿（如中途接入）：直接落为完整消息
+        const direct: Block[] = []
+        for (const c of blocks) {
+          if (c?.type === 'text' && c.text?.trim()) direct.push({ kind: 'text', text: c.text })
+          else if (c?.type === 'thinking' && c.thinking?.trim()) direct.push({ kind: 'thinking', text: c.thinking })
+          else if (c?.type === 'tool_use')
+            direct.push({ kind: 'tool', id: c.id ?? nextId(), name: c.name ?? '?', input: c.input, pending: true })
+        }
+        if (direct.length > 0) pushMsg({ id: msg.uuid ?? msgId ?? nextId(), role: 'assistant', blocks: direct })
+        return
+      }
+      // 块快照：把草稿中对应的增量块定稿（去重关键：同 message.id 同 kind 按序匹配）
+      const dblocks = d.blocks.map((b) => ({ ...b }))
+      for (const c of blocks) {
+        const kind = c?.type === 'thinking' ? 'thinking' : c?.type === 'tool_use' ? 'tool' : 'text'
+        const b = dblocks.find((x) => !x.finalized && x.kind === kind && (kind !== 'tool' || !c.id || x.toolId === c.id))
+        if (!b) continue
+        b.finalized = true
+        if (c?.type === 'text' && c.text) b.text = c.text
+        else if (c?.type === 'thinking' && c.thinking) b.text = c.thinking
+        else if (c?.type === 'tool_use') {
+          b.name = c.name ?? b.name
+          b.toolId = c.id ?? b.toolId
+          b.jsonBuf = c.input != null ? JSON.stringify(c.input) : b.jsonBuf
+        }
+      }
+      setDraftBoth({ ...d, blocks: dblocks })
+      return
+    }
+
+    if (msg.type === 'user') {
+      if (msg.isMeta) return
+      if (taskApi.appendSidechain(rec)) return
+      const content = msg.message?.content
+      const blocks = Array.isArray(content) ? content : typeof content === 'string' ? [{ type: 'text', text: content }] : []
+      const textBlocks: Block[] = []
+      for (const c of blocks) {
+        if (c?.type === 'tool_result') {
+          const resultText = toolResultText(c.content)
+          pairToolResult(c.tool_use_id, resultText, c.is_error === true)
+          // 主线 Agent tool_result 是子代理的终态兜底（正常路径是 task_notification 先到）
+          taskApi.settleBucketFromResult(c.tool_use_id, resultText, c.is_error === true)
+        } else if (c?.type === 'text' && c.text?.trim()) {
+          // /goal 的评估器反馈（Stop hook）：goal 循环内的中途评估，渲染为系统提示而非用户气泡
+          if (c.text.startsWith('Stop hook feedback:')) {
+            const body = c.text.replace(/^Stop hook feedback:\s*/, '')
+            pushSystem(`◎ 目标评估：${body.slice(0, 300)}`)
+            continue
+          }
+          textBlocks.push({ kind: 'text', text: c.text })
+        }
+      }
+      if (textBlocks.length > 0) {
+        const keys = liveMessageKeys({ uuid: msg.uuid })
+        if (hitsSeen(seenIdsRef.current, keys)) return
+        pushMsg({ id: msg.uuid ?? nextId(), role: 'user', blocks: textBlocks })
+      }
+      return
+    }
+
+    if (msg.type === 'system') {
+      switch (msg.subtype) {
+        case 'init': {
+          const slash = Array.isArray(rec.slash_commands) ? (rec.slash_commands as string[]) : undefined
+          setInitInfo({ model: rec.model as string | undefined, slashCommands: slash })
+          setPermMode(rec.permissionMode as string | undefined)
+          break
+        }
+        case 'status': {
+          // status 是 string|null（如 "requesting"/"compacting"），不是对象——勿迭代
+          const st = rec.status
+          setPhase(typeof st === 'string' ? st : undefined)
+          if (typeof rec.permissionMode === 'string') setPermMode(rec.permissionMode)
+          break
+        }
+        case 'thinking_tokens':
+          break // 增量 token 估算，不展示
+        case 'task_started': {
+          // 生命周期事件是桶的主注册点（实现在 hooks/useTaskBuckets.ts）
+          taskApi.taskStarted(rec)
+          if (!replay) pushSystem(`⚙ 后台任务启动：${String(rec.description ?? '')}`)
+          break
+        }
+        case 'task_progress': {
+          taskApi.taskProgress(rec)
+          break
+        }
+        case 'task_updated': {
+          taskApi.taskUpdated(rec)
+          break
+        }
+        case 'task_notification': {
+          const summary = typeof rec.summary === 'string' ? rec.summary : ''
+          taskApi.taskNotification(rec)
+          if (!replay) pushSystem(`⚙ 后台任务完成${summary ? `：${summary.slice(0, 200)}` : ''}`)
+          break
+        }
+        case 'compact_boundary': {
+          if (replay) break
+          const meta = (rec.compactMetadata ?? {}) as { preTokens?: number; postTokens?: number }
+          pushMsg({ id: nextId(), role: 'system', systemKind: 'divider', compactMeta: meta, blocks: [] })
+          break
+        }
+      }
+      return
+    }
+
+    if (msg.type === 'result') {
+      commitDraft()
+      setPhase(undefined)
+      // 补发的旧 result 已在 HTTP 历史里，再落「本轮」会在底部堆出一串重复页脚
+      if (replay) return
+      if (msg.uuid && hitsSeen(seenIdsRef.current, [msg.uuid])) return
+      if (msg.uuid) rememberKeys(seenIdsRef.current, [msg.uuid])
+      const isErr = rec.is_error === true
+      const dur = typeof rec.duration_ms === 'number' ? `${Math.round(rec.duration_ms / 1000)}s` : undefined
+      const usage = rec.usage as { output_tokens?: number } | undefined
+      const parts = [dur, usage?.output_tokens != null ? `${usage.output_tokens} tok` : undefined].filter(Boolean)
+      if (isErr) {
+        pushSystem(`⚠ ${String(rec.result ?? rec.subtype ?? '执行出错')}`, 'error')
+      } else if (parts.length > 0) {
+        pushSystem(`─ 本轮 ${parts.join(' · ')}`)
+      }
+      return
+    }
+  }
+
+  return {
+    messages,
+    draft,
+    api: {
+      setMsgs,
+      setDraftBoth,
+      pushMsg,
+      pushSystem,
+      commitDraft,
+      handleCli,
+      applyHistory,
+      reset,
+      messagesRef,
+      draftRef,
+      pendingResultsRef,
+      toolPosRef,
+      historyOffsetRef,
+      gapReloadingRef,
+      seenIdsRef,
+    },
+  }
+}

--- a/web/src/lib/chatText.test.ts
+++ b/web/src/lib/chatText.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test'
+import { cliSidechainToHistory, statusLineOf } from './chatText'
+import type { SessionState } from './ws'
+
+const baseState: SessionState = { spawned: false, busy: false }
+
+describe('statusLineOf 早退链（优先级即源码顺序）', () => {
+  test('未连接最先', () => {
+    expect(statusLineOf({ ...baseState, busy: true }, { connected: false, waiting: true, phase: 'requesting' })).toBe('连接中…')
+  })
+  test('phase 优先于 waiting/busy', () => {
+    expect(statusLineOf({ ...baseState, busy: true }, { connected: true, waiting: true, phase: 'compacting' })).toBe('压缩上下文…')
+    // 未知 phase 原样透传
+    expect(statusLineOf(baseState, { connected: true, waiting: false, phase: 'whatever' })).toBe('whatever…')
+  })
+  test('waiting 区分 tailing', () => {
+    expect(statusLineOf(baseState, { connected: true, waiting: true })).toBe('等待审批')
+    expect(statusLineOf({ ...baseState, tailing: true }, { connected: true, waiting: true })).toBe('外部会话等待操作')
+  })
+  test('activeTaskCount 优先于 busy', () => {
+    expect(statusLineOf({ ...baseState, busy: true, activeTaskCount: 2 }, { connected: true, waiting: false })).toBe('2 个后台任务运行中')
+  })
+  test('busy 区分 tailing', () => {
+    expect(statusLineOf({ ...baseState, busy: true }, { connected: true, waiting: false })).toBe('工作中')
+    expect(statusLineOf({ ...baseState, busy: true, tailing: true }, { connected: true, waiting: false })).toBe('外部会话工作中')
+  })
+  test('spawned 看 sessionState；且不再看 exited/tailing', () => {
+    expect(statusLineOf({ spawned: true, busy: false, sessionState: 'idle' }, { connected: true, waiting: false })).toBe('CLI 空闲')
+    expect(statusLineOf({ spawned: true, busy: false, sessionState: 'running' }, { connected: true, waiting: false })).toBe('CLI 运行中')
+    expect(statusLineOf({ spawned: true, busy: false, exited: true }, { connected: true, waiting: false })).not.toBe('进程已退出')
+  })
+  test('exited / tailing / 未启动三态', () => {
+    expect(statusLineOf({ ...baseState, exited: true }, { connected: true, waiting: false })).toBe('进程已退出')
+    expect(statusLineOf({ ...baseState, tailing: true }, { connected: true, waiting: false })).toBe('外部会话 · 实时跟踪中')
+    expect(statusLineOf(baseState, { connected: true, waiting: false })).toBe('浏览中（发送消息时启动 CLI）')
+    expect(statusLineOf({ ...baseState, model: 'sonnet' }, { connected: true, waiting: false })).toBe('配置已保存（发送消息时启动 CLI）')
+  })
+})
+
+describe('cliSidechainToHistory', () => {
+  test('非 assistant/user 一律 null', () => {
+    expect(cliSidechainToHistory({ type: 'system' })).toBeNull()
+    expect(cliSidechainToHistory({ type: 'result' })).toBeNull()
+  })
+  test('字符串 content → text 块；空串不落块返回 null', () => {
+    expect(cliSidechainToHistory({ type: 'user', message: { content: '  ' } })).toBeNull()
+    const h = cliSidechainToHistory({ type: 'user', uuid: 'u1', message: { content: '你好' }, timestamp: 't' })
+    expect(h).toEqual({ uuid: 'u1', role: 'user', blocks: [{ kind: 'text', text: '你好' }], timestamp: 't' })
+  })
+  test('块映射与 discovery 同形：text/thinking/tool_use/tool_result', () => {
+    const h = cliSidechainToHistory({
+      type: 'assistant',
+      uuid: 'a1',
+      message: {
+        content: [
+          { type: 'thinking', thinking: '想一想' },
+          { type: 'text', text: '答' },
+          { type: 'tool_use', name: 'Bash', id: 'tu1', input: { command: 'ls' } },
+          { type: 'tool_result', tool_use_id: 'tu1', content: [{ type: 'text', text: 'ok' }], is_error: false },
+          { type: 'text', text: '   ' }, // 空白 text 不落块
+        ],
+      },
+    })
+    expect(h?.role).toBe('assistant')
+    expect(h?.blocks.map((b) => b.kind)).toEqual(['thinking', 'text', 'tool_use', 'tool_result'])
+    const tr = h?.blocks[3]
+    expect(tr?.kind === 'tool_result' && tr.id).toBe('tu1')
+  })
+})

--- a/web/src/lib/chatText.ts
+++ b/web/src/lib/chatText.ts
@@ -1,0 +1,81 @@
+// Chat 页的纯文本/纯数据工具：状态文案、剪贴板、sidechain 消息形状转换。
+// 从 pages/Chat.tsx 下沉（F1）——无组件状态、无 React 依赖，bun:test 直接钉住。
+
+import type { HistoryMessage } from './api'
+import { toolResultText } from './blocks'
+import type { SessionState } from './ws'
+
+/** 复制到剪贴板：clipboard API 仅在安全上下文可用，http 局域网访问走 textarea 回退 */
+export async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    // 权限拒绝等 → 走回退
+  }
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.style.position = 'fixed'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    const ok = document.execCommand('copy')
+    ta.remove()
+    return ok
+  } catch {
+    return false
+  }
+}
+
+export const PHASE_LABEL: Record<string, string> = {
+  requesting: '请求中',
+  compacting: '压缩上下文',
+}
+
+/** 输入行上方的会话状态文案：早退链，优先级即源码顺序。
+ *  spawned 为真时不再看 exited/tailing（保持原嵌套三元的求值顺序）。 */
+export function statusLineOf(
+  state: SessionState,
+  opts: { connected: boolean; phase?: string; waiting: boolean },
+): string {
+  if (!opts.connected) return '连接中…'
+  if (opts.phase) return `${PHASE_LABEL[opts.phase] ?? opts.phase}…`
+  if (opts.waiting) return state.tailing ? '外部会话等待操作' : '等待审批'
+  const activeTaskCount = state.activeTaskCount ?? 0
+  if (activeTaskCount > 0) return `${activeTaskCount} 个后台任务运行中`
+  if (state.busy) return state.tailing ? '外部会话工作中' : '工作中'
+  if (state.spawned) return state.sessionState === 'idle' ? 'CLI 空闲' : 'CLI 运行中'
+  if (state.exited) return '进程已退出'
+  if (state.tailing) return '外部会话 · 实时跟踪中'
+  const hasPendingStartConfig = Boolean(state.model || state.permissionMode || state.effort)
+  return hasPendingStartConfig ? '配置已保存（发送消息时启动 CLI）' : '浏览中（发送消息时启动 CLI）'
+}
+
+/**
+ * 把一条实时 sidechain CLI 消息（带 parent_tool_use_id 的完整 assistant/user）转成
+ * HistoryMessage 形状，使其可以复用 appendHistoryMsg 落进后台任务桶。
+ * 与 discovery.entryToHistoryMessage 的块映射保持一致（text/thinking/tool_use/tool_result）。
+ */
+export function cliSidechainToHistory(rec: Record<string, unknown>): HistoryMessage | null {
+  const type = rec.type
+  if (type !== 'assistant' && type !== 'user') return null
+  const content = (rec.message as { content?: unknown } | undefined)?.content
+  const blocks: { kind: 'text' | 'thinking' | 'tool_use' | 'tool_result'; text?: string; name?: string; id?: string; input?: unknown; isError?: boolean }[] = []
+  if (typeof content === 'string') {
+    if (content.trim()) blocks.push({ kind: 'text', text: content })
+  } else if (Array.isArray(content)) {
+    for (const c of content as Record<string, unknown>[]) {
+      if (c?.type === 'text' && typeof c.text === 'string' && c.text.trim()) blocks.push({ kind: 'text', text: c.text })
+      else if (c?.type === 'thinking' && typeof c.thinking === 'string' && c.thinking.trim())
+        blocks.push({ kind: 'thinking', text: c.thinking })
+      else if (c?.type === 'tool_use') blocks.push({ kind: 'tool_use', name: c.name as string, id: c.id as string, input: c.input })
+      else if (c?.type === 'tool_result')
+        blocks.push({ kind: 'tool_result', id: c.tool_use_id as string, text: toolResultText(c.content), isError: c.is_error === true })
+    }
+  }
+  if (blocks.length === 0) return null
+  return { uuid: rec.uuid as string | undefined, role: type, blocks, timestamp: rec.timestamp as string | undefined }
+}

--- a/web/src/lib/slashIntercept.test.ts
+++ b/web/src/lib/slashIntercept.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test'
+import { interceptSlash } from './slashIntercept'
+
+const claude = { isCodex: false }
+const codex = { isCodex: true }
+
+describe('interceptSlash 双后端通杀（无后端门）', () => {
+  test('/rewind 及官方别名', () => {
+    for (const t of ['/rewind', '/checkpoint', '/undo']) {
+      expect(interceptSlash(t, claude)).toEqual({ type: 'openRewind' })
+      expect(interceptSlash(t, codex)).toEqual({ type: 'openRewind' })
+    }
+    expect(interceptSlash('/rewind now', claude)).toBeNull() // 带参不命中（透传给 CLI）
+  })
+  test('/btw 参数提取（含空参）', () => {
+    expect(interceptSlash('/btw 你好吗', claude)).toEqual({ type: 'btw', question: '你好吗' })
+    expect(interceptSlash('/btw', claude)).toEqual({ type: 'btw', question: '' })
+    expect(interceptSlash('/btx', claude)).toBeNull() // 词边界：(\s|$)
+  })
+  test('/branch|/fork 全形拦截（含参数），名字提取', () => {
+    expect(interceptSlash('/branch', claude)).toEqual({ type: 'branch', name: undefined })
+    expect(interceptSlash('/branch 实验分支', claude)).toEqual({ type: 'branch', name: '实验分支' })
+    expect(interceptSlash('/fork x', codex)).toEqual({ type: 'branch', name: 'x' }) // codex 也命中（执行器给引导提示）
+  })
+  test('/exit /quit', () => {
+    expect(interceptSlash('/exit', claude)).toEqual({ type: 'exitHint' })
+    expect(interceptSlash('/quit', codex)).toEqual({ type: 'exitHint' })
+    expect(interceptSlash('/exit now', claude)).toBeNull()
+  })
+})
+
+describe('interceptSlash codex 专属（claude 透传）', () => {
+  test('/compact 仅 codex', () => {
+    expect(interceptSlash('/compact', codex)).toEqual({ type: 'compact' })
+    expect(interceptSlash('/compact', claude)).toBeNull()
+  })
+  test('/context 仅 codex', () => {
+    expect(interceptSlash('/context', codex)).toEqual({ type: 'context' })
+    expect(interceptSlash('/context', claude)).toBeNull()
+  })
+  test('/goal 三态：查询 / 清除 / 设定', () => {
+    expect(interceptSlash('/goal', codex)).toEqual({ type: 'goal' })
+    expect(interceptSlash('/goal 通过全部测试', codex)).toEqual({ type: 'goal', condition: '通过全部测试' })
+    for (const w of ['clear', 'stop', 'off', 'reset', 'none', 'cancel', 'CLEAR']) {
+      expect(interceptSlash(`/goal ${w}`, codex)).toEqual({ type: 'goal', clear: true })
+    }
+    expect(interceptSlash('/goal clear ok', codex)).toEqual({ type: 'goal', condition: 'clear ok' }) // 整词匹配
+    expect(interceptSlash('/goal x', claude)).toBeNull()
+  })
+  test('/review 参数提取', () => {
+    expect(interceptSlash('/review', codex)).toEqual({ type: 'review', instructions: undefined })
+    expect(interceptSlash('/review 只看安全性', codex)).toEqual({ type: 'review', instructions: '只看安全性' })
+    expect(interceptSlash('/review', claude)).toBeNull()
+  })
+  test('/rename 参数提取', () => {
+    expect(interceptSlash('/rename 新名字', codex)).toEqual({ type: 'rename', name: '新名字' })
+    expect(interceptSlash('/rename', codex)).toEqual({ type: 'rename', name: undefined })
+    expect(interceptSlash('/rename x', claude)).toBeNull()
+  })
+  test('/new /clear 仅 codex', () => {
+    expect(interceptSlash('/new', codex)).toEqual({ type: 'newThread' })
+    expect(interceptSlash('/clear', codex)).toEqual({ type: 'newThread' })
+    expect(interceptSlash('/new', claude)).toBeNull()
+    expect(interceptSlash('/clear', claude)).toBeNull() // claude /clear 透传（CLI 换 sessionId 续跑正是想要的语义）
+  })
+})
+
+describe('interceptSlash 非命令与优先级', () => {
+  test('普通文本/未知命令不拦截', () => {
+    expect(interceptSlash('hello', claude)).toBeNull()
+    expect(interceptSlash('/unknown', codex)).toBeNull()
+    expect(interceptSlash('', codex)).toBeNull()
+  })
+  test('表序即优先级：/btw 不被 /branch 族抢匹配', () => {
+    // 两族正则无交集，此测试钉住"逐字保序"的意图（防后续重排）
+    expect(interceptSlash('/btw /branch', claude)).toEqual({ type: 'btw', question: '/branch' })
+  })
+})

--- a/web/src/lib/slashIntercept.ts
+++ b/web/src/lib/slashIntercept.ts
@@ -1,0 +1,99 @@
+// 斜杠命令拦截表（数据化）：match 顺序即优先级，与原 Chat.tsx send() 内联表逐字一致。
+// 命中后返回动作联合，副作用执行（send/pushSystem/导航）留在 Chat 组合层——
+// 本模块纯函数，bun:test 直接钉住匹配与参数提取。
+//
+// 设计约束（见 AGENTS.md「斜杠命令」）：
+// - claude 尽量透传，CLI 是命令仲裁者；codex app-server 对斜杠文本零解析，
+//   凡有 RPC 对应物的命令必须前端拦截（双后端命令不分叉的代价）。
+// - /btw 官方 headless 是空操作 → side_question 控制通道；/branch headless 写孤立 fork
+//   不切换 → 全形拦截；/exit /quit headless 真杀进程 → 拦下提示归档。
+
+/** 拦截动作联合：执行器（Chat.tsx runSlashAction）按 type 分发副作用 */
+export type SlashAction =
+  /** /rewind 及其官方别名 /checkpoint /undo：打开回滚面板 */
+  | { type: 'openRewind' }
+  /** /btw <问题>：侧问（question 空串 = 缺参数，执行器给用法提示） */
+  | { type: 'btw'; question: string }
+  /** /branch|/fork [名字]：分叉（codex 命中时执行器给引导提示，不发送） */
+  | { type: 'branch'; name?: string }
+  /** /exit|/quit：headless 会真杀进程，拦下给替代指引 */
+  | { type: 'exitHint' }
+  /** codex /compact → control compact */
+  | { type: 'compact' }
+  /** codex /context：无 get_context_usage 对应物，执行器用 state.usage 顶一句 */
+  | { type: 'context' }
+  /** codex /goal [条件]：condition 设定；clear 清除；皆无 = 查询，执行器读 state.goal 给提示 */
+  | { type: 'goal'; condition?: string; clear?: boolean }
+  /** codex /review [说明]：无参审未提交改动，带参按自定义说明审（inline 在本线程跑） */
+  | { type: 'review'; instructions?: string }
+  /** codex /rename <新名字>（name 缺省 = 缺参数，执行器给用法提示） */
+  | { type: 'rename'; name?: string }
+  /** codex /new 与 /clear 同为 thread/start 新线程：导航到 xn| 新会话页（懒启动） */
+  | { type: 'newThread' }
+
+interface InterceptRule {
+  match: (t: string, isCodex: boolean) => boolean
+  action: (t: string) => SlashAction
+}
+
+/** 拦截表：数组顺序 = 判定优先级（逐字对齐原 send() 内联表） */
+const INTERCEPT_TABLE: InterceptRule[] = [
+  {
+    // /rewind 及其官方别名 /checkpoint /undo
+    match: (t) => t === '/rewind' || t === '/checkpoint' || t === '/undo',
+    action: () => ({ type: 'openRewind' }),
+  },
+  {
+    match: (t) => /^\/btw(\s|$)/.test(t),
+    action: (t) => ({ type: 'btw', question: t.slice(4).trim() }),
+  },
+  {
+    // 内建 /branch（有参时）会在 headless 下写孤立 fork 会话文件却不切换（context.resume 缺席），
+    // 必须全形拦截（含参数）；名字透传给分叉 spawn 的 -n
+    match: (t) => /^\/(branch|fork)(\s|$)/.test(t),
+    action: (t) => ({ type: 'branch', name: t.match(/^\/(?:branch|fork)(?:\s+(.*))?$/)?.[1]?.trim() || undefined }),
+  },
+  {
+    // /exit /quit headless 下会真的杀掉 CLI 进程——web 场景下多半是误触，拦下给替代指引
+    match: (t) => t === '/exit' || t === '/quit',
+    action: () => ({ type: 'exitHint' }),
+  },
+  {
+    match: (t, isCodex) => isCodex && t === '/compact',
+    action: () => ({ type: 'compact' }),
+  },
+  {
+    match: (t, isCodex) => isCodex && t === '/context',
+    action: () => ({ type: 'context' }),
+  },
+  {
+    match: (t, isCodex) => isCodex && /^\/goal(\s|$)/.test(t),
+    action: (t) => {
+      const arg = t.slice(5).trim()
+      if (!arg) return { type: 'goal' }
+      if (/^(clear|stop|off|reset|none|cancel)$/i.test(arg)) return { type: 'goal', clear: true }
+      return { type: 'goal', condition: arg }
+    },
+  },
+  {
+    match: (t, isCodex) => isCodex && /^\/review(\s|$)/.test(t),
+    action: (t) => ({ type: 'review', instructions: t.slice(7).trim() || undefined }),
+  },
+  {
+    match: (t, isCodex) => isCodex && /^\/rename(\s|$)/.test(t),
+    action: (t) => ({ type: 'rename', name: t.slice(7).trim() || undefined }),
+  },
+  {
+    // codex /new 与 /clear 同为 thread/start 新线程：导航到 xn| 新会话页（懒启动）
+    match: (t, isCodex) => isCodex && (t === '/new' || t === '/clear'),
+    action: () => ({ type: 'newThread' }),
+  },
+]
+
+/** 命中返回动作（调用方随后清空输入框并 return）；未命中返回 null（透传给 CLI） */
+export function interceptSlash(text: string, opts: { isCodex: boolean }): SlashAction | null {
+  for (const rule of INTERCEPT_TABLE) {
+    if (rule.match(text, opts.isCodex)) return rule.action(text)
+  }
+  return null
+}

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -9,8 +9,9 @@ export type ServerEvent =
   | { kind: 'status'; state: SessionState }
   | { kind: 'approval_request'; requestId: string; toolName: string; input: unknown }
   | { kind: 'approval_resolved'; requestId: string }
-  /** 审批规则引擎自动裁决的留痕事件（服务端已直接回复 CLI，此处只做 UI 审计卡） */
-  | { kind: 'approval_auto'; requestId: string; toolName: string; input: unknown; action: 'allow' | 'deny'; rule: string }
+  /** 审批规则引擎自动裁决的留痕事件（服务端已直接回复 CLI，此处只做 UI 审计卡）；
+   *  detail 是服务端 summarizeInput 唯一口径算好的摘要，前端直接渲染不再自行提取字段 */
+  | { kind: 'approval_auto'; requestId: string; toolName: string; input: unknown; detail: string; action: 'allow' | 'deny'; rule: string }
   | { kind: 'btw_pending'; question: string }
   | { kind: 'btw_delta'; question: string; delta: string; thinking?: boolean }
   | { kind: 'btw_result'; ok: boolean; question: string; text: string }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -12,37 +12,14 @@ import { CodexMark } from '../components/CodexMark'
 import { PopupPanel } from '../components/PopupPanel'
 import { ContextRing } from '../components/ContextRing'
 import { buildTranscriptRows, fmtTokens, nextId, rewindPreview, toolResultText, usageSummary, type Block, type ChatMsg } from '../lib/blocks'
+import { copyText, statusLineOf, cliSidechainToHistory } from '../lib/chatText'
+import { interceptSlash, type SlashAction } from '../lib/slashIntercept'
 import { appendHistoryMsg, createIngestState, flushStrayResults, hitsSeen, indexToolBlocks, liveMessageKeys, pairToolResultIn, rememberKeys, transcriptKeys, type IngestState, type PendingResult, type ToolPos } from '../lib/ingest'
 import { isCodexKey, isExistingKey } from '../lib/key'
 import { COMMAND_DESC, filterSlashHints, mergeSlashCommands, type SlashEntry } from '../lib/slashCommands'
 
 const MORE_ITEM =
   'flex w-full items-center gap-2 rounded-[10px] px-3 py-2 text-left font-mono text-[12px] text-muted transition-colors hover:bg-surface hover:text-ink'
-
-/** 复制到剪贴板：clipboard API 仅在安全上下文可用，http 局域网访问走 textarea 回退 */
-async function copyText(text: string): Promise<boolean> {
-  try {
-    if (navigator.clipboard?.writeText) {
-      await navigator.clipboard.writeText(text)
-      return true
-    }
-  } catch {
-    // 权限拒绝等 → 走回退
-  }
-  try {
-    const ta = document.createElement('textarea')
-    ta.value = text
-    ta.style.position = 'fixed'
-    ta.style.opacity = '0'
-    document.body.appendChild(ta)
-    ta.select()
-    const ok = document.execCommand('copy')
-    ta.remove()
-    return ok
-  } catch {
-    return false
-  }
-}
 
 interface Approval {
   requestId: string
@@ -89,56 +66,6 @@ interface DraftBlock {
 interface Draft {
   msgId?: string
   blocks: DraftBlock[]
-}
-
-const PHASE_LABEL: Record<string, string> = {
-  requesting: '请求中',
-  compacting: '压缩上下文',
-}
-
-/** 输入行上方的会话状态文案：早退链，优先级即源码顺序。
- *  spawned 为真时不再看 exited/tailing（保持原嵌套三元的求值顺序）。 */
-function statusLineOf(
-  state: SessionState,
-  opts: { connected: boolean; phase?: string; waiting: boolean },
-): string {
-  if (!opts.connected) return '连接中…'
-  if (opts.phase) return `${PHASE_LABEL[opts.phase] ?? opts.phase}…`
-  if (opts.waiting) return state.tailing ? '外部会话等待操作' : '等待审批'
-  const activeTaskCount = state.activeTaskCount ?? 0
-  if (activeTaskCount > 0) return `${activeTaskCount} 个后台任务运行中`
-  if (state.busy) return state.tailing ? '外部会话工作中' : '工作中'
-  if (state.spawned) return state.sessionState === 'idle' ? 'CLI 空闲' : 'CLI 运行中'
-  if (state.exited) return '进程已退出'
-  if (state.tailing) return '外部会话 · 实时跟踪中'
-  const hasPendingStartConfig = Boolean(state.model || state.permissionMode || state.effort)
-  return hasPendingStartConfig ? '配置已保存（发送消息时启动 CLI）' : '浏览中（发送消息时启动 CLI）'
-}
-
-/**
- * 把一条实时 sidechain CLI 消息（带 parent_tool_use_id 的完整 assistant/user）转成
- * HistoryMessage 形状，使其可以复用 appendHistoryMsg 落进后台任务桶。
- * 与 discovery.entryToHistoryMessage 的块映射保持一致（text/thinking/tool_use/tool_result）。
- */
-function cliSidechainToHistory(rec: Record<string, unknown>): HistoryMessage | null {
-  const type = rec.type
-  if (type !== 'assistant' && type !== 'user') return null
-  const content = (rec.message as { content?: unknown } | undefined)?.content
-  const blocks: { kind: 'text' | 'thinking' | 'tool_use' | 'tool_result'; text?: string; name?: string; id?: string; input?: unknown; isError?: boolean }[] = []
-  if (typeof content === 'string') {
-    if (content.trim()) blocks.push({ kind: 'text', text: content })
-  } else if (Array.isArray(content)) {
-    for (const c of content as Record<string, unknown>[]) {
-      if (c?.type === 'text' && typeof c.text === 'string' && c.text.trim()) blocks.push({ kind: 'text', text: c.text })
-      else if (c?.type === 'thinking' && typeof c.thinking === 'string' && c.thinking.trim())
-        blocks.push({ kind: 'thinking', text: c.thinking })
-      else if (c?.type === 'tool_use') blocks.push({ kind: 'tool_use', name: c.name as string, id: c.id as string, input: c.input })
-      else if (c?.type === 'tool_result')
-        blocks.push({ kind: 'tool_result', id: c.tool_use_id as string, text: toolResultText(c.content), isError: c.is_error === true })
-    }
-  }
-  if (blocks.length === 0) return null
-  return { uuid: rec.uuid as string | undefined, role: type, blocks, timestamp: rec.timestamp as string | undefined }
 }
 
 /** 后台任务桶：TaskFeed + 归并用的 tool 配对索引与去重集合（不发布给渲染） */
@@ -1262,112 +1189,82 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     sockRef.current?.send({ kind: 'update_env', variables: { CLAUDE_CODE_EFFORT_LEVEL: e } })
   }
 
+  /** 斜杠拦截动作的副作用执行器（拦截表本身已数据化下沉 lib/slashIntercept.ts，含判例注释） */
+  const runSlashAction = (a: SlashAction) => {
+    const sock = sockRef.current
+    switch (a.type) {
+      case 'openRewind':
+        setShowRewind(true)
+        return
+      case 'btw':
+        if (a.question) sock?.send({ kind: 'btw', question: a.question })
+        else pushSystem('用法：/btw <问题>')
+        return
+      case 'branch':
+        if (isCodex) pushSystem('Codex 请用「回滚」面板的从此处分叉')
+        else sock?.send({ kind: 'branch', ...(a.name ? { name: a.name } : {}) })
+        return
+      case 'exitHint':
+        pushSystem('此命令会终止 CLI 进程。要结束会话请回列表页归档（⌄ 按钮），进程回收由服务端空闲策略处理')
+        return
+      case 'compact':
+        sock?.send({ kind: 'control', subtype: 'compact' })
+        return
+      case 'context': {
+        // codex 无 get_context_usage 对应物；用状态里的累计 token 用量顶一句
+        const u = state.usage
+        pushSystem(
+          u
+            ? `◈ 线程累计：in ${u.inputTokens} / out ${u.outputTokens}${u.reasoningTokens ? ` / reasoning ${u.reasoningTokens}` : ''}（窗口占用明细请开「详情」）`
+            : '◈ 暂无用量数据（先跑一轮）',
+        )
+        return
+      }
+      case 'goal':
+        if (a.clear) sendGoal()
+        else if (a.condition) sendGoal(a.condition)
+        else pushSystem(state.goal ? `◎ 当前目标：${state.goal.condition}` : '用法：/goal <条件>，/goal clear 清除')
+        return
+      case 'review':
+        sock?.send({ kind: 'control', subtype: 'review', ...(a.instructions ? { extra: { instructions: a.instructions } } : {}) })
+        pushSystem(a.instructions ? `◈ 审查中：${a.instructions}` : '◈ 审查未提交的改动中…')
+        return
+      case 'rename':
+        if (!a.name) {
+          pushSystem('用法：/rename <新名字>')
+          return
+        }
+        sock?.send({ kind: 'control', subtype: 'rename', extra: { name: a.name } })
+        pushSystem(`✎ 重命名线程为「${a.name}」`)
+        return
+      case 'newThread': {
+        const cwd = session.cwd
+        if (cwd) {
+          void createSession(cwd, 'codex').then(({ key }) =>
+            props.onNavigate?.(
+              makeSessionInfo({ key, slug: 'codex', sessionId: 'new', cwd, backend: 'codex', status: 'offline' }),
+            ),
+          )
+        } else {
+          pushSystem('⚠ 未知当前目录，无法新建线程', 'error')
+        }
+        return
+      }
+    }
+  }
+
   const send = () => {
     const text = input.trim()
     const sock = sockRef.current
     if ((!text && pendingImages.length === 0) || !sock) return
 
-    // 斜杠命令拦截表：顺序即优先级，命中即拦截并清空输入框。
+    // 斜杠命令拦截：表与判例在 lib/slashIntercept.ts（顺序即优先级），命中即拦截并清空输入框。
     // codex 的斜杠命令不会被 app-server 解释（原样进模型上下文），有对应物的必须前端拦截。
-    const interceptors: Array<{ match: (t: string) => boolean; run: (t: string) => void }> = [
-      {
-        // /rewind 及其官方别名 /checkpoint /undo
-        match: (t) => t === '/rewind' || t === '/checkpoint' || t === '/undo',
-        run: () => setShowRewind(true),
-      },
-      {
-        match: (t) => /^\/btw(\s|$)/.test(t),
-        run: (t) => {
-          const q = t.slice(4).trim()
-          if (q) sock.send({ kind: 'btw', question: q })
-          else pushSystem('用法：/btw <问题>')
-        },
-      },
-      {
-        // 内建 /branch（有参时）会在 headless 下写孤立 fork 会话文件却不切换（context.resume 缺席），
-        // 必须全形拦截（含参数）；名字透传给分叉 spawn 的 -n
-        match: (t) => /^\/(branch|fork)(\s|$)/.test(t),
-        run: (t) => {
-          const name = t.match(/^\/(?:branch|fork)(?:\s+(.*))?$/)?.[1]?.trim()
-          if (isCodex) pushSystem('Codex 请用「回滚」面板的从此处分叉')
-          else sock.send({ kind: 'branch', ...(name ? { name } : {}) })
-        },
-      },
-      {
-        // /exit /quit headless 下会真的杀掉 CLI 进程——web 场景下多半是误触，拦下给替代指引
-        match: (t) => t === '/exit' || t === '/quit',
-        run: () =>
-          pushSystem('此命令会终止 CLI 进程。要结束会话请回列表页归档（⌄ 按钮），进程回收由服务端空闲策略处理'),
-      },
-      {
-        match: (t) => isCodex && t === '/compact',
-        run: () => sock.send({ kind: 'control', subtype: 'compact' }),
-      },
-      {
-        match: (t) => isCodex && t === '/context',
-        run: () => {
-          // codex 无 get_context_usage 对应物；用状态里的累计 token 用量顶一句
-          const u = state.usage
-          pushSystem(
-            u
-              ? `◈ 线程累计：in ${u.inputTokens} / out ${u.outputTokens}${u.reasoningTokens ? ` / reasoning ${u.reasoningTokens}` : ''}（窗口占用明细请开「详情」）`
-              : '◈ 暂无用量数据（先跑一轮）',
-          )
-        },
-      },
-      {
-        match: (t) => isCodex && /^\/goal(\s|$)/.test(t),
-        run: (t) => {
-          const arg = t.slice(5).trim()
-          if (!arg) pushSystem(state.goal ? `◎ 当前目标：${state.goal.condition}` : '用法：/goal <条件>，/goal clear 清除')
-          else if (/^(clear|stop|off|reset|none|cancel)$/i.test(arg)) sendGoal()
-          else sendGoal(arg)
-        },
-      },
-      {
-        // codex review/start：无参审未提交改动，带参按自定义说明审（inline 在本线程跑）
-        match: (t) => isCodex && /^\/review(\s|$)/.test(t),
-        run: (t) => {
-          const instructions = t.slice(7).trim()
-          sock.send({ kind: 'control', subtype: 'review', ...(instructions ? { extra: { instructions } } : {}) })
-          pushSystem(instructions ? `◈ 审查中：${instructions}` : '◈ 审查未提交的改动中…')
-        },
-      },
-      {
-        match: (t) => isCodex && /^\/rename(\s|$)/.test(t),
-        run: (t) => {
-          const name = t.slice(7).trim()
-          if (!name) {
-            pushSystem('用法：/rename <新名字>')
-            return
-          }
-          sock.send({ kind: 'control', subtype: 'rename', extra: { name } })
-          pushSystem(`✎ 重命名线程为「${name}」`)
-        },
-      },
-      {
-        // codex /new 与 /clear 同为 thread/start 新线程：导航到 xn| 新会话页（懒启动）
-        match: (t) => isCodex && (t === '/new' || t === '/clear'),
-        run: () => {
-          const cwd = session.cwd
-          if (cwd) {
-            void createSession(cwd, 'codex').then(({ key }) =>
-              props.onNavigate?.(
-                makeSessionInfo({ key, slug: 'codex', sessionId: 'new', cwd, backend: 'codex', status: 'offline' }),
-              ),
-            )
-          } else {
-            pushSystem('⚠ 未知当前目录，无法新建线程', 'error')
-          }
-        },
-      },
-    ]
-    for (const it of interceptors) {
-      if (it.match(text)) {
-        it.run(text)
-        setInput('')
-        return
-      }
+    const action = interceptSlash(text, { isCodex })
+    if (action) {
+      runSlashAction(action)
+      setInput('')
+      return
     }
 
     const echoBlocks: Block[] = [

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type HistoryMessage, type HistoryResponse, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
+import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type HistoryResponse, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
 import { SessionSocket, type CliMsg, type ServerEvent, type SessionState } from '../lib/ws'
 import { ApprovalCard } from '../components/ApprovalCard'
 import { ChatHeader } from '../components/ChatHeader'
@@ -7,14 +7,15 @@ import { Composer, imgPreviewSrc } from '../components/Composer'
 import { DetailDrawer, type ContextDataLite, type McpServerInfo, type SettingsDataLite } from '../components/DetailDrawer'
 import { RewindPicker } from '../components/RewindPicker'
 import { Transcript } from '../components/Transcript'
-import { TasksPanel, type TaskFeed } from '../components/TasksPanel'
+import { TasksPanel } from '../components/TasksPanel'
 import { ClaudeStar } from '../components/ClaudeStar'
 import { CodexMark } from '../components/CodexMark'
 import { buildTranscriptRows, nextId, rewindPreview, toolResultText, usageSummary, type Block, type ChatMsg } from '../lib/blocks'
-import { statusLineOf, cliSidechainToHistory } from '../lib/chatText'
+import { statusLineOf } from '../lib/chatText'
 import { interceptSlash, type SlashAction } from '../lib/slashIntercept'
-import { appendHistoryMsg, createIngestState, flushStrayResults, hitsSeen, indexToolBlocks, liveMessageKeys, pairToolResultIn, rememberKeys, transcriptKeys, type IngestState, type PendingResult, type ToolPos } from '../lib/ingest'
+import { appendHistoryMsg, createIngestState, flushStrayResults, hitsSeen, indexToolBlocks, liveMessageKeys, pairToolResultIn, rememberKeys, transcriptKeys, type IngestState } from '../lib/ingest'
 import { isCodexKey, isExistingKey } from '../lib/key'
+import { useTaskBuckets } from '../hooks/useTaskBuckets'
 
 interface Approval {
   requestId: string
@@ -37,25 +38,10 @@ interface Draft {
   blocks: DraftBlock[]
 }
 
-/** 后台任务桶：TaskFeed + 归并用的 tool 配对索引与去重集合（不发布给渲染） */
-interface TaskBucket extends TaskFeed {
-  toolIdx: Map<string, ToolPos>
-  /** 桶内乱序 tool_result 缓冲（与主线同规则，见 lib/ingest） */
-  pending: Map<string, PendingResult>
-  seen: Set<string>
-  /** codex 子线程转录已懒取过（防重取） */
-  transcriptFetched?: boolean
-}
-
-/**
- * 终态卡片的展示宽限期：镜像官方协调器面板的 PANEL_GRACE_MS
- *（claude-code src/utils/task/framework.ts:28）——完成后留 30s 供扫一眼报告，随后驱逐。
- * 报告摘要仍留在主线 Agent 工具卡与系统消息里，驱逐不丢信息。
- */
-const PANEL_GRACE_MS = 30_000
-
 export function Chat(props: { session: SessionInfo; onBack: () => void; onNavigate?: (s: SessionInfo) => void }) {
   const { session } = props
+  const isCodex = isCodexKey(session.key)
+  const isExisting = isExistingKey(session.key)
   const [messages, setMessages] = useState<ChatMsg[]>([])
   const [input, setInput] = useState('')
   const [state, setState] = useState<SessionState>({ spawned: false, busy: false })
@@ -112,122 +98,9 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const seenIdsRef = useRef(new Set<string>())
 
   // ---------- 后台任务（与主线并行的 agent/task/shell，右侧拉栏展示；task_type 全类型入桶） ----------
-  const taskMapRef = useRef(new Map<string, TaskBucket>())
-  const [tasks, setTasks] = useState<TaskFeed[]>([])
-  const [tasksOpen, setTasksOpen] = useState(false)
-
-  /** 发布桶快照：浅拷贝桶对象与消息数组，让 React 感知变化（事件为逐 turn 粒度，量小） */
-  const pubTasks = () =>
-    setTasks([...taskMapRef.current.values()].map((b) => ({ ...b, messages: [...b.messages] })))
-
-  const taskBucket = (toolUseId: string): TaskBucket => {
-    let b = taskMapRef.current.get(toolUseId)
-    if (!b) {
-      b = { toolUseId, status: 'running', messages: [], toolIdx: new Map(), pending: new Map(), seen: new Set() }
-      taskMapRef.current.set(toolUseId, b)
-    }
-    return b
-  }
-
-  const appendTaskMsg = (toolUseId: string, h: HistoryMessage) => {
-    const b = taskBucket(toolUseId)
-    // 历史加载与 live 追加可能重叠（落盘与 WS 投递交界），按 uuid 去重
-    if (h.uuid) {
-      if (b.seen.has(h.uuid)) return
-      b.seen.add(h.uuid)
-    }
-    const st: IngestState = { msgs: b.messages, toolIdx: b.toolIdx, pending: b.pending }
-    appendHistoryMsg(st, h)
-    b.messages = st.msgs
-  }
-
-  /** sidechain（子代理内部消息）不进主抄本——落进对应后台任务桶，右侧栏展示。
-   *  assistant（子代理输出）与 user（子代理 prompt / tool_result，桶内配对）两路同规则。 */
-  const appendSidechain = (rec: Record<string, unknown>): boolean => {
-    const ptui = rec.parent_tool_use_id as string | undefined
-    if (!ptui) return false
-    const h = cliSidechainToHistory(rec)
-    if (h) {
-      appendTaskMsg(ptui, h)
-      pubTasks()
-    }
-    return true
-  }
-
-  /** 统一终态：状态 + 清心跳 + 挂驱逐倒计时（宽限期后 1s 滴答自动移除卡片）。
-   *  live 与历史终态一视同仁——历史卡默示展示 30s 即足，长期驻留会让老会话侧栏越堆越多。 */
-  const markTerminal = (b: TaskBucket, status: TaskFeed['status']) => {
-    b.status = status
-    b.activity = undefined
-    b.evictAfter = Date.now() + PANEL_GRACE_MS
-    maybeFetchCodexTranscript(b)
-  }
-
-  /** 主线 tool_result 给运行中桶补终态：task_notification 未到的兜底，
-   *  也是外部会话（tailer 路径，无 task_notification）唯一的终态信号。 */
-  const settleBucketFromResult = (toolUseId: string | undefined, text: string, isError: boolean) => {
-    const b = toolUseId ? taskMapRef.current.get(toolUseId) : undefined
-    if (!b || b.status !== 'running') return
-    markTerminal(b, isError ? 'error' : 'done')
-    if (!b.summary && text) b.summary = text.slice(0, 500)
-    pubTasks()
-  }
-
-  /** codex 子代理转录懒取：子线程不被父通知流转发，终态后经 thread/read 拉回填充 */
-  const maybeFetchCodexTranscript = (b: TaskBucket) => {
-    if (!isCodex || !b.agentId || b.transcriptFetched || b.messages.length > 0) return
-    b.transcriptFetched = true
-    fetchCodexHistory(b.agentId)
-      .then((resp) => {
-        for (const h of resp.messages) appendTaskMsg(b.toolUseId, h)
-        pubTasks()
-      })
-      .catch(() => {})
-  }
-
-  /**
-   * 用 SessionState.activeTasks（服务端权威运行任务表）水合桶：
-   * 中途接入的客户端错过 live-only 的 task_started，没有这一步桶的首绘就会是终态。
-   * 反方向：桶还 running 却不在任务表且会话空闲 → 通知在断线间隙丢了，判终态。
-   * codex 服务端不维护任务表（状态里不带 activeTasks 字段），首行守卫直接跳过。
-   */
-  const hydrateTasks = (st: SessionState) => {
-    if (!Array.isArray(st.activeTasks)) return
-    let dirty = false
-    const live = new Set<string>()
-    for (const t of st.activeTasks) {
-      if (!t.toolUseId) continue
-      live.add(t.toolUseId)
-      const existing = taskMapRef.current.get(t.toolUseId)
-      if (existing) {
-        // 终态不被水合覆盖；running 的补心跳信息
-        if (existing.status === 'running' && t.lastToolName && existing.lastToolName !== t.lastToolName) {
-          existing.lastToolName = t.lastToolName
-          dirty = true
-        }
-        continue
-      }
-      const b = taskBucket(t.toolUseId)
-      b.status = 'running'
-      b.agentId = t.id // stop_task 需要 task_id，水合路径此前只建桶不记 agentId
-      b.description = t.description ?? b.description
-      b.agentType = t.taskType ?? b.agentType
-      b.kind = t.taskType ?? b.kind
-      b.lastToolName = t.lastToolName ?? b.lastToolName
-      b.depth = t.depth ?? b.depth
-      b.parentToolUseId = t.parentToolUseId ?? b.parentToolUseId
-      dirty = true
-    }
-    if (!st.busy) {
-      for (const b of taskMapRef.current.values()) {
-        if (b.status === 'running' && !live.has(b.toolUseId)) {
-          markTerminal(b, 'done')
-          dirty = true
-        }
-      }
-    }
-    if (dirty) pubTasks()
-  }
+  // 桶状态与辅助群已下沉 hooks/useTaskBuckets.ts（F3）：api 为每渲染重建的普通对象——
+  // 内部全走 ref/稳定 setState/isCodex（会话内不变），与此前过期闭包语义等价
+  const { tasks, tasksOpen, setTasksOpen, api: taskApi } = useTaskBuckets({ isCodex })
 
   const setMsgs = (up: (prev: ChatMsg[]) => ChatMsg[]) => {
     messagesRef.current = up(messagesRef.current)
@@ -249,8 +122,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const pushSystem = (text: string, kind: 'info' | 'error' = 'info') =>
     pushMsg({ id: nextId(), role: 'system', systemKind: kind, blocks: [{ kind: 'text', text }] })
 
-  const isCodex = isCodexKey(session.key)
-  const isExisting = isExistingKey(session.key)
   const loadSessionHistory = () =>
     isCodex ? fetchCodexHistory(session.sessionId) : fetchHistory(session.slug, session.sessionId)
   /** 当前会话权威 ID：spawn 后以 status 广播为准（/clear 重键、b| 分叉首条消息后的真实 id）；
@@ -300,27 +171,8 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     seenIdsRef.current = transcriptKeys(out)
 
     // 子代理侧链进桶；终态/报告以主线 Agent 工具卡的配对结果为准（tool_result 已落盘 = 已完成）
-    taskMapRef.current.clear()
-    // 先扫主线找「已完成」的 Agent 调用（转录落盘即终态），它们在历史加载时**不建桶**——
-    // 侧栏只放运行中与刚完成的卡，复活一堆 30s 后齐消失是噪声；翻旧账走主线 Agent 工具卡
-    const finished = new Set<string>()
-    for (const m of out) {
-      for (const blk of m.blocks) {
-        if (blk.kind === 'tool' && (blk.name === 'Agent' || blk.name === 'Task') && blk.pending === false && blk.id) {
-          finished.add(blk.id)
-        }
-      }
-    }
-    for (const s of resp.subagents ?? []) {
-      const id = s.toolUseId ?? s.agentId
-      if (!id || finished.has(id)) continue // 已完成的在历史里不复活
-      const b = taskBucket(id)
-      b.agentId = s.agentId ?? b.agentId
-      b.agentType = s.agentType ?? b.agentType
-      b.description = s.description ?? b.description
-      for (const h of s.messages) appendTaskMsg(b.toolUseId, h)
-    }
-    pubTasks()
+    //（清桶 + 未完成 subagent 回填的实现已随桶下沉 hooks/useTaskBuckets.ts）
+    taskApi.resetFromHistory(out, resp)
 
     // 从历史读取位置续订 transcript 追加（外部会话的实时更新）；socket 未 open 时会排队
     // codex 的实时流走 app-server 订阅（attach 即 resume），无 tailer
@@ -344,9 +196,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     setEffort(undefined)
     setApprovals([])
     setPhase(undefined)
-    taskMapRef.current.clear()
-    setTasks([])
-    setTasksOpen(false)
+    taskApi.clear()
     if (!isExisting) return
     loadSessionHistory()
       .then((resp) => {
@@ -360,25 +210,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       cancelled = true
     }
   }, [session.key])
-
-  // ---------- 终态卡片的 TTL 驱逐（仿官方协调器面板：1s 滴答扫 evictAfter） ----------
-  useEffect(() => {
-    const timer = setInterval(() => {
-      const now = Date.now()
-      let dirty = false
-      for (const [id, b] of taskMapRef.current) {
-        if (b.evictAfter != null && now >= b.evictAfter) {
-          // 报告摘要仍留在主线 Agent 工具卡与「⚙ 后台任务完成」系统消息里，驱逐不丢信息
-          taskMapRef.current.delete(id)
-          dirty = true
-        }
-      }
-      if (dirty) pubTasks()
-      // 桶清空时收起侧栏——此时会话无运行中任务（running 桶永不驱逐），收起的都是终态卡
-      if (dirty && taskMapRef.current.size === 0) setTasksOpen(false)
-    }, 1000)
-    return () => clearInterval(timer)
-  }, [])
 
   // ---------- 流式草稿 ----------
 
@@ -497,7 +328,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     }
 
     if (msg.type === 'assistant') {
-      if (appendSidechain(rec)) return
+      if (taskApi.appendSidechain(rec)) return
       const content = msg.message?.content
       const blocks = Array.isArray(content) ? content : []
       const msgId = (rec.message as { id?: string } | undefined)?.id
@@ -540,7 +371,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
 
     if (msg.type === 'user') {
       if (msg.isMeta) return
-      if (appendSidechain(rec)) return
+      if (taskApi.appendSidechain(rec)) return
       const content = msg.message?.content
       const blocks = Array.isArray(content) ? content : typeof content === 'string' ? [{ type: 'text', text: content }] : []
       const textBlocks: Block[] = []
@@ -549,7 +380,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
           const resultText = toolResultText(c.content)
           pairToolResult(c.tool_use_id, resultText, c.is_error === true)
           // 主线 Agent tool_result 是子代理的终态兜底（正常路径是 task_notification 先到）
-          settleBucketFromResult(c.tool_use_id, resultText, c.is_error === true)
+          taskApi.settleBucketFromResult(c.tool_use_id, resultText, c.is_error === true)
         } else if (c?.type === 'text' && c.text?.trim()) {
           // /goal 的评估器反馈（Stop hook）：goal 循环内的中途评估，渲染为系统提示而非用户气泡
           if (c.text.startsWith('Stop hook feedback:')) {
@@ -586,59 +417,22 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
         case 'thinking_tokens':
           break // 增量 token 估算，不展示
         case 'task_started': {
-          // 生命周期事件是桶的主注册点（tool_use_id ↔ task_id 映射在此建立）
-          const toolUseId = rec.tool_use_id as string | undefined
-          if (toolUseId) {
-            const b = taskBucket(toolUseId)
-            // claude 用 task_id；codex 合成事件经 agent_thread_id 携带子线程 id（终态后懒拉转录用），后者优先
-            b.agentId =
-              (rec.agent_thread_id as string | undefined) ?? (rec.task_id as string | undefined) ?? b.agentId
-            b.description = (rec.description as string | undefined) ?? b.description
-            b.agentType = (rec.subagent_type as string | undefined) ?? (rec.task_type as string | undefined) ?? b.agentType
-            b.kind = (rec.task_type as string | undefined) ?? b.kind
-            b.depth = (rec.spawn_depth as number | undefined) ?? b.depth
-            b.status = 'running'
-            pubTasks()
-            // 桌面端自动拉开侧栏（移动端屏幕小，只亮顶栏按钮）
-            if (window.matchMedia('(min-width: 768px)').matches) setTasksOpen(true)
-          }
+          // 生命周期事件是桶的主注册点（实现在 hooks/useTaskBuckets.ts）
+          taskApi.taskStarted(rec)
           if (!replay) pushSystem(`⚙ 后台任务启动：${String(rec.description ?? '')}`)
           break
         }
         case 'task_progress': {
-          // 心跳：拟人化动作描述 + 用量，解决"长 turn 安静期像卡住"的体感
-          // 桶不存在也补建——中途接入错过 task_started 时，心跳就是首个可见信号
-          const toolUseId = rec.tool_use_id as string | undefined
-          if (toolUseId) {
-            const b = taskBucket(toolUseId)
-            b.activity = (rec.description as string | undefined) ?? b.activity
-            b.lastToolName = (rec.last_tool_name as string | undefined) ?? b.lastToolName
-            b.usage = (rec.usage as TaskFeed['usage'] | undefined) ?? b.usage
-            pubTasks()
-          }
+          taskApi.taskProgress(rec)
           break
         }
         case 'task_updated': {
-          // 终态 patch（completed/stopped/failed）；只带 task_id，经 agentId 映射回桶
-          const taskId = rec.task_id as string | undefined
-          const patch = rec.patch as { status?: string } | undefined
-          const b = [...taskMapRef.current.values()].find((x) => x.agentId === taskId)
-          if (b && patch?.status && patch.status !== 'running' && b.status === 'running') {
-            markTerminal(b, patch.status === 'completed' ? 'done' : patch.status === 'stopped' ? 'stopped' : 'error')
-            pubTasks()
-          }
+          taskApi.taskUpdated(rec)
           break
         }
         case 'task_notification': {
           const summary = typeof rec.summary === 'string' ? rec.summary : ''
-          const toolUseId = rec.tool_use_id as string | undefined
-          if (toolUseId) {
-            const b = taskBucket(toolUseId)
-            markTerminal(b, rec.status === 'completed' ? 'done' : rec.status === 'stopped' ? 'stopped' : 'error')
-            b.summary = summary || b.summary
-            b.usage = (rec.usage as TaskFeed['usage'] | undefined) ?? b.usage
-            pubTasks()
-          }
+          taskApi.taskNotification(rec)
           if (!replay) pushSystem(`⚙ 后台任务完成${summary ? `：${summary.slice(0, 200)}` : ''}`)
           break
         }
@@ -687,7 +481,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             if (typeof ev.state.permissionMode === 'string') setPermMode(ev.state.permissionMode)
             if (typeof ev.state.effort === 'string') setEffort(ev.state.effort)
             // 服务端权威运行任务表水合任务桶（中途接入补建 / 断线丢通知判死）
-            hydrateTasks(ev.state)
+            taskApi.hydrateTasks(ev.state)
             // 进程已退出时固化/清理未完成的流式草稿，避免半截内容悬挂
             if (ev.state.exited) {
               commitDraft()
@@ -919,7 +713,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             // task_notification，这是它唯一的终态信号；与历史回填同规则：终态挂 30s 驱逐
             for (const blk of h.blocks) {
               if (blk.kind !== 'tool_result' || !blk.id) continue
-              settleBucketFromResult(blk.id, blk.text ?? '', blk.isError === true)
+              taskApi.settleBucketFromResult(blk.id, blk.text ?? '', blk.isError === true)
             }
             break
           }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,56 +1,25 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type HistoryMessage, type HistoryResponse, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
 import { SessionSocket, type CliMsg, type ServerEvent, type SessionState } from '../lib/ws'
-import { StatusPill } from '../components/StatusPill'
 import { ApprovalCard } from '../components/ApprovalCard'
+import { ChatHeader } from '../components/ChatHeader'
+import { Composer, imgPreviewSrc } from '../components/Composer'
+import { DetailDrawer, type ContextDataLite, type McpServerInfo, type SettingsDataLite } from '../components/DetailDrawer'
 import { RewindPicker } from '../components/RewindPicker'
 import { Transcript } from '../components/Transcript'
 import { TasksPanel, type TaskFeed } from '../components/TasksPanel'
-import { ClaudeMark } from '../components/ClaudeMark'
 import { ClaudeStar } from '../components/ClaudeStar'
 import { CodexMark } from '../components/CodexMark'
-import { PopupPanel } from '../components/PopupPanel'
-import { ContextRing } from '../components/ContextRing'
-import { buildTranscriptRows, fmtTokens, nextId, rewindPreview, toolResultText, usageSummary, type Block, type ChatMsg } from '../lib/blocks'
-import { copyText, statusLineOf, cliSidechainToHistory } from '../lib/chatText'
+import { buildTranscriptRows, nextId, rewindPreview, toolResultText, usageSummary, type Block, type ChatMsg } from '../lib/blocks'
+import { statusLineOf, cliSidechainToHistory } from '../lib/chatText'
 import { interceptSlash, type SlashAction } from '../lib/slashIntercept'
 import { appendHistoryMsg, createIngestState, flushStrayResults, hitsSeen, indexToolBlocks, liveMessageKeys, pairToolResultIn, rememberKeys, transcriptKeys, type IngestState, type PendingResult, type ToolPos } from '../lib/ingest'
 import { isCodexKey, isExistingKey } from '../lib/key'
-import { COMMAND_DESC, filterSlashHints, mergeSlashCommands, type SlashEntry } from '../lib/slashCommands'
-
-const MORE_ITEM =
-  'flex w-full items-center gap-2 rounded-[10px] px-3 py-2 text-left font-mono text-[12px] text-muted transition-colors hover:bg-surface hover:text-ink'
 
 interface Approval {
   requestId: string
   toolName: string
   input: unknown
-}
-
-/** claude mcp_status 应答里的单个服务器（buildMcpServerStatuses 形状） */
-interface McpServerInfo {
-  name: string
-  /** connected / failed / disabled / pending / needs-auth 等（CLI 的 connection.type 直出） */
-  status: string
-  error?: string
-  config?: { type?: string; command?: string; args?: string[]; url?: string }
-  scope?: string
-  tools?: { name: string }[]
-}
-
-/** claude get_context_usage 应答的取用子集（analyzeContext 的 ContextData 里我们渲染的部分） */
-interface ContextDataLite {
-  categories: { name: string; tokens: number; isDeferred?: boolean }[]
-  totalTokens: number
-  maxTokens: number
-  percentage: number
-  model?: string
-}
-
-/** claude get_settings 应答的取用子集（settings 全量不枚举——applied + sources 概览 + 原始 JSON 折叠） */
-interface SettingsDataLite {
-  applied?: { model?: string; effort?: string | null }
-  sources?: { source: string; settings: Record<string, unknown> }[]
 }
 
 /** 流式草稿：一轮 assistant 输出的增量块（按 message.id + block index 归并） */
@@ -107,7 +76,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const [pendingImages, setPendingImages] = useState<
     Array<{ name: string; mediaType: string; dataBase64: string }>
   >([])
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const [detailOpen, setDetailOpen] = useState(false)
   const [detailTitle, setDetailTitle] = useState('')
   const [detailContent, setDetailContent] = useState('加载中…')
@@ -124,12 +92,9 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const [goalOpen, setGoalOpen] = useState(false)
   const [goalDraft, setGoalDraft] = useState('')
   const [moreOpen, setMoreOpen] = useState(false)
-  const moreBtnRef = useRef<HTMLButtonElement>(null)
-  const [idCopied, setIdCopied] = useState(false)
   const querySeq = useRef(0)
   const sockRef = useRef<SessionSocket | undefined>(undefined)
   const scrollRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLTextAreaElement>(null)
   const [atBottom, setAtBottom] = useState(true)
   const atBottomRef = useRef(true)
 
@@ -319,37 +284,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       )
       .catch(() => {})
   }, [session.key])
-
-  /** claude 权限模式名 → codex 预设档位（显示用） */
-  const codexModeOf = (m?: string): string => {
-    switch (m) {
-      case 'bypassPermissions':
-        return 'fullAccess'
-      case 'acceptEdits':
-      case 'auto':
-        return 'workspaceAuto'
-      case 'plan':
-        return 'readOnly'
-      case 'readOnly':
-      case 'workspace':
-      case 'workspaceAuto':
-      case 'fullAccess':
-        return m
-      default:
-        return 'workspace'
-    }
-  }
-
-  const codexDefaultModel = codexModels?.find((m) => m.isDefault) ?? codexModels?.[0]
-  const codexModelId = state.model ?? codexDefaultModel?.id
-  const codexCurrentModel = codexModels?.find((m) => m.id === codexModelId) ?? codexDefaultModel
-  const codexEffortLevels: readonly string[] = codexCurrentModel?.efforts.map((e) => e.value) ?? ['low', 'high', 'max']
-  const codexCfg: ServerConfigInfo = {
-    permissionPolicy: 'ask',
-    permissionModes: ['readOnly', 'workspace', 'workspaceAuto', 'fullAccess'],
-    effortLevels: [...codexEffortLevels],
-    models: (codexModels ?? []).map((m) => m.id),
-  }
 
   /** 历史响应落到消息列表 + 从读取位置续订 tail（初次加载与 tail_reset 重载共用） */
   const applyHistory = (resp: HistoryResponse) => {
@@ -1091,17 +1025,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     scheduleFollow(!draft) // 流式进行中走 auto，收尾/新消息才用 smooth
   }, [messages, approvals, draft])
 
-  // 输入框自适应高度：随内容增长，超过 200px 后不再扩大、内部滚动。
-  // 注意 border-box：style.height 包含边框，需补回上下边框宽，否则单行时内容被裁出滚动条
-  useEffect(() => {
-    const el = inputRef.current
-    if (!el) return
-    el.style.height = 'auto'
-    const h = el.scrollHeight + (el.offsetHeight - el.clientHeight)
-    el.style.height = `${Math.min(h, 200)}px`
-    el.style.overflowY = h > 200 ? 'auto' : 'hidden'
-  }, [input])
-
   const onScroll = () => {
     const el = scrollRef.current
     if (!el) return
@@ -1142,28 +1065,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       extra: { serverName, ...(enabled === undefined ? {} : { enabled }) },
     })
   }
-
-  const pickImages = (files: FileList | null) => {
-    if (!files) return
-    for (const f of Array.from(files)) {
-      if (!f.type.startsWith('image/')) continue
-      const reader = new FileReader()
-      reader.onload = () => {
-        const url = String(reader.result ?? '')
-        const comma = url.indexOf(',')
-        if (comma < 0) return
-        setPendingImages((prev) => [
-          ...prev,
-          { name: f.name, mediaType: f.type, dataBase64: url.slice(comma + 1) },
-        ])
-      }
-      reader.readAsDataURL(f)
-    }
-  }
-
-  /** 预览 src：dataURL 与传输用 base64 本是一份数据，渲染时派生 */
-  const imgPreviewSrc = (img: { mediaType: string; dataBase64: string }) =>
-    `data:${img.mediaType};base64,${img.dataBase64}`
 
   // ---------- goal 设定/清除：claude 走 /goal 斜杠命令（本地命令，不进模型上下文），codex 走 thread/goal RPC ----------
   const sendGoal = (condition?: string) => {
@@ -1296,31 +1197,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       })
   }, [showRewind, messages])
 
-  // 优先 initialize 握手返回的命令（含描述），其次 init 消息的命令名，最后空清单（合并层用自有命令兜底）
-  const cliEntries: SlashEntry[] = state.slashCommands?.length
-    ? state.slashCommands.map((c) => ({ name: c.name, desc: c.description }))
-    : (initInfo.slashCommands ?? []).map((n) => ({ name: n, desc: COMMAND_DESC[n] }))
-  // anyplane 自有命令置顶（中文描述优先于 CLI 同名命令），其后是 CLI 报告的完整清单
-  const allEntries = mergeSlashCommands(cliEntries)
-  const slashHints = filterSlashHints(input, allEntries)
-  // 键盘导航：↑↓ 移动，Tab/Enter 采纳，Esc 关闭（索引随清单变化钳位）
-  const [slashIdx, setSlashIdx] = useState(0)
-  const slashActive = slashHints.length > 0 ? Math.min(slashIdx, slashHints.length - 1) : 0
-  /** 面板滚动容器：键盘导航时保证高亮行在视口内 */
-  const slashScrollRef = useRef<HTMLDivElement>(null)
-
-  // 高亮行跟随滚动：只滚面板容器（getBoundingClientRect 相对数学），不动页面滚动条
-  useEffect(() => {
-    const c = slashScrollRef.current
-    if (!c || slashHints.length === 0) return
-    const row = c.querySelectorAll('button')[slashActive]
-    if (!row) return
-    const cRect = c.getBoundingClientRect()
-    const rRect = row.getBoundingClientRect()
-    if (rRect.top < cRect.top) c.scrollTop -= cRect.top - rRect.top
-    else if (rRect.bottom > cRect.bottom) c.scrollTop += rRect.bottom - cRect.bottom
-  }, [slashActive, slashHints.length])
-
   // 渲染行在 Chat 层算：Transcript 保持纯展示，重进/重渲时不重复摊平
   const transcriptRows = useMemo(() => buildTranscriptRows(messages, draft), [messages, draft])
 
@@ -1357,433 +1233,68 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       </div>
 
       {/* 顶栏：悬浮磨砂横带 */}
-      <div className="glass-bar absolute inset-x-0 top-0 z-30">
-        <div className="px-3 py-2.5">
-          <div className="flex items-center gap-2">
-            <button
-              className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-surface2 text-muted transition-colors hover:text-ink md:hidden"
-              onClick={props.onBack}
-              title="返回列表"
-              aria-label="返回列表"
-            >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
-                <path d="M19 12H5M12 19l-7-7 7-7" />
-              </svg>
-            </button>
-            <div className="min-w-0 flex-1">
-              <div className="truncate text-sm font-medium">{session.title ?? session.cwd ?? session.sessionId}</div>
-              <div className="flex items-center gap-2 font-mono text-[10px] tracking-wide text-faint">
-                <span className={connected ? 'text-ok' : 'text-accent'}>{connected ? '●' : '○'}</span>
-                <span className={busy || phase ? 'text-busy' : ''}>{statusLine}</span>
-              </div>
-            </div>
-            {/* 后台任务侧栏开关：有任务活动时出现；运行中带计数徽标与呼吸 */}
-            {tasks.length > 0 && (
-              <button
-                type="button"
-                className={`relative grid h-8 w-8 shrink-0 place-items-center rounded-full transition-colors ${
-                  tasksOpen ? 'bg-surface2 text-ink' : 'bg-surface2 text-muted hover:text-ink'
-                }`}
-                title="后台任务"
-                aria-label="后台任务"
-                aria-expanded={tasksOpen}
-                onClick={() => setTasksOpen((v) => !v)}
-              >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden>
-                  <path d="M6 3v12" />
-                  <circle cx="18" cy="6" r="3" />
-                  <circle cx="6" cy="18" r="3" />
-                  <path d="M18 9a9 9 0 0 1-9 9" />
-                </svg>
-                {tasks.some((s) => s.status === 'running') && (
-                  <span className="absolute top-0.5 right-0.5 size-1.5 animate-pulse rounded-full bg-busy" aria-hidden />
-                )}
-              </button>
-            )}
-            {(isExisting || !isCodex || state.sessionId) && (
-              <>
-                <button
-                  ref={moreBtnRef}
-                  type="button"
-                  className={`relative grid h-8 w-8 shrink-0 place-items-center rounded-full transition-colors ${
-                    moreOpen ? 'bg-surface2 text-ink' : 'bg-surface2 text-muted hover:text-ink'
-                  }`}
-                  title="更多"
-                  aria-label="更多"
-                  aria-haspopup="menu"
-                  aria-expanded={moreOpen}
-                  onClick={() => setMoreOpen((v) => !v)}
-                >
-                  <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4" aria-hidden>
-                    <circle cx="5" cy="12" r="1.8" />
-                    <circle cx="12" cy="12" r="1.8" />
-                    <circle cx="19" cy="12" r="1.8" />
-                  </svg>
-                  {state.goal && (
-                    <span className="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-ok" aria-hidden />
-                  )}
-                </button>
-                <PopupPanel
-                  open={moreOpen}
-                  anchor={moreBtnRef.current}
-                  onClose={() => setMoreOpen(false)}
-                  placement="bottom-end"
-                  offset={6}
-                  className="min-w-44"
-                >
-                  {currentSessionId && (
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={`${MORE_ITEM} ${idCopied ? 'text-ok hover:text-ok' : ''}`}
-                      title={`${isCodex ? 'thread id' : 'session id'}：${currentSessionId}（点击复制完整 ID）`}
-                      onClick={() => {
-                        void copyText(currentSessionId).then((ok) => {
-                          if (!ok) {
-                            setMoreOpen(false)
-                            pushSystem(`⚠ 复制失败，请手动复制：${currentSessionId}`, 'error')
-                            return
-                          }
-                          setIdCopied(true)
-                          setTimeout(() => {
-                            setIdCopied(false)
-                            setMoreOpen(false)
-                          }, 900)
-                        })
-                      }}
-                    >
-                      {idCopied ? '✓ 已复制' : `⧉ ${currentSessionId.slice(0, 8)}…`}
-                    </button>
-                  )}
-                  {isExisting && (
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={MORE_ITEM}
-                      title="会话详情：context 用量 / MCP 状态 / 设置"
-                      onClick={() => {
-                        setMoreOpen(false)
-                        setDetailOpen((v) => !v)
-                        // codex 无 get_context_usage 对应物，默认落在 MCP 状态上
-                        if (!detailOpen) runQuery(isCodex ? 'mcp_status' : 'get_context_usage', isCodex ? 'MCP 状态' : 'context 用量')
-                      }}
-                    >
-                      ▤ 详情
-                    </button>
-                  )}
-                  {(!isCodex || state.sessionId) && (
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={`${MORE_ITEM} ${state.goal ? 'text-ok hover:text-ok' : ''}`}
-                      title={
-                        state.goal
-                          ? `当前目标：${state.goal.condition}（点击管理）`
-                          : '设定目标：agent 会持续工作直到条件达成（claude /goal · codex thread/goal）'
-                      }
-                      onClick={() => {
-                        setMoreOpen(false)
-                        setGoalDraft(state.goal?.condition ?? '')
-                        setGoalOpen((v) => !v)
-                      }}
-                    >
-                      {state.goal
-                        ? `◎ ${state.goal.condition.slice(0, 16)}${state.goal.condition.length > 16 ? '…' : ''}`
-                        : '◎ 目标'}
-                    </button>
-                  )}
-                  {isExisting && !isCodex && (
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={MORE_ITEM}
-                      title="分叉当前会话：新分支携带全部历史，原会话保持不动"
-                      onClick={() => {
-                        setMoreOpen(false)
-                        sockRef.current?.send({ kind: 'branch' })
-                      }}
-                    >
-                      ⎇ 分叉
-                    </button>
-                  )}
-                  {isExisting && (
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={`${MORE_ITEM} disabled:opacity-40`}
-                      disabled={handoffBusy}
-                      title="让另一个 agent 接续本目录的工作（源会话 fork 自写简报，目标会话带简报进场）"
-                      onClick={() => {
-                        setMoreOpen(false)
-                        const toBackend = isCodex ? 'claude' : 'codex'
-                        setHandoffBusy(true)
-                        startHandoff(session.key, toBackend)
-                          .catch((e) => pushSystem(`⚠ 接力失败: ${e instanceof Error ? e.message : e}`, 'error'))
-                          .finally(() => setHandoffBusy(false))
-                      }}
-                    >
-                      {handoffBusy ? '接力中…' : `⇄ 接力给${isCodex ? ' Claude' : ' Codex'}`}
-                    </button>
-                  )}
-                </PopupPanel>
-              </>
-            )}
-          </div>
-          {usageLine && (
-            <div className="mt-1 font-mono text-[10px] tracking-wide text-faint/80">{usageLine}</div>
-          )}
-          {goalOpen && (
-            <div className="mt-2 rounded-[14px] bg-surface2/80 p-2.5 backdrop-blur-xl">
-              <div className="mb-1.5 flex items-center justify-between">
-                <span className="font-mono text-[10px] tracking-wide text-faint">
-                  ◎ 会话目标{state.goal ? '（进行中）' : ''}——agent 会持续工作直到条件达成
-                </span>
-                <button className="font-mono text-[10px] text-faint hover:text-muted" onClick={() => setGoalOpen(false)}>
-                  ✕
-                </button>
-              </div>
-              {state.goal && (
-                <div className="mb-1.5 font-mono text-[11px] leading-relaxed text-ok">
-                  当前：{state.goal.condition}
-                  {state.goal.tokensUsed != null && (
-                    <span className="text-faint"> · {state.goal.tokensUsed} tok</span>
-                  )}
-                </div>
-              )}
-              <div className="flex gap-1.5">
-                <input
-                  className="min-w-0 flex-1 rounded-full bg-bg/60 px-3 py-1.5 font-mono text-[11px] text-ink outline-none placeholder:text-faint/60"
-                  placeholder={isCodex ? '如：迁移完所有调用点并通过测试' : '如：test/auth 全部通过且 lint 干净'}
-                  value={goalDraft}
-                  onChange={(e) => setGoalDraft(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && goalDraft.trim()) {
-                      sendGoal(goalDraft.trim())
-                      setGoalOpen(false)
-                    }
-                  }}
-                />
-                <button
-                  className="shrink-0 rounded-full bg-ink px-3 py-1.5 font-mono text-[11px] text-bg disabled:opacity-40"
-                  disabled={!goalDraft.trim()}
-                  onClick={() => {
-                    if (!goalDraft.trim()) return
-                    sendGoal(goalDraft.trim())
-                    setGoalOpen(false)
-                  }}
-                >
-                  设定
-                </button>
-                {state.goal && (
-                  <button
-                    className="shrink-0 rounded-full px-3 py-1.5 font-mono text-[11px] text-accent hover:bg-accent/10"
-                    onClick={() => {
-                      sendGoal()
-                      setGoalOpen(false)
-                    }}
-                  >
-                    清除
-                  </button>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* 接力链导航条：仅在当前会话参与血缘时出现 */}
-        {lineage && (
-          <div className="flex items-center gap-1.5 overflow-x-auto px-3 py-1.5 font-mono text-[10px]">
-            <span className="shrink-0 text-faint">⇄ 接力链:</span>
-            {lineage.records
-              .map((r) => {
-                const fromKey = r.fromResolvedKey ?? r.fromKey
-                const toKey = r.toResolvedKey ?? r.toKey
-                const node = (k: string, backend: 'claude' | 'codex') => {
-                  const info = lineage.nodes[k]
-                  const current = k === session.key
-                  return (
-                    <button
-                      key={k}
-                      disabled={!info}
-                      onClick={() => info && props.onNavigate?.(info)}
-                      className={`flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 ${
-                        current
-                          ? 'bg-surface2 text-ink'
-                          : 'text-faint hover:text-muted'
-                      }`}
-                      title={k}
-                    >
-                      {backend === 'codex' ? <CodexMark size={10} /> : <ClaudeMark className="h-2.5 w-2.5" />}
-                      {new Date(r.at).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' })}
-                    </button>
-                  )
-                }
-                return (
-                  <span key={r.id} className="flex shrink-0 items-center gap-1.5">
-                    {node(fromKey, r.fromBackend)}
-                    <span className="text-faint/60">→</span>
-                    {node(toKey, r.toBackend)}
-                  </span>
-                )
-              })}
-          </div>
-        )}
-
-        {/* 后台任务 Chips 已并入右侧「后台任务」面板（运行中卡片上有停止按钮） */}
-
+      <ChatHeader
+        session={session}
+        connected={connected}
+        statusLine={statusLine}
+        busy={busy}
+        phase={phase}
+        onBack={props.onBack}
+        tasks={tasks}
+        tasksOpen={tasksOpen}
+        onToggleTasks={() => setTasksOpen((v) => !v)}
+        isExisting={isExisting}
+        isCodex={isCodex}
+        sessionId={state.sessionId}
+        currentSessionId={currentSessionId}
+        goal={state.goal}
+        usageLine={usageLine}
+        moreOpen={moreOpen}
+        setMoreOpen={setMoreOpen}
+        onSystemMessage={pushSystem}
+        onToggleDetail={() => {
+          setDetailOpen((v) => !v)
+          // codex 无 get_context_usage 对应物，默认落在 MCP 状态上
+          if (!detailOpen) runQuery(isCodex ? 'mcp_status' : 'get_context_usage', isCodex ? 'MCP 状态' : 'context 用量')
+        }}
+        goalOpen={goalOpen}
+        onToggleGoal={() => {
+          setGoalDraft(state.goal?.condition ?? '')
+          setGoalOpen((v) => !v)
+        }}
+        onCloseGoal={() => setGoalOpen(false)}
+        goalDraft={goalDraft}
+        onGoalDraftChange={setGoalDraft}
+        onSendGoal={sendGoal}
+        onBranch={() => sockRef.current?.send({ kind: 'branch' })}
+        handoffBusy={handoffBusy}
+        onHandoff={() => {
+          const toBackend = isCodex ? 'claude' : 'codex'
+          setHandoffBusy(true)
+          startHandoff(session.key, toBackend)
+            .catch((e) => pushSystem(`⚠ 接力失败: ${e instanceof Error ? e.message : e}`, 'error'))
+            .finally(() => setHandoffBusy(false))
+        }}
+        lineage={lineage}
+        onNavigate={props.onNavigate}
+      >
         {/* 会话详情抽屉 */}
         {detailOpen && (
-          <div className="px-3 py-2">
-            <div className="mb-1.5 flex items-center gap-2 font-mono text-[11px]">
-              <span className="text-muted">{detailTitle}</span>
-              {/* codex 只有 mcp_status 有对应物（mcpServerStatus/list）；context/设置是 claude 控制请求 */}
-              {(isCodex ? (['mcp_status'] as const) : (['get_context_usage', 'mcp_status', 'get_settings'] as const)).map((q) => (
-                <button
-                  key={q}
-                  className="rounded-full bg-surface px-2.5 py-1 text-[10px] text-faint hover:text-ink"
-                  onClick={() =>
-                    runQuery(q, q === 'get_context_usage' ? 'context 用量' : q === 'mcp_status' ? 'MCP 状态' : '设置')
-                  }
-                >
-                  {q === 'get_context_usage' ? 'context' : q === 'mcp_status' ? 'MCP' : '设置'}
-                </button>
-              ))}
-              <button className="ml-auto text-faint hover:text-muted" onClick={() => setDetailOpen(false)}>
-                ✕
-              </button>
-            </div>
-            {detailTitle === 'MCP 状态' && !isCodex && mcpServers ? (
-              /* claude MCP 管理面板：状态 + 重连/启停（toggle 持久化到 settings，与 TUI 同语义） */
-              <div className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5">
-                {mcpServers.length === 0 && (
-                  <div className="py-1 font-mono text-[10px] text-faint">无 MCP 服务器（在 claude 配置里添加后出现）</div>
-                )}
-                {mcpServers.map((srv) => {
-                  const meta =
-                    srv.status === 'connected'
-                      ? { dot: 'bg-ok', label: '已连接' }
-                      : srv.status === 'failed'
-                        ? { dot: 'bg-danger', label: '失败' }
-                        : srv.status === 'disabled'
-                          ? { dot: 'bg-faint', label: '已禁用' }
-                          : { dot: 'bg-wait', label: srv.status }
-                  const configLine = srv.config?.url
-                    ? srv.config.url
-                    : srv.config?.command
-                      ? `${srv.config.command} ${(srv.config.args ?? []).join(' ')}`.trim()
-                      : (srv.config?.type ?? '')
-                  const reconnecting = mcpBusy === `${srv.name}:mcp_reconnect`
-                  const toggling = mcpBusy === `${srv.name}:mcp_toggle`
-                  return (
-                    <div key={srv.name} className="flex items-center gap-2 py-1">
-                      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${meta.dot}`} />
-                      <div className="min-w-0 flex-1">
-                        <div className="font-mono text-[11px] text-ink">
-                          {srv.name}
-                          <span className="text-faint">
-                            {' '}
-                            {meta.label}
-                            {srv.status === 'connected' && srv.tools ? ` · ${srv.tools.length} 工具` : ''}
-                            {srv.scope ? ` · ${srv.scope}` : ''}
-                          </span>
-                        </div>
-                        {configLine && <div className="truncate font-mono text-[10px] text-faint">{configLine}</div>}
-                        {srv.error && <div className="truncate font-mono text-[10px] text-danger">{srv.error}</div>}
-                      </div>
-                      <button
-                        className="shrink-0 rounded-full bg-surface2 px-2.5 py-1 font-mono text-[10px] text-faint hover:text-ink disabled:opacity-40"
-                        disabled={!!mcpBusy || srv.status === 'disabled'}
-                        title="重新连接（mcp_reconnect）"
-                        onClick={() => mcpAction(srv.name, 'mcp_reconnect')}
-                      >
-                        {reconnecting ? '…' : '重连'}
-                      </button>
-                      <button
-                        className="shrink-0 rounded-full bg-surface2 px-2.5 py-1 font-mono text-[10px] text-faint hover:text-ink disabled:opacity-40"
-                        disabled={!!mcpBusy}
-                        title={srv.status === 'disabled' ? '启用并连接（写入 settings）' : '禁用并断开（写入 settings）'}
-                        onClick={() => mcpAction(srv.name, 'mcp_toggle', srv.status === 'disabled')}
-                      >
-                        {toggling ? '…' : srv.status === 'disabled' ? '启用' : '禁用'}
-                      </button>
-                    </div>
-                  )
-                })}
-              </div>
-            ) : detailTitle === 'context 用量' && !isCodex && contextData ? (
-              /* claude context 结构化：总量条 + 分类占比（deferred 类别淡显） */
-              <div className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5">
-                <div className="mb-1.5 flex items-baseline justify-between font-mono text-[11px] text-ink">
-                  <span>
-                    {fmtTokens(contextData.totalTokens)} / {fmtTokens(contextData.maxTokens)} tok ·{' '}
-                    {contextData.percentage.toFixed(1)}%
-                  </span>
-                  {contextData.model && (
-                    <span className="text-[10px] text-faint">
-                      {modelNames?.[contextData.model]?.name ?? contextData.model}
-                    </span>
-                  )}
-                </div>
-                <div className="mb-2 h-1 overflow-hidden rounded-full bg-surface2">
-                  <div
-                    className="h-full bg-ink/60"
-                    style={{ width: `${Math.min(100, contextData.percentage)}%` }}
-                  />
-                </div>
-                {contextData.categories.map((c) => (
-                  <div key={c.name} className={`flex items-center gap-2 py-0.5 ${c.isDeferred ? 'opacity-50' : ''}`}>
-                    <span className="w-28 shrink-0 truncate font-mono text-[10px] text-muted" title={c.name}>
-                      {c.name}
-                    </span>
-                    <div className="h-1 flex-1 overflow-hidden rounded-full bg-surface2">
-                      <div
-                        className={`h-full ${c.isDeferred ? 'bg-faint' : 'bg-muted'}`}
-                        style={{
-                          width: `${Math.min(100, (c.tokens / Math.max(1, contextData.maxTokens)) * 100)}%`,
-                        }}
-                      />
-                    </div>
-                    <span className="w-12 shrink-0 text-right font-mono text-[10px] text-faint">
-                      {fmtTokens(c.tokens)}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            ) : detailTitle === '设置' && !isCodex && settingsData ? (
-              /* claude 设置轻结构：生效值 + 来源概览；全量设置不枚举，原始 JSON 折叠兜底 */
-              <div className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5">
-                {settingsData.applied && (
-                  <div className="mb-1.5 font-mono text-[11px] text-ink">
-                    当前生效：
-                    <span className="text-muted">
-                      {modelNames?.[settingsData.applied.model ?? '']?.name ?? settingsData.applied.model ?? 'default'}
-                    </span>
-                    <span className="text-faint"> · effort {settingsData.applied.effort ?? '默认'}</span>
-                  </div>
-                )}
-                {(settingsData.sources ?? []).map((s) => (
-                  <div key={s.source} className="flex items-center gap-2 py-0.5 font-mono text-[10px]">
-                    <span className="text-muted">{s.source}</span>
-                    <span className="text-faint">{Object.keys(s.settings ?? {}).length} 项</span>
-                  </div>
-                ))}
-                <details className="mt-1.5">
-                  <summary className="cursor-pointer font-mono text-[10px] text-faint hover:text-muted">
-                    原始 JSON
-                  </summary>
-                  <pre className="mt-1 max-h-40 overflow-auto rounded-[10px] bg-bg/60 p-2 font-mono text-[10px] whitespace-pre-wrap text-muted">
-                    {detailContent}
-                  </pre>
-                </details>
-              </div>
-            ) : (
-              <pre className="max-h-56 overflow-auto rounded-[14px] bg-surface p-2.5 font-mono text-[10px] whitespace-pre-wrap text-muted">
-                {detailContent}
-              </pre>
-            )}
-          </div>
+          <DetailDrawer
+            detailTitle={detailTitle}
+            detailContent={detailContent}
+            isCodex={isCodex}
+            mcpServers={mcpServers}
+            mcpBusy={mcpBusy}
+            onMcpAction={mcpAction}
+            contextData={contextData}
+            settingsData={settingsData}
+            modelNames={modelNames}
+            onRunQuery={runQuery}
+            onClose={() => setDetailOpen(false)}
+          />
         )}
-      </div>
+      </ChatHeader>
 
       {showRewind && (
         <RewindPicker
@@ -1807,247 +1318,52 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       )}
 
       {/* 输入区：悬浮磨砂圆角块；模型胶囊 / 图片 / 发送全收进块内 */}
-      <div className="absolute inset-x-0 bottom-0 z-30 px-3 pb-3 pt-2">
-        <div className="mx-auto max-w-3xl">
-          {slashHints.length > 0 && (
-            <div className="mb-2 rounded-[14px] bg-surface2/85 p-1 shadow-[0_16px_40px_-12px_rgba(0,0,0,0.5)] backdrop-blur-xl">
-              {/* 完整清单可滚动（CLI initialize 握手报告多少就列多少），自有命令置顶；键盘导航时高亮行跟随滚动 */}
-              <div ref={slashScrollRef} className="max-h-60 overflow-y-auto">
-                {slashHints.map((c, i) => (
-                  <button
-                    key={c.name}
-                    className={`flex w-full items-center gap-2 rounded-[10px] px-2.5 py-1.5 text-left ${
-                      i === slashActive ? 'bg-surface' : 'hover:bg-surface'
-                    }`}
-                    onMouseEnter={() => setSlashIdx(i)}
-                    onClick={() => {
-                      setInput(`/${c.name} `)
-                      setSlashIdx(0)
-                      inputRef.current?.focus()
-                    }}
-                  >
-                    <span className="font-mono text-[12px] text-ink">/{c.name}</span>
-                    {c.desc && <span className="truncate text-xs text-faint">{c.desc}</span>}
-                  </button>
-                ))}
-              </div>
-              <div className="px-2.5 py-1 font-mono text-[9px] tracking-wide text-faint">
-                {slashHints.length} 个命令 · ↑↓ 移动 · Tab 补全
-                {input.trim() === '/' && ' · 继续输入可过滤'}
-              </div>
-            </div>
-          )}
-          <div className="relative">
-            {/* ↓ 与输入块同列、贴在正上方；不放进磨砂块内，否则 backdrop 只能糊到父级内部 */}
-            {!atBottom && (
-              <button
-                className="absolute bottom-full right-0 z-40 mb-2 grid h-9 w-9 place-items-center rounded-full bg-surface2/85 text-ink shadow-lg backdrop-blur-xl hover:bg-surface2"
-                onClick={() => scrollToBottom(false)}
-                title="回到底部"
-                aria-label="回到底部"
-              >
-                ↓
-              </button>
-            )}
-            <div className="rounded-[14px] bg-surface2/80 px-3 pb-2 pt-2.5 shadow-[0_16px_40px_-12px_rgba(0,0,0,0.5)] backdrop-blur-xl">
-            {/* busy 时发送方式：插队（steer，下一边界被模型看到）/ 排队（queue，当前轮结束后） */}
-            {busy && (
-              <div className="mb-1.5 flex items-center gap-1.5 font-mono text-[10px]">
-                <span className="text-faint">工作中，发送：</span>
-                {(['steer', 'queue'] as const).map((m) => (
-                  <button
-                    key={m}
-                    className={`rounded-full px-2.5 py-0.5 ${
-                      sendMode === m ? 'bg-surface text-ink' : 'text-faint hover:text-muted'
-                    }`}
-                    onClick={() => setSendMode(m)}
-                  >
-                    {m === 'steer' ? '插队' : '排队'}
-                  </button>
-                ))}
-                <span className="text-faint/70">
-                  {sendMode === 'steer'
-                    ? isCodex
-                      ? '追加进当前轮'
-                      : '打断当前并立即处理'
-                    : '当前轮结束后自动开始'}
-                </span>
-              </div>
-            )}
-            {/* 待发送图片预览 */}
-            {pendingImages.length > 0 && (
-              <div className="mb-2 flex flex-wrap gap-2">
-                {pendingImages.map((img, i) => (
-                  <span key={i} className="relative">
-                    <img src={imgPreviewSrc(img)} alt={img.name} className="h-14 w-14 rounded-[10px] object-cover" />
-                    <button
-                      className="absolute -right-1.5 -top-1.5 grid h-4 w-4 place-items-center rounded-full bg-accent text-[9px] leading-none text-white"
-                      onClick={() => setPendingImages((prev) => prev.filter((_, j) => j !== i))}
-                    >
-                      ✕
-                    </button>
-                  </span>
-                ))}
-              </div>
-            )}
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/jpeg,image/png,image/gif,image/webp"
-              multiple
-              className="hidden"
-              onChange={(e) => {
-                pickImages(e.target.files)
-                e.target.value = ''
-              }}
-            />
-            <textarea
-              ref={inputRef}
-              className="max-h-[200px] min-h-[1.5rem] w-full resize-none overflow-hidden bg-transparent px-1 text-[15px] leading-snug text-ink outline-none placeholder:text-faint"
-              rows={1}
-              placeholder={busy ? '工作中…' : 'ᕕ( ◠ڼ◠ )ᕗ'}
-              value={input}
-              onChange={(e) => {
-                setInput(e.target.value)
-                setSlashIdx(0)
-              }}
-              onKeyDown={(e) => {
-                // 斜杠命令面板打开时的键盘导航
-                if (slashHints.length > 0) {
-                  if (e.key === 'ArrowDown') {
-                    e.preventDefault()
-                    setSlashIdx((i) => Math.min(i + 1, slashHints.length - 1))
-                    return
-                  }
-                  if (e.key === 'ArrowUp') {
-                    e.preventDefault()
-                    setSlashIdx((i) => Math.max(i - 1, 0))
-                    return
-                  }
-                  if (e.key === 'Tab') {
-                    e.preventDefault()
-                    setInput(`/${slashHints[slashActive].name} `)
-                    setSlashIdx(0)
-                    return
-                  }
-                  if (e.key === 'Escape') {
-                    e.preventDefault()
-                    setInput('')
-                    setSlashIdx(0)
-                    return
-                  }
-                }
-                if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-                  e.preventDefault()
-                  // 输入还是高亮命令的真前缀时先补全不发送；完整命令名（如 /compact）才直接发送
-                  const trimmed = input.trim()
-                  const active = slashHints[slashActive]
-                  if (slashHints.length > 0 && active && `/${active.name}` !== trimmed) {
-                    setInput(`/${active.name} `)
-                    setSlashIdx(0)
-                    return
-                  }
-                  send()
-                }
-              }}
-            />
-            <div className="mt-1 flex min-w-0 items-center gap-1.5">
-              <div className="min-w-0 flex-1">
-              {cfg && !isCodex && (
-                <StatusPill
-                  cfg={cfg}
-                  model={initInfo.model}
-                  permissionMode={permMode}
-                  effort={effort}
-                  modelNames={modelNames}
-                  onPanelOpen={loadModelNames}
-                  onSetModel={(m) => {
-                    setInitInfo((prev) => ({ ...prev, model: m }))
-                    sockRef.current?.send({ kind: 'control', subtype: 'set_model', extra: { model: m } })
-                  }}
-                  onSetMode={handleSetMode}
-                  onSetEffort={handleSetEffort}
-                />
-              )}
-              {isCodex && codexModels && codexModels.length > 0 && (
-                <StatusPill
-                  cfg={codexCfg}
-                  model={codexModelId}
-                  permissionMode={codexModeOf(permMode ?? state.permissionMode)}
-                  effort={effort ?? state.effort ?? codexCurrentModel?.defaultEffort}
-                  effortLevels={codexEffortLevels}
-                  onSetModel={(m) => {
-                    sockRef.current?.send({ kind: 'control', subtype: 'set_model', extra: { model: m } })
-                  }}
-                  onSetMode={handleSetMode}
-                  onSetEffort={handleSetEffort}
-                />
-              )}
-              </div>
-              {/* 上下文窗口占用环：首个 API 应答/首个 turn 前（state.context 缺省）不渲染 */}
-              <ContextRing
-                backend={isCodex ? 'codex' : 'claude'}
-                context={state.context}
-                usage={state.usage}
-                modelLabel={
-                  isCodex
-                    ? (codexCurrentModel?.label ?? codexModelId)
-                    : (modelNames?.[initInfo.model ?? '']?.name ?? initInfo.model)
-                }
-                onOpenFullDetail={
-                  !isCodex && isExisting
-                    ? () => {
-                        setDetailOpen(true)
-                        runQuery('get_context_usage', 'context 用量')
-                      }
-                    : undefined
-                }
-              />
-              <button
-                type="button"
-                className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-muted transition-colors hover:bg-surface hover:text-ink"
-                title="添加图片（jpg/png/gif/webp，≤5MB）"
-                aria-label="添加图片"
-                onClick={() => fileInputRef.current?.click()}
-              >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden="true">
-                  <rect x="3" y="3" width="18" height="18" rx="2" />
-                  <circle cx="8.5" cy="8.5" r="1.5" />
-                  <path d="m21 15-5-5L5 21" />
-                </svg>
-              </button>
-              {busy ? (
-                <button
-                  type="button"
-                  className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-accent text-white transition-opacity hover:opacity-85"
-                  onClick={() => sockRef.current?.send({ kind: 'control', subtype: 'interrupt' })}
-                  title="中断当前回合"
-                  aria-label="中断当前回合"
-                >
-                  <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4" aria-hidden="true">
-                    <rect x="5" y="5" width="14" height="14" rx="3" />
-                  </svg>
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-ink text-bg transition-opacity hover:opacity-85 disabled:pointer-events-none disabled:opacity-25"
-                  disabled={(!input.trim() && pendingImages.length === 0) || !connected}
-                  onClick={send}
-                  title="发送"
-                  aria-label="发送"
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4" aria-hidden="true">
-                    <path d="M12 19V5" />
-                    <path d="m5 12 7-7 7 7" />
-                  </svg>
-                </button>
-              )}
-            </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <Composer
+        input={input}
+        onInputChange={setInput}
+        busy={busy}
+        connected={connected}
+        sendMode={sendMode}
+        onSendModeChange={setSendMode}
+        isCodex={isCodex}
+        pendingImages={pendingImages}
+        onPendingImagesChange={setPendingImages}
+        onSend={send}
+        onInterrupt={() => sockRef.current?.send({ kind: 'control', subtype: 'interrupt' })}
+        atBottom={atBottom}
+        onScrollToBottom={() => scrollToBottom(false)}
+        slashCommands={state.slashCommands}
+        initSlashCommands={initInfo.slashCommands}
+        cfg={cfg}
+        claudeModel={initInfo.model}
+        permMode={permMode}
+        effort={effort}
+        modelNames={modelNames}
+        onPanelOpen={loadModelNames}
+        onSetClaudeModel={(m) => {
+          setInitInfo((prev) => ({ ...prev, model: m }))
+          sockRef.current?.send({ kind: 'control', subtype: 'set_model', extra: { model: m } })
+        }}
+        onSetMode={handleSetMode}
+        onSetEffort={handleSetEffort}
+        codexModels={codexModels}
+        stateModel={state.model}
+        statePermissionMode={state.permissionMode}
+        stateEffort={state.effort}
+        onSetCodexModel={(m) => {
+          sockRef.current?.send({ kind: 'control', subtype: 'set_model', extra: { model: m } })
+        }}
+        context={state.context}
+        usage={state.usage}
+        onOpenFullDetail={
+          !isCodex && isExisting
+            ? () => {
+                setDetailOpen(true)
+                runQuery('get_context_usage', 'context 用量')
+              }
+            : undefined
+        }
+      />
       </div>
       <TasksPanel
         open={tasksOpen}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
-import { SessionSocket, type ServerEvent, type SessionState } from '../lib/ws'
+import { SessionSocket } from '../lib/ws'
 import { ApprovalCard } from '../components/ApprovalCard'
 import { ChatHeader } from '../components/ChatHeader'
 import { Composer, imgPreviewSrc } from '../components/Composer'
@@ -13,31 +13,18 @@ import { CodexMark } from '../components/CodexMark'
 import { buildTranscriptRows, nextId, rewindPreview, usageSummary, type Block, type ChatMsg } from '../lib/blocks'
 import { statusLineOf } from '../lib/chatText'
 import { interceptSlash, type SlashAction } from '../lib/slashIntercept'
-import { appendHistoryMsg, flushStrayResults, type IngestState } from '../lib/ingest'
 import { isCodexKey, isExistingKey } from '../lib/key'
 import { useTaskBuckets } from '../hooks/useTaskBuckets'
 import { useTranscriptIngest } from '../hooks/useTranscriptIngest'
-
-interface Approval {
-  requestId: string
-  toolName: string
-  input: unknown
-}
+import { useSessionSocket, type QueryResultEvent } from '../hooks/useSessionSocket'
 
 export function Chat(props: { session: SessionInfo; onBack: () => void; onNavigate?: (s: SessionInfo) => void }) {
   const { session } = props
   const isCodex = isCodexKey(session.key)
   const isExisting = isExistingKey(session.key)
   const [input, setInput] = useState('')
-  const [state, setState] = useState<SessionState>({ spawned: false, busy: false })
-  const [connected, setConnected] = useState(false)
-  const [approvals, setApprovals] = useState<Approval[]>([])
   const [cfg, setCfg] = useState<ServerConfigInfo>()
   const [showRewind, setShowRewind] = useState(false)
-  const [phase, setPhase] = useState<string>()
-  const [initInfo, setInitInfo] = useState<{ model?: string; slashCommands?: string[] }>({})
-  const [permMode, setPermMode] = useState<string>()
-  const [effort, setEffort] = useState<string>()
   const [codexModels, setCodexModels] = useState<CodexModelInfo[]>()
   const [lineage, setLineage] = useState<LineageResponse>()
   const [handoffBusy, setHandoffBusy] = useState(false)
@@ -73,24 +60,55 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   // 内部全走 ref/稳定 setState/isCodex（会话内不变），与此前过期闭包语义等价
   const { tasks, tasksOpen, setTasksOpen, api: taskApi } = useTaskBuckets({ isCodex })
 
-  // ---------- 主抄本 ingest（消息/流式草稿/配对索引；F4 下沉 hooks/useTranscriptIngest.ts） ----------
-  // api 为每渲染重建的普通对象：内部全走 ref/稳定 setState/注入的稳定 setter，过期闭包语义等价
-  const { messages, draft, api: ingestApi } = useTranscriptIngest({
+  // ---------- 主抄本 ingest（消息/流式草稿/配对索引 + cli 流驱动的会话元数据；F4/F5 下沉 hooks/useTranscriptIngest.ts） ----------
+  // api 为每渲染重建的普通对象：内部全走 ref/稳定 setState，过期闭包语义等价
+  const { messages, draft, phase, initInfo, permMode, effort, api: ingestApi } = useTranscriptIngest({
     isCodex,
     sockRef,
     taskApi,
-    setPhase,
-    setPermMode,
-    setInitInfo,
   })
 
   const loadSessionHistory = () =>
     isCodex ? fetchCodexHistory(session.sessionId) : fetchHistory(session.slug, session.sessionId)
-  /** 当前会话权威 ID：spawn 后以 status 广播为准（/clear 重键、b| 分叉首条消息后的真实 id）；
-   *  未 spawn 时只有 s|/x| key 内嵌的才是本会话 id——b| 嵌的是源会话 id，不能误显示 */
-  const currentSessionId =
-    state.sessionId ??
-    (session.key.startsWith('s|') || session.key.startsWith('x|') ? session.sessionId : undefined)
+
+  // ---------- 详情查询（query 通道；应答的详情域分发留组合层） ----------
+  const runQuery = (query: string, title: string) => {
+    querySeq.current += 1
+    setDetailTitle(title)
+    setDetailContent('加载中…')
+    sockRef.current?.send({ kind: 'query', id: `q-${querySeq.current}`, query })
+  }
+
+  /** query_result 详情域分发：MCP 动作应答辨认 + 结构化面板（F5 从 WS 分发切出，语义逐字） */
+  const onQueryResult = (ev: QueryResultEvent) => {
+    // MCP 管理动作应答（按 query id 辨认）：清忙态、给反馈、成功后刷新清单
+    if (pendingMcpActionRef.current && ev.id === pendingMcpActionRef.current) {
+      pendingMcpActionRef.current = null
+      setMcpBusy(null)
+      if (ev.ok) {
+        ingestApi.pushSystem('✓ MCP 操作完成')
+        runQuery('mcp_status', 'MCP 状态')
+      } else {
+        ingestApi.pushSystem(`⚠ MCP 操作失败: ${ev.error ?? '未知错误'}`, 'error')
+      }
+      return
+    }
+    // 始终保留原始 JSON（非结构化 tab 的主视图 + 设置面板的折叠原件）
+    const raw = ev.ok
+      ? JSON.stringify(ev.data, null, 2).slice(0, 8000)
+      : `⚠ ${ev.error ?? '查询失败'}`
+    setDetailContent(raw)
+    // 按应答形状分发到结构化面板（claude 专属；codex 一律 JSON 直出）。
+    // 形状不匹配的 tab 清空对应结构化态，渲染链自然落回 <pre>
+    const d = ev.ok && !isCodex ? (ev.data as Record<string, unknown>) : undefined
+    setMcpServers(Array.isArray(d?.mcpServers) ? (d.mcpServers as McpServerInfo[]) : null)
+    setContextData(
+      d && Array.isArray(d.categories) && typeof d.totalTokens === 'number'
+        ? (d as unknown as ContextDataLite)
+        : null,
+    )
+    setSettingsData(d && d.applied && Array.isArray(d.sources) ? (d as unknown as SettingsDataLite) : null)
+  }
 
   // codex 模型目录（model/list）：模型/effort 档位/默认值
   useEffect(() => {
@@ -124,11 +142,11 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     ingestApi.reset()
     // Chat 组件在 session 切换时会复用，清掉上一会话的运行时/待启动配置。
     // 新会话的缓存选择会由随后到达的 status 恢复。
-    setInitInfo({})
-    setPermMode(undefined)
-    setEffort(undefined)
+    ingestApi.setInitInfo({})
+    ingestApi.setPermMode(undefined)
+    ingestApi.setEffort(undefined)
     setApprovals([])
-    setPhase(undefined)
+    ingestApi.setPhase(undefined)
     taskApi.clear()
     if (!isExisting) return
     loadSessionHistory()
@@ -144,329 +162,29 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     }
   }, [session.key])
 
-  // ---------- WS 连接 ----------
+  // ---------- 会话 WS（连接生命周期 + ServerEvent 分发；F5 下沉 hooks/useSessionSocket.ts） ----------
+  // 调用位置即 effect 注册顺序：E3 历史加载（reset 先于建连）必须在 WS effect 之前注册，
+  // 故本调用放在 E3 之后——顺序纪律钉死，勿上移。
+  const { state, connected, approvals, setApprovals } = useSessionSocket({
+    session,
+    sockRef,
+    ingestApi,
+    taskApi,
+    loadSessionHistory,
+    onNavigate: props.onNavigate,
+    onCloseRewind: () => setShowRewind(false),
+    onQueryResult,
+  })
+
+  /** 当前会话权威 ID：spawn 后以 status 广播为准（/clear 重键、b| 分叉首条消息后的真实 id）；
+   *  未 spawn 时只有 s|/x| key 内嵌的才是本会话 id——b| 嵌的是源会话 id，不能误显示 */
+  const currentSessionId =
+    state.sessionId ??
+    (session.key.startsWith('s|') || session.key.startsWith('x|') ? session.sessionId : undefined)
+
+  // ---------- 服务配置（Composer StatusPill 用；与 socket 生命周期无关——原与建连同 effect 同步先后执行，独立后同 commit 按序执行，行为等价） ----------
   useEffect(() => {
     fetchConfig().then(setCfg).catch(() => {})
-    const sock = new SessionSocket(
-      session.key,
-      (ev: ServerEvent) => {
-        switch (ev.kind) {
-          case 'status':
-            setState(ev.state)
-            if (typeof ev.state.model === 'string') {
-              setInitInfo((prev) => ({ ...prev, model: ev.state.model }))
-            }
-            if (typeof ev.state.permissionMode === 'string') setPermMode(ev.state.permissionMode)
-            if (typeof ev.state.effort === 'string') setEffort(ev.state.effort)
-            // 服务端权威运行任务表水合任务桶（中途接入补建 / 断线丢通知判死）
-            taskApi.hydrateTasks(ev.state)
-            // 进程已退出时固化/清理未完成的流式草稿，避免半截内容悬挂
-            if (ev.state.exited) {
-              ingestApi.commitDraft()
-              setPhase(undefined)
-            } else if (ev.state.sessionState === 'idle' && !ev.state.busy && !ev.state.waiting && ingestApi.draftRef.current) {
-              // 自愈：权威 idle 到达时清掉陈旧流式草稿。服务端重启/断线期间 turn 终结时
-              // 客户端拿不到终结事件，"生成中"会永远挂着（实测：watch 重载后复现）。
-              // 等审批（waiting/requires_action）期间草稿是合法的，不在此清理。
-              ingestApi.setDraftBoth(null)
-              setPhase(undefined)
-              // turn 已终结：此刻仍未配对的 tool_result 不会再等到它的调用了，
-              // 浮现为孤立提示而非静默丢弃（旧实现直接 clear，用户零反馈）
-              ingestApi.setMsgs((prev) => {
-                const st: IngestState = { msgs: prev, toolIdx: ingestApi.toolPosRef.current, pending: ingestApi.pendingResultsRef.current }
-                flushStrayResults(st)
-                return st.msgs
-              })
-            }
-            break
-          case 'approval_request':
-            setApprovals((prev) =>
-              prev.some((a) => a.requestId === ev.requestId)
-                ? prev
-                : [...prev, { requestId: ev.requestId, toolName: ev.toolName, input: ev.input }],
-            )
-            break
-          case 'approval_resolved':
-            setApprovals((prev) => prev.filter((a) => a.requestId !== ev.requestId))
-            break
-          case 'approval_auto': {
-            // 规则引擎自动裁决的审计留痕：不进审批队列，只落一条系统卡。
-            // 摘要字段提取与服务端 summarizeInput 同口径（command / file_path / url）。
-            const inp = ev.input as Record<string, unknown> | undefined
-            const detail =
-              (typeof inp?.command === 'string' && inp.command) ||
-              (typeof inp?.file_path === 'string' && inp.file_path) ||
-              (typeof inp?.grantRoot === 'string' && inp.grantRoot) ||
-              (typeof inp?.url === 'string' && inp.url) ||
-              ''
-            ingestApi.pushSystem(
-              `规则自动${ev.action === 'allow' ? '放行' : '拒绝'}：${ev.toolName}${detail ? ` ${detail.slice(0, 120)}` : ''}（${ev.rule}）`,
-            )
-            break
-          }
-          case 'error':
-            ingestApi.pushSystem(`⚠ ${ev.message}`, 'error')
-            break
-          case 'btw_pending':
-            // 创建侧问卡片（发送方与其他客户端都以此为准）
-            if (!ingestApi.messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
-              ingestApi.pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: true, blocks: [] })
-            }
-            break
-          case 'btw_delta': {
-            const target = ingestApi.messagesRef.current.find((m) => m.btw === ev.question && m.btwPending)
-            if (!target) break
-            ingestApi.setMsgs((prev) =>
-              prev.map((m) => {
-                if (m.id !== target.id) return m
-                const blocks = [...m.blocks]
-                const kind = ev.thinking ? 'thinking' : 'text'
-                const i = blocks.findIndex((b) => b.kind === kind)
-                if (i >= 0) {
-                  const b = blocks[i]
-                  if (b.kind === 'text' || b.kind === 'thinking') {
-                    blocks[i] = { ...b, text: b.text + ev.delta }
-                  }
-                } else {
-                  blocks.push({ kind, text: ev.delta })
-                }
-                // thinking 在 text 之前
-                blocks.sort((a, b) => (a.kind === 'thinking' ? -1 : 0) - (b.kind === 'thinking' ? -1 : 0))
-                return { ...m, blocks }
-              }),
-            )
-            break
-          }
-          case 'btw_result': {
-            // 找不到 pending 卡（如校验失败路径或漏收 btw_pending）时自行建卡落地结果——
-            // 配对不变量由数据保证，不依赖服务端的消息时序
-            if (!ingestApi.messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
-              const blocks: Block[] = ev.ok
-                ? ev.text.trim()
-                  ? [{ kind: 'text', text: ev.text }]
-                  : []
-                : [{ kind: 'text', text: `⚠ ${ev.text}` }]
-              ingestApi.pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: false, blocks })
-              break
-            }
-            ingestApi.setMsgs((prev) =>
-              prev.map((m) => {
-                if (m.btw !== ev.question || !m.btwPending) return m
-                if (ev.ok) {
-                  // 用完整结果替换正文（增量可能因快照归并而不全）
-                  const thinking = m.blocks.find((b) => b.kind === 'thinking')
-                  const blocks: Block[] = []
-                  if (thinking) blocks.push(thinking)
-                  if (ev.text.trim()) blocks.push({ kind: 'text', text: ev.text })
-                  return { ...m, blocks, btwPending: false }
-                }
-                return { ...m, blocks: [...m.blocks, { kind: 'text', text: `⚠ ${ev.text}` }], btwPending: false }
-              }),
-            )
-            break
-          }
-          case 'forked': {
-            if (ev.branchOf) {
-              // claude 懒分叉：b| key 导航，首条消息才真正 --fork-session；
-              // 历史视图直接读源会话 transcript（分支将原样继承它）
-              ingestApi.pushSystem(
-                `⎇ 已创建分支${ev.name ? `「${ev.name}」` : ''}：新会话携带当前全部历史，原会话保持不动`,
-              )
-              props.onNavigate?.(
-                makeSessionInfo({
-                  key: ev.targetKey,
-                  slug: session.slug,
-                  sessionId: ev.branchOf,
-                  cwd: session.cwd,
-                  backend: 'claude',
-                }),
-              )
-              break
-            }
-            // codex 分叉回滚完成：原线程不动，跳到携带截断历史的新线程
-            ingestApi.pushSystem('⎇ 已分叉：新会话携带所选消息之前的历史，原会话保持不动')
-            setShowRewind(false)
-            props.onNavigate?.(
-              makeSessionInfo({
-                key: ev.targetKey,
-                slug: 'codex',
-                // codex 分叉路径服务端始终携带 targetSessionId（branchOf 不存在时）
-                sessionId: ev.targetSessionId ?? '',
-                cwd: session.cwd,
-                backend: 'codex',
-                managed: { spawned: true, busy: false, clients: 0 },
-              }),
-            )
-            break
-          }
-          case 'handoff_pending':
-            ingestApi.pushSystem(`⇄ 源会话正在生成交接简报（→ ${ev.toBackend === 'codex' ? 'Codex' : 'Claude'}）…`)
-            break
-          case 'handoff_brief':
-            break // 简报在 handoff_done 时一并展示
-          case 'handoff_done': {
-            ingestApi.pushMsg({
-              id: nextId(),
-              role: 'system',
-              systemKind: 'info',
-              blocks: [{ kind: 'text', text: `⇄ 接力简报（已播种给 ${ev.toBackend === 'codex' ? 'Codex' : 'Claude'} 新会话）：\n\n${ev.brief}` }],
-            })
-            props.onNavigate?.(
-              makeSessionInfo({
-                key: ev.targetKey,
-                slug: ev.toBackend === 'codex' ? 'codex' : session.slug,
-                // 目标已 spawn 时 targetKey 是 resolved key（s|/x|）：必须带真实 id，
-                // 否则 codex 侧 fetchCodexHistory('new') 必失败、历史视图永远空白
-                sessionId: ev.targetSessionId ?? 'new',
-                cwd: session.cwd,
-                backend: ev.toBackend,
-                status: 'busy',
-                managed: { spawned: true, busy: true, clients: 0 },
-              }),
-            )
-            break
-          }
-          case 'handoff_error':
-            ingestApi.pushSystem(`⚠ 接力失败: ${ev.message}`, 'error')
-            break
-          case 'query_result': {
-            // MCP 管理动作应答（按 query id 辨认）：清忙态、给反馈、成功后刷新清单
-            if (pendingMcpActionRef.current && ev.id === pendingMcpActionRef.current) {
-              pendingMcpActionRef.current = null
-              setMcpBusy(null)
-              if (ev.ok) {
-                ingestApi.pushSystem('✓ MCP 操作完成')
-                runQuery('mcp_status', 'MCP 状态')
-              } else {
-                ingestApi.pushSystem(`⚠ MCP 操作失败: ${ev.error ?? '未知错误'}`, 'error')
-              }
-              break
-            }
-            // 始终保留原始 JSON（非结构化 tab 的主视图 + 设置面板的折叠原件）
-            const raw = ev.ok
-              ? JSON.stringify(ev.data, null, 2).slice(0, 8000)
-              : `⚠ ${ev.error ?? '查询失败'}`
-            setDetailContent(raw)
-            // 按应答形状分发到结构化面板（claude 专属；codex 一律 JSON 直出）。
-            // 形状不匹配的 tab 清空对应结构化态，渲染链自然落回 <pre>
-            const d = ev.ok && !isCodex ? (ev.data as Record<string, unknown>) : undefined
-            setMcpServers(Array.isArray(d?.mcpServers) ? (d.mcpServers as McpServerInfo[]) : null)
-            setContextData(
-              d && Array.isArray(d.categories) && typeof d.totalTokens === 'number'
-                ? (d as unknown as ContextDataLite)
-                : null,
-            )
-            setSettingsData(d && d.applied && Array.isArray(d.sources) ? (d as unknown as SettingsDataLite) : null)
-            break
-          }
-          case 'rewound':
-            // 回滚会销毁并重生 CLI 进程（dispose 先摘 map 再 kill，onExit 不会触发），
-            // 进行中的流式草稿/待配对工具结果/相位指示全部失效，必须一并清理，
-            // 否则陈旧草稿会挂在回滚标签之下。
-            ingestApi.setDraftBoth(null)
-            ingestApi.pendingResultsRef.current.clear()
-            setPhase(undefined)
-            ingestApi.setMsgs((prev) => {
-              const idx = prev.findIndex((m) => m.id === ev.userMessageId)
-              const base = idx >= 0 ? prev.slice(0, idx + 1) : prev
-              const label = ev.scope === 'both' ? '↩ 对话和文件已回滚' : '↩ 对话已回滚'
-              return [...base, { id: nextId(), role: 'system', blocks: [{ kind: 'text', text: label }] }]
-            })
-            break
-          case 'cli':
-            if (ingestApi.gapReloadingRef.current) break
-            ingestApi.handleCli(ev.msg, ev.replay === true)
-            break
-          case 'tail': {
-            // 外部会话 transcript 追加：与历史共用同一套归并；uuid 去重兜底（重连续订可能重放）
-            const h = ev.msg
-            if (h.uuid && ingestApi.messagesRef.current.some((m) => m.id === h.uuid)) break
-            ingestApi.setMsgs((prev) => {
-              const st: IngestState = { msgs: prev, toolIdx: ingestApi.toolPosRef.current, pending: ingestApi.pendingResultsRef.current }
-              appendHistoryMsg(st, h)
-              // 不在此 flush：tail 是逐条到达，tool_use 可能在后续行；孤儿在权威 idle 时统一浮现
-              return st.msgs
-            })
-            // 尾到的主线 tool_result 给已存在桶补终态——外部会话（tailer 路径）没有
-            // task_notification，这是它唯一的终态信号；与历史回填同规则：终态挂 30s 驱逐
-            for (const blk of h.blocks) {
-              if (blk.kind !== 'tool_result' || !blk.id) continue
-              taskApi.settleBucketFromResult(blk.id, blk.text ?? '', blk.isError === true)
-            }
-            break
-          }
-          case 'moved': {
-            // /clear 对话重置：进程已换新 sessionId 续跑，Hub 重键完毕——跳到新会话页
-            //（旧 transcript 在磁盘原样保留，列表页可见）
-            const parts = ev.targetKey.split('|')
-            props.onNavigate?.(
-              makeSessionInfo({
-                key: ev.targetKey,
-                slug: parts[1] ?? session.slug,
-                sessionId: ev.targetSessionId ?? 'new',
-                cwd: session.cwd,
-                backend: 'claude',
-                managed: { spawned: true, busy: false, clients: 0 },
-              }),
-            )
-            break
-          }
-          case 'replay_gap': {
-            // 断线太久，服务端环形缓冲已挤掉起点：补发会留空洞，直接重载历史。
-            // transcript 是权威事实源，重载一定能补齐（代价只是一次 HTTP）。
-            // 必须与初次加载走同一 loader——Codex 没有 Claude transcript 路径。
-            // 先挡住 cli 再清草稿：环里残留的 stream/assistant 不能在重载完成前改抄本。
-            ingestApi.gapReloadingRef.current = true
-            ingestApi.setDraftBoth(null)
-            ingestApi.pendingResultsRef.current.clear()
-            setPhase(undefined)
-            const gapKey = session.key
-            loadSessionHistory()
-              .then((resp) => {
-                if (sockRef.current?.key !== gapKey) return // 异步返回时已切走
-                ingestApi.applyHistory(resp)
-                ingestApi.pushSystem('↻ 断线较久，已重新载入对话')
-              })
-              .catch(() => {
-                if (sockRef.current?.key !== gapKey) return
-                ingestApi.pushSystem('⚠ 重新载入对话失败，请手动刷新', 'error')
-              })
-              .finally(() => {
-                if (sockRef.current?.key === gapKey) ingestApi.gapReloadingRef.current = false
-              })
-            break
-          }
-          case 'tail_reset': {
-            // 外部会话截断了 transcript（rewind / clear）：重载历史并用新偏移重新订阅
-            ingestApi.setDraftBoth(null)
-            ingestApi.pendingResultsRef.current.clear()
-            const keyAtFetch = session.key
-            fetchHistory(session.slug, session.sessionId)
-              .then((resp) => {
-                // 异步返回时用户可能已切走：socket 已换成新会话的，弃掉过期结果
-                if (sockRef.current?.key !== keyAtFetch) return
-                ingestApi.applyHistory(resp)
-              })
-              .catch(() => {})
-            break
-          }
-        }
-      },
-      (open) => {
-        setConnected(open)
-        if (!open) return
-        // 重连必须 attach：Codex x| 靠它 resume；fromSeq 为 0 也要带上，
-        // 才能取回「一条可落盘 cli 都没收到就断线」期间的环。首连走下面的 attach。
-        if (sock.reconnecting) sock.send({ kind: 'attach', fromSeq: sock.replayFrom })
-        // 重连后服务端的 tailer 已随连接断开被回收，用已知的偏移重新订阅（重放部分由 uuid 去重）
-        if (ingestApi.historyOffsetRef.current != null) {
-          sock.send({ kind: 'tail_subscribe', from: ingestApi.historyOffsetRef.current })
-        }
-      },
-    )
-    sockRef.current = sock
-    sock.send({ kind: 'attach' })
-    return () => sock.close()
   }, [session.key])
 
   // 只滚消息列表容器。禁止 scrollIntoView：它会连带滚动 overflow 祖先，
@@ -506,12 +224,6 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   }
 
   // ---------- 发送 ----------
-  const runQuery = (query: string, title: string) => {
-    querySeq.current += 1
-    setDetailTitle(title)
-    setDetailContent('加载中…')
-    sockRef.current?.send({ kind: 'query', id: `q-${querySeq.current}`, query })
-  }
 
   /** 各档实际配置的模型名（StatusPill 打开时实时拉取；null = 未拉取/失败 → 降级 tier 名） */
   const [modelNames, setModelNames] = useState<Record<string, TierModelName> | null>(null)
@@ -554,11 +266,11 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
 
   // ---------- StatusPill 共享处理器（claude/codex 两个胶囊的 mode/effort 同构；model 因本地回显差异分开） ----------
   const handleSetMode = (m: string) => {
-    setPermMode(m)
+    ingestApi.setPermMode(m)
     sockRef.current?.send({ kind: 'control', subtype: 'set_permission_mode', extra: { mode: m } })
   }
   const handleSetEffort = (e: string) => {
-    setEffort(e)
+    ingestApi.setEffort(e)
     sockRef.current?.send({ kind: 'update_env', variables: { CLAUDE_CODE_EFFORT_LEVEL: e } })
   }
 
@@ -813,7 +525,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
         modelNames={modelNames}
         onPanelOpen={loadModelNames}
         onSetClaudeModel={(m) => {
-          setInitInfo((prev) => ({ ...prev, model: m }))
+          ingestApi.setInitInfo((prev) => ({ ...prev, model: m }))
           sockRef.current?.send({ kind: 'control', subtype: 'set_model', extra: { model: m } })
         }}
         onSetMode={handleSetMode}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type HistoryResponse, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
-import { SessionSocket, type CliMsg, type ServerEvent, type SessionState } from '../lib/ws'
+import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
+import { SessionSocket, type ServerEvent, type SessionState } from '../lib/ws'
 import { ApprovalCard } from '../components/ApprovalCard'
 import { ChatHeader } from '../components/ChatHeader'
 import { Composer, imgPreviewSrc } from '../components/Composer'
@@ -10,12 +10,13 @@ import { Transcript } from '../components/Transcript'
 import { TasksPanel } from '../components/TasksPanel'
 import { ClaudeStar } from '../components/ClaudeStar'
 import { CodexMark } from '../components/CodexMark'
-import { buildTranscriptRows, nextId, rewindPreview, toolResultText, usageSummary, type Block, type ChatMsg } from '../lib/blocks'
+import { buildTranscriptRows, nextId, rewindPreview, usageSummary, type Block, type ChatMsg } from '../lib/blocks'
 import { statusLineOf } from '../lib/chatText'
 import { interceptSlash, type SlashAction } from '../lib/slashIntercept'
-import { appendHistoryMsg, createIngestState, flushStrayResults, hitsSeen, indexToolBlocks, liveMessageKeys, pairToolResultIn, rememberKeys, transcriptKeys, type IngestState } from '../lib/ingest'
+import { appendHistoryMsg, flushStrayResults, type IngestState } from '../lib/ingest'
 import { isCodexKey, isExistingKey } from '../lib/key'
 import { useTaskBuckets } from '../hooks/useTaskBuckets'
+import { useTranscriptIngest } from '../hooks/useTranscriptIngest'
 
 interface Approval {
   requestId: string
@@ -23,33 +24,16 @@ interface Approval {
   input: unknown
 }
 
-/** 流式草稿：一轮 assistant 输出的增量块（按 message.id + block index 归并） */
-interface DraftBlock {
-  idx: number
-  kind: 'text' | 'thinking' | 'tool'
-  text: string
-  name?: string
-  toolId?: string
-  jsonBuf?: string
-  finalized?: boolean
-}
-interface Draft {
-  msgId?: string
-  blocks: DraftBlock[]
-}
-
 export function Chat(props: { session: SessionInfo; onBack: () => void; onNavigate?: (s: SessionInfo) => void }) {
   const { session } = props
   const isCodex = isCodexKey(session.key)
   const isExisting = isExistingKey(session.key)
-  const [messages, setMessages] = useState<ChatMsg[]>([])
   const [input, setInput] = useState('')
   const [state, setState] = useState<SessionState>({ spawned: false, busy: false })
   const [connected, setConnected] = useState(false)
   const [approvals, setApprovals] = useState<Approval[]>([])
   const [cfg, setCfg] = useState<ServerConfigInfo>()
   const [showRewind, setShowRewind] = useState(false)
-  const [draft, setDraft] = useState<Draft | null>(null)
   const [phase, setPhase] = useState<string>()
   const [initInfo, setInitInfo] = useState<{ model?: string; slashCommands?: string[] }>({})
   const [permMode, setPermMode] = useState<string>()
@@ -84,43 +68,21 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
   const [atBottom, setAtBottom] = useState(true)
   const atBottomRef = useRef(true)
 
-  // ref 镜像：事件处理器在 React 渲染外触发，直接基于 ref 计算，避免过期闭包/updater 双重调用
-  const messagesRef = useRef<ChatMsg[]>([])
-  const draftRef = useRef<Draft | null>(null)
-  const pendingResultsRef = useRef(new Map<string, { text: string; isError: boolean }>())
-  /** toolUseId → 落地位置索引：tool_result 配对的 O(1) 快路径（失效时回退线性扫描） */
-  const toolPosRef = useRef(new Map<string, { mi: number; bi: number }>())
-  /** 历史加载时服务端读到的 transcript 字节数，tail_subscribe 的起始偏移 */
-  const historyOffsetRef = useRef<number | undefined>(undefined)
-  /** replay_gap 正在重载历史：丢弃这段窗口内的 cli，避免和 applyHistory 对抄本抢写 */
-  const gapReloadingRef = useRef(false)
-  /** 已见消息身份（uuid / message.id / tool:id）。HTTP 历史与 live/补发重叠时靠它去重 */
-  const seenIdsRef = useRef(new Set<string>())
-
   // ---------- 后台任务（与主线并行的 agent/task/shell，右侧拉栏展示；task_type 全类型入桶） ----------
   // 桶状态与辅助群已下沉 hooks/useTaskBuckets.ts（F3）：api 为每渲染重建的普通对象——
   // 内部全走 ref/稳定 setState/isCodex（会话内不变），与此前过期闭包语义等价
   const { tasks, tasksOpen, setTasksOpen, api: taskApi } = useTaskBuckets({ isCodex })
 
-  const setMsgs = (up: (prev: ChatMsg[]) => ChatMsg[]) => {
-    messagesRef.current = up(messagesRef.current)
-    setMessages(messagesRef.current)
-  }
-  const setDraftBoth = (d: Draft | null) => {
-    draftRef.current = d
-    setDraft(d)
-  }
-  const pushMsg = (m: ChatMsg) => {
-    setMsgs((prev) => {
-      // 建索引的同时消费乱序缓冲：结果早于工具块落地时（live 流常见）在此补齐
-      const st: IngestState = { msgs: [...prev, m], toolIdx: toolPosRef.current, pending: pendingResultsRef.current }
-      indexToolBlocks(st, st.msgs.length - 1)
-      rememberKeys(seenIdsRef.current, [...transcriptKeys([m])])
-      return st.msgs
-    })
-  }
-  const pushSystem = (text: string, kind: 'info' | 'error' = 'info') =>
-    pushMsg({ id: nextId(), role: 'system', systemKind: kind, blocks: [{ kind: 'text', text }] })
+  // ---------- 主抄本 ingest（消息/流式草稿/配对索引；F4 下沉 hooks/useTranscriptIngest.ts） ----------
+  // api 为每渲染重建的普通对象：内部全走 ref/稳定 setState/注入的稳定 setter，过期闭包语义等价
+  const { messages, draft, api: ingestApi } = useTranscriptIngest({
+    isCodex,
+    sockRef,
+    taskApi,
+    setPhase,
+    setPermMode,
+    setInitInfo,
+  })
 
   const loadSessionHistory = () =>
     isCodex ? fetchCodexHistory(session.sessionId) : fetchHistory(session.slug, session.sessionId)
@@ -156,39 +118,10 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       .catch(() => {})
   }, [session.key])
 
-  /** 历史响应落到消息列表 + 从读取位置续订 tail（初次加载与 tail_reset 重载共用） */
-  const applyHistory = (resp: HistoryResponse) => {
-    historyOffsetRef.current = resp.fileBytes
-    const st = createIngestState()
-    for (const h of resp.messages) appendHistoryMsg(st, h)
-    // 批次收尾：整批读完仍未配对的才是真孤儿（批内乱序此时已修复）
-    flushStrayResults(st)
-    const out = st.msgs
-    setMsgs(() => out)
-    // 实时配对索引与乱序缓冲直接沿用历史加载建好的（out 已成为新 state）
-    toolPosRef.current = st.toolIdx
-    pendingResultsRef.current = st.pending
-    seenIdsRef.current = transcriptKeys(out)
-
-    // 子代理侧链进桶；终态/报告以主线 Agent 工具卡的配对结果为准（tool_result 已落盘 = 已完成）
-    //（清桶 + 未完成 subagent 回填的实现已随桶下沉 hooks/useTaskBuckets.ts）
-    taskApi.resetFromHistory(out, resp)
-
-    // 从历史读取位置续订 transcript 追加（外部会话的实时更新）；socket 未 open 时会排队
-    // codex 的实时流走 app-server 订阅（attach 即 resume），无 tailer
-    if (!isCodex) sockRef.current?.send({ kind: 'tail_subscribe', from: resp.fileBytes })
-  }
-
   // ---------- 历史加载（切换会话时取消过期请求，避免「卡住不出对话」） ----------
   useEffect(() => {
     let cancelled = false
-    setMsgs(() => [])
-    setDraftBoth(null)
-    pendingResultsRef.current.clear()
-    toolPosRef.current.clear()
-    seenIdsRef.current.clear()
-    historyOffsetRef.current = undefined
-    gapReloadingRef.current = false
+    ingestApi.reset()
     // Chat 组件在 session 切换时会复用，清掉上一会话的运行时/待启动配置。
     // 新会话的缓存选择会由随后到达的 status 恢复。
     setInitInfo({})
@@ -201,270 +134,15 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     loadSessionHistory()
       .then((resp) => {
         if (cancelled) return
-        applyHistory(resp)
+        ingestApi.applyHistory(resp)
       })
       .catch((e) => {
-        if (!cancelled) pushSystem(`⚠ 加载历史失败: ${e}`, 'error')
+        if (!cancelled) ingestApi.pushSystem(`⚠ 加载历史失败: ${e}`, 'error')
       })
     return () => {
       cancelled = true
     }
   }, [session.key])
-
-  // ---------- 流式草稿 ----------
-
-  /** message_stop / result 时把草稿固化为一条 assistant 消息 */
-  const commitDraft = () => {
-    const d = draftRef.current
-    if (!d) return
-    setDraftBoth(null)
-    if (d.blocks.length === 0) return
-    const blocks: Block[] = []
-    for (const b of d.blocks) {
-      if (b.kind === 'tool') {
-        let input: unknown
-        try {
-          input = b.jsonBuf ? JSON.parse(b.jsonBuf) : undefined
-        } catch {}
-        const toolId = b.toolId ?? nextId()
-        const held = pendingResultsRef.current.get(toolId)
-        if (held) pendingResultsRef.current.delete(toolId)
-        blocks.push({
-          kind: 'tool',
-          id: toolId,
-          name: b.name ?? '?',
-          input,
-          pending: !held,
-          resultText: held?.text,
-          resultError: held?.isError,
-        })
-      } else if (b.text.trim()) {
-        blocks.push({ kind: b.kind, text: b.text })
-      }
-    }
-    if (blocks.length > 0) pushMsg({ id: d.msgId ?? nextId(), role: 'assistant', blocks })
-  }
-
-  /** tool_result 配对到已渲染的工具卡片；工具块还在草稿里则暂存（归并实现见 lib/ingest） */
-  const pairToolResult = (toolUseId: string | undefined, text: string, isError: boolean) => {
-    if (!toolUseId) return
-    setMsgs((prev) => {
-      const r = pairToolResultIn(prev, toolPosRef.current, toolUseId, text, isError)
-      if (!r.paired) pendingResultsRef.current.set(toolUseId, { text, isError })
-      return r.msgs
-    })
-  }
-
-  // ---------- CLI 消息处理 ----------
-  const handleCli = (msg: CliMsg, replay = false) => {
-    const rec = msg as Record<string, unknown>
-
-    // 流式增量事件（Anthropic API SSE 透传）
-    if (msg.type === 'stream_event') {
-      const ev = rec.event as
-        | {
-            type?: string
-            index?: number
-            message?: { id?: string }
-            content_block?: { type?: string; id?: string; name?: string }
-            delta?: { type?: string; text?: string; thinking?: string; partial_json?: string }
-          }
-        | undefined
-      if (!ev?.type) return
-      switch (ev.type) {
-        case 'message_start':
-          setDraftBoth({ msgId: ev.message?.id, blocks: [] })
-          break
-        case 'content_block_start': {
-          const t = ev.content_block?.type
-          const d: Draft = draftRef.current ?? { blocks: [] }
-          const idx = ev.index ?? d.blocks.length
-          if (!d.blocks.some((b) => b.idx === idx)) {
-            d.blocks.push({
-              idx,
-              kind: t === 'thinking' ? 'thinking' : t === 'tool_use' ? 'tool' : 'text',
-              text: '',
-              toolId: ev.content_block?.id,
-              name: ev.content_block?.name,
-              jsonBuf: t === 'tool_use' ? '' : undefined,
-            })
-            d.blocks.sort((a, b) => a.idx - b.idx)
-            setDraftBoth({ ...d })
-          }
-          break
-        }
-        case 'content_block_delta': {
-          const delta = ev.delta
-          if (!delta) break
-          const d: Draft = draftRef.current ?? { blocks: [] }
-          const idx = ev.index ?? d.blocks.length - 1
-          let b = d.blocks.find((x) => x.idx === idx)
-          if (!b) {
-            b = { idx, kind: 'text', text: '' }
-            d.blocks.push(b)
-            d.blocks.sort((a, z) => a.idx - z.idx)
-          }
-          if (delta.type === 'text_delta' && delta.text) b.text += delta.text
-          else if (delta.type === 'thinking_delta' && delta.thinking) {
-            b.kind = 'thinking'
-            b.text += delta.thinking
-          } else if (delta.type === 'input_json_delta' && delta.partial_json) b.jsonBuf = (b.jsonBuf ?? '') + delta.partial_json
-          // signature_delta 永不展示
-          setDraftBoth({ ...d, blocks: [...d.blocks] })
-          break
-        }
-        case 'message_stop':
-          commitDraft()
-          break
-        // content_block_stop / message_delta 无需处理（assistant 快照与 result 会收尾）
-      }
-      return
-    }
-
-    if (msg.type === 'control_response') {
-      const resp = rec.response as { subtype?: string; error?: string } | undefined
-      if (resp?.subtype === 'error') pushSystem(`⚠ ${resp.error ?? '控制请求失败'}`, 'error')
-      return
-    }
-
-    if (msg.type === 'assistant') {
-      if (taskApi.appendSidechain(rec)) return
-      const content = msg.message?.content
-      const blocks = Array.isArray(content) ? content : []
-      const msgId = (rec.message as { id?: string } | undefined)?.id
-      const d = draftRef.current
-      if (!d || msgId !== d.msgId) {
-        const toolIds = blocks.filter((c) => c?.type === 'tool_use' && c.id).map((c) => String(c.id))
-        const keys = liveMessageKeys({ uuid: msg.uuid, messageId: msgId, toolIds })
-        // uuid / message.id / 工具块 id 任一已在抄本（HTTP 历史或先前 live）即跳过——
-        // 旧实现只比 message.id，而落盘 id 是 uuid，Codex 甚至没有 uuid，重连补发会重复气泡
-        if (hitsSeen(seenIdsRef.current, keys)) return
-        // 没有对应草稿（如中途接入）：直接落为完整消息
-        const direct: Block[] = []
-        for (const c of blocks) {
-          if (c?.type === 'text' && c.text?.trim()) direct.push({ kind: 'text', text: c.text })
-          else if (c?.type === 'thinking' && c.thinking?.trim()) direct.push({ kind: 'thinking', text: c.thinking })
-          else if (c?.type === 'tool_use')
-            direct.push({ kind: 'tool', id: c.id ?? nextId(), name: c.name ?? '?', input: c.input, pending: true })
-        }
-        if (direct.length > 0) pushMsg({ id: msg.uuid ?? msgId ?? nextId(), role: 'assistant', blocks: direct })
-        return
-      }
-      // 块快照：把草稿中对应的增量块定稿（去重关键：同 message.id 同 kind 按序匹配）
-      const dblocks = d.blocks.map((b) => ({ ...b }))
-      for (const c of blocks) {
-        const kind = c?.type === 'thinking' ? 'thinking' : c?.type === 'tool_use' ? 'tool' : 'text'
-        const b = dblocks.find((x) => !x.finalized && x.kind === kind && (kind !== 'tool' || !c.id || x.toolId === c.id))
-        if (!b) continue
-        b.finalized = true
-        if (c?.type === 'text' && c.text) b.text = c.text
-        else if (c?.type === 'thinking' && c.thinking) b.text = c.thinking
-        else if (c?.type === 'tool_use') {
-          b.name = c.name ?? b.name
-          b.toolId = c.id ?? b.toolId
-          b.jsonBuf = c.input != null ? JSON.stringify(c.input) : b.jsonBuf
-        }
-      }
-      setDraftBoth({ ...d, blocks: dblocks })
-      return
-    }
-
-    if (msg.type === 'user') {
-      if (msg.isMeta) return
-      if (taskApi.appendSidechain(rec)) return
-      const content = msg.message?.content
-      const blocks = Array.isArray(content) ? content : typeof content === 'string' ? [{ type: 'text', text: content }] : []
-      const textBlocks: Block[] = []
-      for (const c of blocks) {
-        if (c?.type === 'tool_result') {
-          const resultText = toolResultText(c.content)
-          pairToolResult(c.tool_use_id, resultText, c.is_error === true)
-          // 主线 Agent tool_result 是子代理的终态兜底（正常路径是 task_notification 先到）
-          taskApi.settleBucketFromResult(c.tool_use_id, resultText, c.is_error === true)
-        } else if (c?.type === 'text' && c.text?.trim()) {
-          // /goal 的评估器反馈（Stop hook）：goal 循环内的中途评估，渲染为系统提示而非用户气泡
-          if (c.text.startsWith('Stop hook feedback:')) {
-            const body = c.text.replace(/^Stop hook feedback:\s*/, '')
-            pushSystem(`◎ 目标评估：${body.slice(0, 300)}`)
-            continue
-          }
-          textBlocks.push({ kind: 'text', text: c.text })
-        }
-      }
-      if (textBlocks.length > 0) {
-        const keys = liveMessageKeys({ uuid: msg.uuid })
-        if (hitsSeen(seenIdsRef.current, keys)) return
-        pushMsg({ id: msg.uuid ?? nextId(), role: 'user', blocks: textBlocks })
-      }
-      return
-    }
-
-    if (msg.type === 'system') {
-      switch (msg.subtype) {
-        case 'init': {
-          const slash = Array.isArray(rec.slash_commands) ? (rec.slash_commands as string[]) : undefined
-          setInitInfo({ model: rec.model as string | undefined, slashCommands: slash })
-          setPermMode(rec.permissionMode as string | undefined)
-          break
-        }
-        case 'status': {
-          // status 是 string|null（如 "requesting"/"compacting"），不是对象——勿迭代
-          const st = rec.status
-          setPhase(typeof st === 'string' ? st : undefined)
-          if (typeof rec.permissionMode === 'string') setPermMode(rec.permissionMode)
-          break
-        }
-        case 'thinking_tokens':
-          break // 增量 token 估算，不展示
-        case 'task_started': {
-          // 生命周期事件是桶的主注册点（实现在 hooks/useTaskBuckets.ts）
-          taskApi.taskStarted(rec)
-          if (!replay) pushSystem(`⚙ 后台任务启动：${String(rec.description ?? '')}`)
-          break
-        }
-        case 'task_progress': {
-          taskApi.taskProgress(rec)
-          break
-        }
-        case 'task_updated': {
-          taskApi.taskUpdated(rec)
-          break
-        }
-        case 'task_notification': {
-          const summary = typeof rec.summary === 'string' ? rec.summary : ''
-          taskApi.taskNotification(rec)
-          if (!replay) pushSystem(`⚙ 后台任务完成${summary ? `：${summary.slice(0, 200)}` : ''}`)
-          break
-        }
-        case 'compact_boundary': {
-          if (replay) break
-          const meta = (rec.compactMetadata ?? {}) as { preTokens?: number; postTokens?: number }
-          pushMsg({ id: nextId(), role: 'system', systemKind: 'divider', compactMeta: meta, blocks: [] })
-          break
-        }
-      }
-      return
-    }
-
-    if (msg.type === 'result') {
-      commitDraft()
-      setPhase(undefined)
-      // 补发的旧 result 已在 HTTP 历史里，再落「本轮」会在底部堆出一串重复页脚
-      if (replay) return
-      if (msg.uuid && hitsSeen(seenIdsRef.current, [msg.uuid])) return
-      if (msg.uuid) rememberKeys(seenIdsRef.current, [msg.uuid])
-      const isErr = rec.is_error === true
-      const dur = typeof rec.duration_ms === 'number' ? `${Math.round(rec.duration_ms / 1000)}s` : undefined
-      const usage = rec.usage as { output_tokens?: number } | undefined
-      const parts = [dur, usage?.output_tokens != null ? `${usage.output_tokens} tok` : undefined].filter(Boolean)
-      if (isErr) {
-        pushSystem(`⚠ ${String(rec.result ?? rec.subtype ?? '执行出错')}`, 'error')
-      } else if (parts.length > 0) {
-        pushSystem(`─ 本轮 ${parts.join(' · ')}`)
-      }
-      return
-    }
-  }
 
   // ---------- WS 连接 ----------
   useEffect(() => {
@@ -484,18 +162,18 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             taskApi.hydrateTasks(ev.state)
             // 进程已退出时固化/清理未完成的流式草稿，避免半截内容悬挂
             if (ev.state.exited) {
-              commitDraft()
+              ingestApi.commitDraft()
               setPhase(undefined)
-            } else if (ev.state.sessionState === 'idle' && !ev.state.busy && !ev.state.waiting && draftRef.current) {
+            } else if (ev.state.sessionState === 'idle' && !ev.state.busy && !ev.state.waiting && ingestApi.draftRef.current) {
               // 自愈：权威 idle 到达时清掉陈旧流式草稿。服务端重启/断线期间 turn 终结时
               // 客户端拿不到终结事件，"生成中"会永远挂着（实测：watch 重载后复现）。
               // 等审批（waiting/requires_action）期间草稿是合法的，不在此清理。
-              setDraftBoth(null)
+              ingestApi.setDraftBoth(null)
               setPhase(undefined)
               // turn 已终结：此刻仍未配对的 tool_result 不会再等到它的调用了，
               // 浮现为孤立提示而非静默丢弃（旧实现直接 clear，用户零反馈）
-              setMsgs((prev) => {
-                const st: IngestState = { msgs: prev, toolIdx: toolPosRef.current, pending: pendingResultsRef.current }
+              ingestApi.setMsgs((prev) => {
+                const st: IngestState = { msgs: prev, toolIdx: ingestApi.toolPosRef.current, pending: ingestApi.pendingResultsRef.current }
                 flushStrayResults(st)
                 return st.msgs
               })
@@ -521,24 +199,24 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               (typeof inp?.grantRoot === 'string' && inp.grantRoot) ||
               (typeof inp?.url === 'string' && inp.url) ||
               ''
-            pushSystem(
+            ingestApi.pushSystem(
               `规则自动${ev.action === 'allow' ? '放行' : '拒绝'}：${ev.toolName}${detail ? ` ${detail.slice(0, 120)}` : ''}（${ev.rule}）`,
             )
             break
           }
           case 'error':
-            pushSystem(`⚠ ${ev.message}`, 'error')
+            ingestApi.pushSystem(`⚠ ${ev.message}`, 'error')
             break
           case 'btw_pending':
             // 创建侧问卡片（发送方与其他客户端都以此为准）
-            if (!messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
-              pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: true, blocks: [] })
+            if (!ingestApi.messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
+              ingestApi.pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: true, blocks: [] })
             }
             break
           case 'btw_delta': {
-            const target = messagesRef.current.find((m) => m.btw === ev.question && m.btwPending)
+            const target = ingestApi.messagesRef.current.find((m) => m.btw === ev.question && m.btwPending)
             if (!target) break
-            setMsgs((prev) =>
+            ingestApi.setMsgs((prev) =>
               prev.map((m) => {
                 if (m.id !== target.id) return m
                 const blocks = [...m.blocks]
@@ -562,16 +240,16 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
           case 'btw_result': {
             // 找不到 pending 卡（如校验失败路径或漏收 btw_pending）时自行建卡落地结果——
             // 配对不变量由数据保证，不依赖服务端的消息时序
-            if (!messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
+            if (!ingestApi.messagesRef.current.some((m) => m.btw === ev.question && m.btwPending)) {
               const blocks: Block[] = ev.ok
                 ? ev.text.trim()
                   ? [{ kind: 'text', text: ev.text }]
                   : []
                 : [{ kind: 'text', text: `⚠ ${ev.text}` }]
-              pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: false, blocks })
+              ingestApi.pushMsg({ id: nextId(), role: 'assistant', btw: ev.question, btwPending: false, blocks })
               break
             }
-            setMsgs((prev) =>
+            ingestApi.setMsgs((prev) =>
               prev.map((m) => {
                 if (m.btw !== ev.question || !m.btwPending) return m
                 if (ev.ok) {
@@ -591,7 +269,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             if (ev.branchOf) {
               // claude 懒分叉：b| key 导航，首条消息才真正 --fork-session；
               // 历史视图直接读源会话 transcript（分支将原样继承它）
-              pushSystem(
+              ingestApi.pushSystem(
                 `⎇ 已创建分支${ev.name ? `「${ev.name}」` : ''}：新会话携带当前全部历史，原会话保持不动`,
               )
               props.onNavigate?.(
@@ -606,7 +284,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               break
             }
             // codex 分叉回滚完成：原线程不动，跳到携带截断历史的新线程
-            pushSystem('⎇ 已分叉：新会话携带所选消息之前的历史，原会话保持不动')
+            ingestApi.pushSystem('⎇ 已分叉：新会话携带所选消息之前的历史，原会话保持不动')
             setShowRewind(false)
             props.onNavigate?.(
               makeSessionInfo({
@@ -622,12 +300,12 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             break
           }
           case 'handoff_pending':
-            pushSystem(`⇄ 源会话正在生成交接简报（→ ${ev.toBackend === 'codex' ? 'Codex' : 'Claude'}）…`)
+            ingestApi.pushSystem(`⇄ 源会话正在生成交接简报（→ ${ev.toBackend === 'codex' ? 'Codex' : 'Claude'}）…`)
             break
           case 'handoff_brief':
             break // 简报在 handoff_done 时一并展示
           case 'handoff_done': {
-            pushMsg({
+            ingestApi.pushMsg({
               id: nextId(),
               role: 'system',
               systemKind: 'info',
@@ -649,7 +327,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             break
           }
           case 'handoff_error':
-            pushSystem(`⚠ 接力失败: ${ev.message}`, 'error')
+            ingestApi.pushSystem(`⚠ 接力失败: ${ev.message}`, 'error')
             break
           case 'query_result': {
             // MCP 管理动作应答（按 query id 辨认）：清忙态、给反馈、成功后刷新清单
@@ -657,10 +335,10 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
               pendingMcpActionRef.current = null
               setMcpBusy(null)
               if (ev.ok) {
-                pushSystem('✓ MCP 操作完成')
+                ingestApi.pushSystem('✓ MCP 操作完成')
                 runQuery('mcp_status', 'MCP 状态')
               } else {
-                pushSystem(`⚠ MCP 操作失败: ${ev.error ?? '未知错误'}`, 'error')
+                ingestApi.pushSystem(`⚠ MCP 操作失败: ${ev.error ?? '未知错误'}`, 'error')
               }
               break
             }
@@ -685,10 +363,10 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             // 回滚会销毁并重生 CLI 进程（dispose 先摘 map 再 kill，onExit 不会触发），
             // 进行中的流式草稿/待配对工具结果/相位指示全部失效，必须一并清理，
             // 否则陈旧草稿会挂在回滚标签之下。
-            setDraftBoth(null)
-            pendingResultsRef.current.clear()
+            ingestApi.setDraftBoth(null)
+            ingestApi.pendingResultsRef.current.clear()
             setPhase(undefined)
-            setMsgs((prev) => {
+            ingestApi.setMsgs((prev) => {
               const idx = prev.findIndex((m) => m.id === ev.userMessageId)
               const base = idx >= 0 ? prev.slice(0, idx + 1) : prev
               const label = ev.scope === 'both' ? '↩ 对话和文件已回滚' : '↩ 对话已回滚'
@@ -696,15 +374,15 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             })
             break
           case 'cli':
-            if (gapReloadingRef.current) break
-            handleCli(ev.msg, ev.replay === true)
+            if (ingestApi.gapReloadingRef.current) break
+            ingestApi.handleCli(ev.msg, ev.replay === true)
             break
           case 'tail': {
             // 外部会话 transcript 追加：与历史共用同一套归并；uuid 去重兜底（重连续订可能重放）
             const h = ev.msg
-            if (h.uuid && messagesRef.current.some((m) => m.id === h.uuid)) break
-            setMsgs((prev) => {
-              const st: IngestState = { msgs: prev, toolIdx: toolPosRef.current, pending: pendingResultsRef.current }
+            if (h.uuid && ingestApi.messagesRef.current.some((m) => m.id === h.uuid)) break
+            ingestApi.setMsgs((prev) => {
+              const st: IngestState = { msgs: prev, toolIdx: ingestApi.toolPosRef.current, pending: ingestApi.pendingResultsRef.current }
               appendHistoryMsg(st, h)
               // 不在此 flush：tail 是逐条到达，tool_use 可能在后续行；孤儿在权威 idle 时统一浮现
               return st.msgs
@@ -738,36 +416,36 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             // transcript 是权威事实源，重载一定能补齐（代价只是一次 HTTP）。
             // 必须与初次加载走同一 loader——Codex 没有 Claude transcript 路径。
             // 先挡住 cli 再清草稿：环里残留的 stream/assistant 不能在重载完成前改抄本。
-            gapReloadingRef.current = true
-            setDraftBoth(null)
-            pendingResultsRef.current.clear()
+            ingestApi.gapReloadingRef.current = true
+            ingestApi.setDraftBoth(null)
+            ingestApi.pendingResultsRef.current.clear()
             setPhase(undefined)
             const gapKey = session.key
             loadSessionHistory()
               .then((resp) => {
                 if (sockRef.current?.key !== gapKey) return // 异步返回时已切走
-                applyHistory(resp)
-                pushSystem('↻ 断线较久，已重新载入对话')
+                ingestApi.applyHistory(resp)
+                ingestApi.pushSystem('↻ 断线较久，已重新载入对话')
               })
               .catch(() => {
                 if (sockRef.current?.key !== gapKey) return
-                pushSystem('⚠ 重新载入对话失败，请手动刷新', 'error')
+                ingestApi.pushSystem('⚠ 重新载入对话失败，请手动刷新', 'error')
               })
               .finally(() => {
-                if (sockRef.current?.key === gapKey) gapReloadingRef.current = false
+                if (sockRef.current?.key === gapKey) ingestApi.gapReloadingRef.current = false
               })
             break
           }
           case 'tail_reset': {
             // 外部会话截断了 transcript（rewind / clear）：重载历史并用新偏移重新订阅
-            setDraftBoth(null)
-            pendingResultsRef.current.clear()
+            ingestApi.setDraftBoth(null)
+            ingestApi.pendingResultsRef.current.clear()
             const keyAtFetch = session.key
             fetchHistory(session.slug, session.sessionId)
               .then((resp) => {
                 // 异步返回时用户可能已切走：socket 已换成新会话的，弃掉过期结果
                 if (sockRef.current?.key !== keyAtFetch) return
-                applyHistory(resp)
+                ingestApi.applyHistory(resp)
               })
               .catch(() => {})
             break
@@ -781,8 +459,8 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
         // 才能取回「一条可落盘 cli 都没收到就断线」期间的环。首连走下面的 attach。
         if (sock.reconnecting) sock.send({ kind: 'attach', fromSeq: sock.replayFrom })
         // 重连后服务端的 tailer 已随连接断开被回收，用已知的偏移重新订阅（重放部分由 uuid 去重）
-        if (historyOffsetRef.current != null) {
-          sock.send({ kind: 'tail_subscribe', from: historyOffsetRef.current })
+        if (ingestApi.historyOffsetRef.current != null) {
+          sock.send({ kind: 'tail_subscribe', from: ingestApi.historyOffsetRef.current })
         }
       },
     )
@@ -871,7 +549,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
     } else {
       sockRef.current?.send({ kind: 'user', text: condition ? `/goal ${condition}` : '/goal clear' })
     }
-    pushSystem(condition ? `◎ 已设定目标：${condition}` : '◎ 已清除目标')
+    ingestApi.pushSystem(condition ? `◎ 已设定目标：${condition}` : '◎ 已清除目标')
   }
 
   // ---------- StatusPill 共享处理器（claude/codex 两个胶囊的 mode/effort 同构；model 因本地回显差异分开） ----------
@@ -893,14 +571,14 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
         return
       case 'btw':
         if (a.question) sock?.send({ kind: 'btw', question: a.question })
-        else pushSystem('用法：/btw <问题>')
+        else ingestApi.pushSystem('用法：/btw <问题>')
         return
       case 'branch':
-        if (isCodex) pushSystem('Codex 请用「回滚」面板的从此处分叉')
+        if (isCodex) ingestApi.pushSystem('Codex 请用「回滚」面板的从此处分叉')
         else sock?.send({ kind: 'branch', ...(a.name ? { name: a.name } : {}) })
         return
       case 'exitHint':
-        pushSystem('此命令会终止 CLI 进程。要结束会话请回列表页归档（⌄ 按钮），进程回收由服务端空闲策略处理')
+        ingestApi.pushSystem('此命令会终止 CLI 进程。要结束会话请回列表页归档（⌄ 按钮），进程回收由服务端空闲策略处理')
         return
       case 'compact':
         sock?.send({ kind: 'control', subtype: 'compact' })
@@ -908,7 +586,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       case 'context': {
         // codex 无 get_context_usage 对应物；用状态里的累计 token 用量顶一句
         const u = state.usage
-        pushSystem(
+        ingestApi.pushSystem(
           u
             ? `◈ 线程累计：in ${u.inputTokens} / out ${u.outputTokens}${u.reasoningTokens ? ` / reasoning ${u.reasoningTokens}` : ''}（窗口占用明细请开「详情」）`
             : '◈ 暂无用量数据（先跑一轮）',
@@ -918,19 +596,19 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       case 'goal':
         if (a.clear) sendGoal()
         else if (a.condition) sendGoal(a.condition)
-        else pushSystem(state.goal ? `◎ 当前目标：${state.goal.condition}` : '用法：/goal <条件>，/goal clear 清除')
+        else ingestApi.pushSystem(state.goal ? `◎ 当前目标：${state.goal.condition}` : '用法：/goal <条件>，/goal clear 清除')
         return
       case 'review':
         sock?.send({ kind: 'control', subtype: 'review', ...(a.instructions ? { extra: { instructions: a.instructions } } : {}) })
-        pushSystem(a.instructions ? `◈ 审查中：${a.instructions}` : '◈ 审查未提交的改动中…')
+        ingestApi.pushSystem(a.instructions ? `◈ 审查中：${a.instructions}` : '◈ 审查未提交的改动中…')
         return
       case 'rename':
         if (!a.name) {
-          pushSystem('用法：/rename <新名字>')
+          ingestApi.pushSystem('用法：/rename <新名字>')
           return
         }
         sock?.send({ kind: 'control', subtype: 'rename', extra: { name: a.name } })
-        pushSystem(`✎ 重命名线程为「${a.name}」`)
+        ingestApi.pushSystem(`✎ 重命名线程为「${a.name}」`)
         return
       case 'newThread': {
         const cwd = session.cwd
@@ -941,7 +619,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
             ),
           )
         } else {
-          pushSystem('⚠ 未知当前目录，无法新建线程', 'error')
+          ingestApi.pushSystem('⚠ 未知当前目录，无法新建线程', 'error')
         }
         return
       }
@@ -966,7 +644,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
       ...pendingImages.map((img) => ({ kind: 'image' as const, src: imgPreviewSrc(img) })),
       ...(text ? [{ kind: 'text' as const, text }] : []),
     ]
-    pushMsg({ id: nextId(), role: 'user', blocks: echoBlocks })
+    ingestApi.pushMsg({ id: nextId(), role: 'user', blocks: echoBlocks })
     sock.send({
       kind: 'user',
       text,
@@ -1045,7 +723,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
         usageLine={usageLine}
         moreOpen={moreOpen}
         setMoreOpen={setMoreOpen}
-        onSystemMessage={pushSystem}
+        onSystemMessage={ingestApi.pushSystem}
         onToggleDetail={() => {
           setDetailOpen((v) => !v)
           // codex 无 get_context_usage 对应物，默认落在 MCP 状态上
@@ -1066,7 +744,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
           const toBackend = isCodex ? 'claude' : 'codex'
           setHandoffBusy(true)
           startHandoff(session.key, toBackend)
-            .catch((e) => pushSystem(`⚠ 接力失败: ${e instanceof Error ? e.message : e}`, 'error'))
+            .catch((e) => ingestApi.pushSystem(`⚠ 接力失败: ${e instanceof Error ? e.message : e}`, 'error'))
             .finally(() => setHandoffBusy(false))
         }}
         lineage={lineage}
@@ -1097,7 +775,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
           onClose={() => setShowRewind(false)}
           onRewindFiles={(uuid) => {
             sockRef.current?.send({ kind: 'control', subtype: 'rewind_files', extra: { user_message_id: uuid } })
-            pushSystem('↩ 已请求回滚文件')
+            ingestApi.pushSystem('↩ 已请求回滚文件')
             setShowRewind(false)
           }}
           onRewindConversation={(uuid) => {


### PR DESCRIPTION
## 概要

ROADMAP 方向六（架构解耦）全量落地，**零行为改动**红线：

- **S1 BackendPort 契约**：`server/src/backends/port.ts` + claude/codex 两个适配器，18 处 `isCodexKey` 分支从编排层清零；适配器严守零 await 时序约束（ensure 函数体到 return 前无 await）
- **S2 index.ts 物理拆分**：1945 → 306 行装配层；`hub/`（types/registry/broadcast/status/callbacks/lifecycle/messages/handoff/socket）+ `push/`（fanout/inbox）+ `routes/`（api/sessions/pushRoutes/misc）四组；循环依赖经显式注册消解（`initBackendPorts(hubServices)` / `initInbox(deps)`，不依赖 ESM 加载顺序）
- **F1-F5 Chat.tsx 拆解**：2052 → 565 行；`lib/chatText.ts` + `lib/slashIntercept.ts`（10 条拦截表搬迁，顺序=优先级逐字保留，新增 bun:test 钉住）；`ChatHeader/Composer/DetailDrawer` 三个纯展示组件（props 平铺、不加 memo）；三个 hook——`useTaskBuckets`（后台任务桶 + TTL 驱逐）→ `useTranscriptIngest`（主抄本 ingest + 7 个配对/去重 ref + cli 流元数据）→ `useSessionSocket`（WS 生命周期 + 17 种 ServerEvent 分发）。「reset 先于建连」顺序纪律在 Chat.tsx 注释钉死

## 兼容面（逐字不变）

REST 路径/响应形状、WS 消息协议、`web/src/lib/*` 导出签名、`TasksPanel.flattenTasks`、`PopupPanel.popupPosition`、`App→Chat` props。每个 commit 均过 `typecheck + bun test(406) + build` 门禁。

## 验证

- **单元**：406 tests 全绿（F1 新增拦截表测试）
- **e2e 全量回归**（真实 claude 2.1.261 / codex 0.149.0）：smoke ✓、e2e-ws ✓、e2e-slash ✓（/compact + /btw side_question 私有 subtype）、e2e-branch-btw-goal ✓ 6/6、e2e-codex ✓、e2e-codex-cmds ✓ 3/3、e2e-codex-goal ✓ 3/3、e2e-handoff ✓ 双向、e2e-rewind ✓ 三路径、e2e-push ✓ 15/15（VAPID 验签 + RFC8291 解密 + 能力 URL 直接审批 + 410 摘除）
- **浏览器实测**（chrome-devtools MCP）：发消息全链路（echo → 流式草稿 → commitDraft → result 页脚 → idle）、ContextRing（13% 32.1k/256.0k）、AI 标题生成、斜杠面板 8 命令、更多菜单 5 项、详情抽屉三 tab、会话切换重置 + 历史恢复、codex 会话渲染（思考折叠/usage 行含 cache+rs/StatusPill 工作区模式）、控制台零报错

## e2e 环境坑记录（非本 PR 引入，建议后续修）

1. **e2e-clear 的「新会话无旧上下文」断言会被 CLI 新版自动记忆功能打败**：模型把暗号写进项目 memory/ 目录，clear 后的新会话读记忆文件回答——clear 语义本身正常（moved 重键 ✓ 路由 ✓），是测试假设腐化
2. **e2e-push / e2e-approval 的审批触发依赖本机权限模式**：本机用户级 settings.json 设了 `defaultMode: "auto"`（AI 门禁），简单 Write/Bash 不触发审批；验证时用 `set_permission_mode default` 显式覆盖后全绿
3. **codex 把 `/tmp` 解析为 `D:\tmp`**（不存在）——Windows 下跑 e2e 脚本必须显式传存在的目录（e2e-branch-btw-goal/e2e-push 的默认值是 POSIX 假设）
4. **codex 同 threadId 多会话注册的静默竞态（pre-existing）**：`registerThread` 无条件覆盖 byThread 映射；浏览器 attach `x|<tid>` 会把通知解复用从 `xn|` 源会话抢走，后者 turn 照跑但客户端收不到事件（runtime.ts 本 PR 零 diff，master 同构）

## 回退粒度

单 commit revert；阶段 tag：d6-s2（服务端拆完）、d6-f5（前端拆完）。