### PR TITLE
security: 全仓库安全审查修复轮（启动日志 authToken / webhook 渠道凭证脱敏）

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -217,20 +217,23 @@ const displayHost = isLoopbackHost(config.host)
   : config.host === '0.0.0.0' || config.host === '::'
     ? lanAddress()
     : config.host
-const accessUrl = `http://${displayHost}:${server.port}/${config.authToken ? `?token=${config.authToken}` : ''}`
+// authToken 是 /api 与 /ws 的唯一防线凭据，绝不能进日志 sink（stdout 会被 nohup/journal/日志采集持久化，
+// docs 还建议打包上传日志）。带 token 的完整 URL 与二维码仅向交互终端直出（绕过 logger），供管理员扫码 onboarding。
+const baseUrl = `http://${displayHost}:${server.port}/`
 log.info(
-  `[anyplane] listening on ${accessUrl} pid=${process.pid} ppid=${process.ppid} bun=${Bun.version}`,
+  `[anyplane] listening on ${baseUrl} pid=${process.pid} ppid=${process.ppid} bun=${Bun.version} auth=${config.authToken ? 'token' : 'off'}`,
 )
 log.info(`[anyplane] permissionPolicy=${config.permissionPolicy} claudeConfigDir=${config.claudeConfigDir}`)
 if (!config.authToken) {
   log.info('[anyplane] 未配置 authToken，仅监听回环地址。需要局域网访问时：配置 authToken 并设置 host。')
 }
 
-// 局域网模式：打印扫码即入的终端二维码（URL 已带 token）
-if (!isLoopbackHost(config.host)) {
+// 局域网模式：打印扫码即入的终端二维码（URL 带 token；仅交互终端——重定向到文件/服务管理器时不输出）
+if (!isLoopbackHost(config.host) && process.stdout.isTTY) {
   try {
     const { default: QRCode } = await import('qrcode')
-    log.info(await QRCode.toString(accessUrl, { type: 'terminal', small: true }))
+    const accessUrl = `${baseUrl}${config.authToken ? `?token=${config.authToken}` : ''}`
+    process.stdout.write(`${await QRCode.toString(accessUrl, { type: 'terminal', small: true })}\n`)
   } catch (e) {
     log.warn('[anyplane] 二维码生成失败（不影响服务）:', e)
   }

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -13,6 +13,7 @@
 import { existsSync } from 'node:fs'
 import {
   createCipheriv,
+  createHash,
   createHmac,
   createPrivateKey,
   createPublicKey,
@@ -349,9 +350,11 @@ export async function pushToAll(payload: PushPayload): Promise<{ sent: number; p
 //   Bark/Server酱 —— 无原生按钮，链接落 GET /api/approval-page 确认页（按钮再 POST），
 //                    不做直出 GET 审批链接：链接被预览/抓取即误触。
 
-/** 渠道标识：唯一定位一条配置的字符串（secret 派生输入，也用于日志）
+/** 渠道标识：唯一定位一条配置的字符串（secret 派生输入）
  *  ntfy server 必须规范化（去掉末尾斜杠），否则 https://ntfy.sh/ 与 https://ntfy.sh
  *  会派生不同 secret，导致改配置后旧审批 URL 失效。
+ *  注意：返回值含渠道凭证（ntfy topic / Bark URL key / Server酱 SendKey），持有者可读通知全文
+ *  （含审批能力 URL），严禁进日志——日志场景一律用 webhookLogId。
  */
 function webhookId(wh: PushWebhookConfig): string {
   switch (wh.type) {
@@ -362,6 +365,11 @@ function webhookId(wh: PushWebhookConfig): string {
     case 'sct':
       return `sct:${wh.sendkey}`
   }
+}
+
+/** 日志用渠道标识：类型 + webhookId 的 SHA-256 前 8 位（稳定可区分、不泄露渠道凭证） */
+function webhookLogId(wh: PushWebhookConfig): string {
+  return `${wh.type}:${createHash('sha256').update(webhookId(wh)).digest('hex').slice(0, 8)}`
 }
 
 /** 从 vapid 私钥派生的 per-webhook 能力密钥（18 字节 → 24 字符，与订阅 secret 同长） */
@@ -494,16 +502,16 @@ export async function pushWebhooksToAll(payload: PushPayload): Promise<{ sent: n
       try {
         const status = await sendWebhook(wh, payload)
         if (status === undefined) {
-          log.warn(`[push] webhook ${webhookId(wh)} 类型未知，跳过`)
+          log.warn(`[push] webhook ${webhookLogId(wh)} 类型未知，跳过`)
           return
         }
         if (status >= 200 && status < 300) {
           sent++
         } else {
-          log.warn(`[push] webhook ${webhookId(wh)} 投递失败 (HTTP ${status})`)
+          log.warn(`[push] webhook ${webhookLogId(wh)} 投递失败 (HTTP ${status})`)
         }
       } catch (e) {
-        log.warn(`[push] webhook ${webhookId(wh)} 投递失败:`, e instanceof Error ? e.message : e)
+        log.warn(`[push] webhook ${webhookLogId(wh)} 投递失败:`, e instanceof Error ? e.message : e)
       }
     }),
   )


### PR DESCRIPTION
## 审查范围与方法

对全仓库 `server/`、`web/`、`scripts/` 下全部 TypeScript/TSX 源码（约 1.9 万行，非仅 diff）做了一轮安全审查：4 路并行审查（服务端核心+路由+推送 / claude 后端 / codex 后端 / 前端+网关脚本）→ 每个候选发现独立对抗性验证 → 只修复确认的真实问题。

覆盖重点：注入、认证与授权绕过、CORS/跨源防护、密钥泄露、SSRF、路径穿越、不安全默认值、WebSocket 鉴权缺口。

## 发现 → 修复

### 1. authToken 明文写入启动日志（Medium，CWE-532）→ 已修复

**证据**：`server/src/index.ts:220-223`（修复前）

```ts
const accessUrl = `http://${displayHost}:${server.port}/${config.authToken ? `?token=${config.authToken}` : ''}`
log.info(`[anyplane] listening on ${accessUrl} pid=...`)
```

- 无条件执行、无 TTY 门控；authToken 是 `/api` 与 `/ws` 的唯一防线（`util.ts:56-61` 注释自认，且特意从子进程 env 剥离），却每次启动明文进 stdout。nohup/journal/容器日志采集会持久化；`docs/configuration.md:44` 还建议 `> anyplane.log 2>&1` 并在反馈时打包上传。读日志 = 拿到完整远程控制权（spawn 会话 = RCE）。
- 同 URL 的终端二维码（原 230-234 行）是刻意的局域网 onboarding 设计，但它走同一个 log sink，同样被持久化。

**修复**（commit `eb99c7c`）：`listening on` 行只保留裸地址 + `auth=token|off` 状态位；带 token 的完整 URL 与二维码保留给刻意设计，但加 `process.stdout.isTTY` 门控并改用 `process.stdout.write` 直出终端、绕过 logger——重定向/服务管理器场景零泄露。已实测：管道场景日志全文 0 次出现 token；TTY 场景 QR 正常打印、`listening on` 行仍无 token。

### 2. push webhook 渠道凭证写入投递失败日志（Low，CWE-532）→ 已修复

**证据**：`server/src/push.ts:356-364`（`webhookId`）+ 原 497/503/506 三处 `log.warn`

```ts
function webhookId(wh: PushWebhookConfig): string {
  // ntfy: server+topic； bark: 完整 URL（路径含 device key）； sct: 完整 SendKey
}
log.warn(`[push] webhook ${webhookId(wh)} 投递失败 (HTTP ${status})`)
```

- `config.ts:13-14` 注释自认"渠道凭证即通知保密边界……持有者能读通知全文（含审批能力 URL）"。这些值进日志后，读日志者可窃听未保护 ntfy topic 的后续通知、捕获渠道稳定的审批能力密钥 `s=`；对 Bark/Server酱 则可向用户通知流注入伪造内容。
- 验证中已排除过度声明：`s=` 是 HMAC(vapid 私钥, …) 派生，私钥不落日志，仅知 SendKey 无法重算历史 `s=`。

**修复**（commit `79afe47`）：`webhookId` 仅保留给 secret 派生（HMAC 输入需全保真）；日志改用新增 `webhookLogId`（`类型:SHA-256(webhookId) 前 8 位`），稳定可区分渠道、不泄露凭证，投递失败排查能力不受影响。

## 残留风险（人工判断项）

- **`b|` 会话 key 第三段 `forkFromSessionId` 无字符集校验**（`server/src/backends/claude/backend.ts:55-56` 直接返回 `parts[2]`，不像 `s|` key 走 `splitExistingKey` 的 `[a-zA-Z0-9-]` 门）：该值进入 `processManager.ts:303-305` `hydrateContextUsage` 的 `join(projects, cwd, \`${sourceId}.jsonl\`)`，`../` 可逃逸 projects 目录；attach 消息 `opts` 裸 spread（`port.ts:117-124`）是更宽的注入点。验证结论：**不构成漏洞**——sink 只读且只回传数字 token 用量（无文件内容外泄、无写路径），且唯一能触发的认证 WS 客户端本就拥有任意目录起会话的更高权限。是否作为纵深防御补字符集门（对齐 `s|` key，约 3 行）请人工定夺。
- 启动 QR/带 token URL 在交互终端可见属刻意设计（Jupyter/code-server 同款 onboarding），本 PR 仅将其与持久化日志 sink 隔离，未移除该功能。

## 验证

- `bun test`：460 pass / 0 fail（42 个测试文件）
- `bun run typecheck`：通过
- 启动冒烟：非 TTY 日志零 token；TTY QR 正常

刻意设计均已确认保留：Origin/Host 一致性校验、审批能力 URL 链路、订阅 endpoint 白名单、无 token 拒绝非回环绑定等均未改动。