### PR TITLE
fix: code-review 全量审查修复——补发/翻页/回滚/审批生命周期与水合、轮询效率

### DIFF
--- a/server/src/archive.ts
+++ b/server/src/archive.ts
@@ -6,7 +6,7 @@
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
 import { config } from './config'
-import { ccDataDir, ensurePrivateDir } from './util'
+import { ccDataDir, ensurePrivateDir, transcriptPathOf } from './util'
 
 function trashRoot(): string {
   return ensurePrivateDir(join(ccDataDir(), 'trash', 'claude'))
@@ -34,10 +34,6 @@ function move(src: string, dest: string): void {
   }
 }
 
-function transcriptPath(slug: string, sessionId: string): string {
-  return join(config.claudeConfigDir, 'projects', slug, `${sessionId}.jsonl`)
-}
-
 export interface TrashEntry {
   key: string
   slug: string
@@ -49,7 +45,7 @@ export interface TrashEntry {
 
 /** claude 会话归档：jsonl + 可能的 subagents 目录一起移入回收站 */
 export function archiveClaudeSession(slug: string, sessionId: string): void {
-  const src = transcriptPath(slug, sessionId)
+  const src = transcriptPathOf(slug, sessionId)
   if (!existsSync(src)) throw new Error('transcript 不存在')
   const destDir = join(trashRoot(), slug)
   mkdirSync(destDir, { recursive: true })
@@ -70,7 +66,7 @@ export function restoreClaudeSession(slug: string, sessionId: string): void {
   const destDir = join(trashRoot(), slug)
   const src = join(destDir, `${sessionId}.jsonl`)
   if (!existsSync(src)) throw new Error('回收站中没有该会话')
-  const dest = transcriptPath(slug, sessionId)
+  const dest = transcriptPathOf(slug, sessionId)
   if (existsSync(dest)) throw new Error('原位置已有同名 transcript')
   const projectDir = join(config.claudeConfigDir, 'projects', slug)
   mkdirSync(projectDir, { recursive: true })

--- a/server/src/backends/claude/agents.ts
+++ b/server/src/backends/claude/agents.ts
@@ -58,7 +58,9 @@ export function parseAgentsJson(text: string): Map<string, DaemonAgent> {
   return map
 }
 
-const TTL_MS = 15_000
+// /api/sessions 每 10s 轮询一次，而每次 spawn `claude agents --json --all` 都是全量 CLI 冷启动。
+// 15s TTL 意味着列表页开着就每 ~15s 白 spawn 一个 CLI；后台 agent 的存活态不需要秒级新鲜度。
+const TTL_MS = 60_000
 let cache: { at: number; map: Map<string, DaemonAgent> } | undefined
 let inflight = false
 

--- a/server/src/backends/claude/backend.ts
+++ b/server/src/backends/claude/backend.ts
@@ -3,12 +3,11 @@
 // 分叉会话 `b|<encodeURIComponent(cwd)>|<sourceSessionId>`（懒分叉：首条消息才 --fork-session）。
 
 import { closeSync, openSync, readSync, statSync } from 'node:fs'
-import { join } from 'node:path'
-import { config } from '../../config'
 import type { ContextUsageInfo } from '../types'
 import { listSessions, sessionMetaOf } from './discovery'
 import { contextUsageOf, contextWindowOf, extractUsageFromTranscriptTail } from './processManager'
 import { sessionModelOf } from './sessionModels'
+import { transcriptPathOf } from '../../util'
 
 export function keyFor(slug: string, sessionId: string): string {
   return `s|${slug}|${sessionId}`
@@ -85,7 +84,7 @@ const hydrationCache = new Map<string, { mtimeMs: number; context: ContextUsageI
 export function hydratedContextOf(key: string): ContextUsageInfo | undefined {
   const ek = splitExistingKey(key)
   if (!ek) return undefined
-  const path = join(config.claudeConfigDir, 'projects', ek.slug, `${ek.sessionId}.jsonl`)
+  const path = transcriptPathOf(ek.slug, ek.sessionId)
   let size: number
   let mtimeMs: number
   try {

--- a/server/src/backends/claude/discovery.ts
+++ b/server/src/backends/claude/discovery.ts
@@ -5,7 +5,7 @@ import { closeSync, existsSync, fstatSync, openSync, readdirSync, readFileSync, 
 import { basename, join } from 'node:path'
 import { saveUpload } from '../../uploads'
 import { config } from '../../config'
-import { sanitizePath } from '../../util'
+import { sanitizePath, transcriptPathOf } from '../../util'
 import { backgroundAlive, daemonAgents } from './agents'
 import { isInternalUserMessage, type CliMessage } from './protocol'
 
@@ -178,7 +178,7 @@ function extractMetaCached(path: string, mtimeMs: number, size: number): ReturnT
 /** 单个 transcript 的 meta（经 memo）。parseKey 快路径用：O(1) 单文件读替代 listSessions() 全盘扫描。
  *  调用方须先过 splitExistingKey 的形状闸（slug/sessionId 拼进文件路径）。 */
 export function sessionMetaOf(slug: string, sessionId: string): ReturnType<typeof extractMeta> | undefined {
-  const path = join(config.claudeConfigDir, 'projects', slug, `${sessionId}.jsonl`)
+  const path = transcriptPathOf(slug, sessionId)
   try {
     const st = statSync(path)
     return extractMetaCached(path, st.mtimeMs, st.size)
@@ -396,18 +396,40 @@ export interface HistoryPage {
   nextBefore?: number
 }
 
-export function readHistory(
-  slug: string,
-  sessionId: string,
-  opts?: { limit?: number; before?: number },
-): HistoryPage {
-  const limit = opts?.limit ?? 300
-  const before = opts?.before
-  const path = join(config.claudeConfigDir, 'projects', slug, `${sessionId}.jsonl`)
-  if (!existsSync(path)) return { messages: [], fileBytes: 0, subagents: readSubagentTranscripts(slug, sessionId), hasMore: false }
-  // 读 Buffer 而非 utf8 文本：fileBytes 必须与本次实际解析的字节精确一致，
-  // tailer 从该偏移续读才不会有缝（statSync 与 read 之间文件可能增长）。
-  const raw = readFileSync(path)
+/** 全量解析结果的 (mtimeMs, size) 键缓存：翻 N 页不再付 N 次全文件读 + 逐行 JSON.parse
+ *  （长会话每页可达数百 ms，阻塞单线程事件循环）。transcript 只追加，键变即内容变；
+ *  外部回滚/重建会改 size/mtime，自然失效。LRU 封顶防长会话集合撑爆内存。 */
+interface ParsedTranscript {
+  fileBytes: number
+  msgs: HistoryMessage[]
+  msgLineIdx: number[]
+  selectable: boolean[]
+  lastBoundaryLine: number
+  /** 旧版内联侧链桶：仅首页（无 before）消费，解析是内容派生，随缓存一起保留 */
+  legacySidechain: Map<string, HistoryMessage[]>
+}
+const PARSE_CACHE_CAP = 8
+const parseCache = new Map<string, { mtimeMs: number; size: number; parsed: ParsedTranscript }>()
+
+function parseTranscriptCached(path: string, mtimeMs: number, size: number, raw: Buffer): ParsedTranscript {
+  const hit = parseCache.get(path)
+  if (hit && hit.mtimeMs === mtimeMs && hit.size === size) {
+    // LRU 触摸：命中即最新，淘汰从最早未用开始
+    parseCache.delete(path)
+    parseCache.set(path, hit)
+    return hit.parsed
+  }
+  const parsed = parseTranscript(raw)
+  parseCache.set(path, { mtimeMs, size, parsed })
+  while (parseCache.size > PARSE_CACHE_CAP) {
+    const oldest = parseCache.keys().next().value
+    if (oldest === undefined) break
+    parseCache.delete(oldest)
+  }
+  return parsed
+}
+
+function parseTranscript(raw: Buffer): ParsedTranscript {
   const lines = raw.toString('utf8').split('\n')
   const msgs: HistoryMessage[] = []
   const msgLineIdx: number[] = []
@@ -441,6 +463,25 @@ export function readHistory(
     msgLineIdx.push(li)
     selectable.push(msg.role !== 'user' || isSelectableRewindTarget(obj))
   }
+  // legacySidechain 随缓存返回（内容派生）；旧注释见 interface 字段说明
+  return { fileBytes: raw.length, msgs, msgLineIdx, selectable, lastBoundaryLine, legacySidechain }
+}
+
+export function readHistory(
+  slug: string,
+  sessionId: string,
+  opts?: { limit?: number; before?: number },
+): HistoryPage {
+  const limit = opts?.limit ?? 300
+  const before = opts?.before
+  const path = transcriptPathOf(slug, sessionId)
+  if (!existsSync(path)) return { messages: [], fileBytes: 0, subagents: readSubagentTranscripts(slug, sessionId), hasMore: false }
+  // 读 Buffer 而非 utf8 文本：fileBytes 必须与本次实际解析的字节精确一致，
+  // tailer 从该偏移续读才不会有缝（statSync 与 read 之间文件可能增长）。
+  const st = statSync(path)
+  const raw = readFileSync(path)
+  const { fileBytes, msgs, msgLineIdx, selectable, lastBoundaryLine, legacySidechain } =
+    parseTranscriptCached(path, st.mtimeMs, st.size, raw)
   // 只有最后一个 compact 边界之后的消息才是逻辑上存在、可回滚的；
   // user 消息还需通过官方同款的目标过滤（无 checkpoint 的消息不可作为 rewind 目标）。
   // rewindable 必须基于全量列表计算（lastBoundaryLine 是全文件扫描的产物），与分页窗口无关
@@ -465,9 +506,9 @@ export function readHistory(
       if (!subagents.some((s) => s.toolUseId === toolUseId)) subagents.push({ toolUseId, messages })
     }
     subagents.sort((a, b) => (a.messages[0]?.timestamp ?? '').localeCompare(b.messages[0]?.timestamp ?? ''))
-    return { messages: page, fileBytes: raw.length, subagents, hasMore, nextBefore }
+    return { messages: page, fileBytes, subagents, hasMore, nextBefore }
   }
-  return { messages: page, fileBytes: raw.length, hasMore, nextBefore }
+  return { messages: page, fileBytes, hasMore, nextBefore }
 }
 
 /** 单个子代理转录的消息上限（防止超长转录拖垮首载；超出时保留末尾） */

--- a/server/src/backends/claude/port.ts
+++ b/server/src/backends/claude/port.ts
@@ -2,12 +2,11 @@
 // 方法体多为 index.ts 原 claude 分支的逐字搬迁——重构红线是零行为改动。
 
 import { appendFileSync, existsSync } from 'node:fs'
-import { join } from 'node:path'
 import { archiveClaudeSession, listTrash, restoreClaudeSession } from '../../archive'
-import { config, defaultPermissionMode } from '../../config'
+import { defaultPermissionMode } from '../../config'
 import { briefPrompt, generateClaudeBrief, type HandoffDetail } from '../../handoff'
 import { log } from '../../log'
-import { errorMessage } from '../../util'
+import { errorMessage, transcriptPathOf } from '../../util'
 import type { Hub } from '../../hub/types'
 import {
   baseStatusOf,
@@ -218,7 +217,7 @@ class ClaudePort implements BackendPort {
     const ek = splitExistingKey(hub.key)
     if (!ek) return // 新会话还没有 transcript
     if (processManager.get(hub.key)) return // 已 spawn：live 流覆盖，无需 tail
-    const path = join(config.claudeConfigDir, 'projects', ek.slug, `${ek.sessionId}.jsonl`)
+    const path = transcriptPathOf(ek.slug, ek.sessionId)
     hub.tailer = new TranscriptTailer(path, from, {
       onMessage: (msg) => {
         hubServices().broadcast(hub, { kind: 'tail', msg })
@@ -261,7 +260,16 @@ class ClaudePort implements BackendPort {
         this.rewindConversationAt(hub, at, 'both')
       })
       .catch((error) => {
-        hubServices().broadcastError(hub, `回滚文件失败，未回滚对话：${errorMessage(error)}`)
+        // 超时 ≠ 失败：rewind_files 没有 CLI 侧超时，大项目恢复可能在我们 120s 断点后
+        // 仍静默完成——此时文件已回滚而对话未截断（半回滚）。文案必须如实区分，
+        // 不能让用户误以为"什么都没发生"而继续在新状态上工作。
+        const timedOut = errorMessage(error).includes('超时')
+        hubServices().broadcastError(
+          hub,
+          timedOut
+            ? '回滚文件响应超时：文件恢复可能仍在后台进行，未回滚对话。请确认工作区状态后再决定是否重试'
+            : `回滚文件失败，未回滚对话：${errorMessage(error)}`,
+        )
       })
       .finally(() => {
         hub.rewindPending = false
@@ -275,6 +283,13 @@ class ClaudePort implements BackendPort {
     const sid = current?.sessionId ?? parsed?.resumeSessionId
     if (!parsed || !sid) {
       hubServices().broadcastError(hub, '无法回滚：未知会话 ID')
+      return
+    }
+    // 与 archive/rename 同款守卫：会话正被外部 CLI（终端 TUI）持有时拒绝——
+    // 否则 --resume-session-at 会与活进程双写同一 transcript，截断点之后交错损坏。
+    // 外部会话的截断由 tail_reset 路径承接（tailer 发现文件缩小即通知前端重载）。
+    if (!current && liveSessionInfo(sid)) {
+      hubServices().broadcastError(hub, '会话正在官方 CLI 中运行，请先在该 CLI 内回滚')
       return
     }
     // 先从 map 摘掉再 kill，避免旧 onExit 污染新会话。
@@ -486,7 +501,7 @@ class ClaudePort implements BackendPort {
     if (processManager.get(key) || liveSessionInfo(sessionId)) {
       return { ok: false, error: '会话正在运行，请在 CLI 退出后改名', status: 409 }
     }
-    const file = join(config.claudeConfigDir, 'projects', slug, `${sessionId}.jsonl`)
+    const file = transcriptPathOf(slug, sessionId)
     if (!existsSync(file)) return { ok: false, error: 'transcript 不存在', status: 404 }
     try {
       // 与官方 /rename 相同的条目形状；discovery 读取时后者优先

--- a/server/src/backends/claude/port.ts
+++ b/server/src/backends/claude/port.ts
@@ -129,6 +129,11 @@ class ClaudePort implements BackendPort {
       delete spawnOpts.forkFromSessionId
       spawnOpts.resumeSessionId = hub.sessionId
     }
+    // 会话身份以最新 init 记下的 hub.sessionId 为权威：/clear 重键、handoff 重键、n| 首 turn 之后，
+    // spawnOpts 里的 resumeSessionId 都是陈旧值（或是显式 undefined——扩散合并会盖掉 parsed 的
+    // resumeSessionId）。进程空闲回收后重生必须续跑当前会话，否则 /clear 后回到旧 transcript、
+    // n| 会话静默开空白新会话。
+    if (hub.sessionId) spawnOpts.resumeSessionId = hub.sessionId
     hub.spawnOpts = spawnOpts
     try {
       const s = processManager.ensure(hub.key, spawnOpts, hubServices().sessionCallbacks(hub))
@@ -464,6 +469,12 @@ class ClaudePort implements BackendPort {
       }
     }
     return s.sessionId
+  }
+
+  /** handoff 播种进程的重键（n|→s|）：进程不换，map 键跟随真实 sessionId。
+   *  spawnOpts 的 resumeSessionId 无需在此对齐——ensureSpawned 的身份权威行会处理。 */
+  rekeySession(_hub: Hub, oldKey: string, newKey: string, _newSessionId: string): void {
+    processManager.rekey(oldKey, newKey)
   }
 
   // ---------- REST 管理面（归档/恢复/改名） ----------

--- a/server/src/backends/claude/processManager.ts
+++ b/server/src/backends/claude/processManager.ts
@@ -95,7 +95,9 @@ export function extractUsageFromTranscriptTail(text: string): TranscriptCallUsag
     }
     if (msg.type !== 'assistant' || msg.isSidechain === true) continue
     const u = coerceCallUsage((msg.message as { usage?: unknown } | undefined)?.usage)
-    if (u) return u
+    // 全零 usage（中断/截断写盘、协议漂移产出 {}）不算命中：继续往更早行回扫真实占用，
+    // 否则环形 UI 会被水合成一个假的 0/窗口大小
+    if (u && u.inputTokens + u.outputTokens + u.cacheReadTokens + u.cacheWriteTokens > 0) return u
   }
   return undefined
 }

--- a/server/src/backends/claude/tailer.ts
+++ b/server/src/backends/claude/tailer.ts
@@ -14,6 +14,9 @@ export interface TailerEvents {
 }
 
 const POLL_MS = 2000
+/** 无写入时的状态心跳间隔：onTick 的用途是节流刷新外部会话的 busy/idle，
+ *  没有新内容时每 2s 无条件广播一次 status 纯属噪声（页面常开 N 个外部会话就是 N 路 2s 广播） */
+const TICK_HEARTBEAT_MS = 30_000
 
 export class TranscriptTailer {
   private offset: number
@@ -22,6 +25,7 @@ export class TranscriptTailer {
   private pollTimer?: ReturnType<typeof setInterval>
   private debounce?: ReturnType<typeof setTimeout>
   private stopped = false
+  private lastTickAt = 0
 
   constructor(
     private path: string,
@@ -82,7 +86,8 @@ export class TranscriptTailer {
       this.events.onReset()
       return
     }
-    if (size > this.offset) {
+    const grew = size > this.offset
+    if (grew) {
       let fd = -1
       try {
         fd = openSync(this.path, 'r')
@@ -99,7 +104,12 @@ export class TranscriptTailer {
           } catch {}
       }
     }
-    this.events.onTick()
+    // 只有文件真的增长（或心跳到期）才打 onTick：空闲的外部会话不再每 2s 广播一次 status
+    const now = Date.now()
+    if (grew || now - this.lastTickAt >= TICK_HEARTBEAT_MS) {
+      this.lastTickAt = now
+      this.events.onTick()
+    }
   }
 
   private emitLines(buf: Buffer): void {

--- a/server/src/backends/codex/port.ts
+++ b/server/src/backends/codex/port.ts
@@ -84,6 +84,9 @@ class CodexPort implements BackendPort {
     try {
       await s.start()
     } catch (e) {
+      // start 失败（如 -32600 线程被占用）必须摘掉句柄：否则 exited=false 的僵尸会话让
+      // hasLiveSession 恒真——Hub 永不回收，且下次 ensure 复用同一坏对象永远不自愈。
+      s.dispose()
       hubServices().broadcastError(hub, errorMessage(e))
       hubServices().pushStatus(hub)
       return undefined
@@ -114,11 +117,16 @@ class CodexPort implements BackendPort {
    *  - legacy 线程：降级 thread/fork(beforeTurnId) 复制该轮之前的历史为新线程，原线程不动。
    *  userMessageId 即历史的轮首 userMessage 的 turnId。 */
   rewindConversation(hub: Hub, at: string): void {
+    if (hubServices().rewindBusy(hub)) return
     const tid = codexRuntime.get(hub.key)?.sessionId ?? codexParseKey(hub.key)?.resumeThreadId
     if (!tid) {
       hubServices().broadcastError(hub, 'codex 会话未就绪，无法回滚')
       return
     }
+    // revert/fork 是异步 RPC（最长 60s）窗口：置 rewindPending 门控用户消息
+    //（hub/messages.ts user 分支），否则新 turn 与 thread/revert 并发会截掉刚开始的对话
+    hub.rewindPending = true
+    hubServices().pushStatus(hub, { rewindPending: true })
     void codexRuntime
       .historyModeOf(tid)
       .then(async (mode) => {
@@ -142,6 +150,10 @@ class CodexPort implements BackendPort {
         })
       })
       .catch((e) => hubServices().broadcastError(hub, `回滚失败: ${errorMessage(e)}`))
+      .finally(() => {
+        hub.rewindPending = false
+        hubServices().pushStatus(hub, { rewindPending: false })
+      })
   }
 
   rewindBoth(hub: Hub, _at: string): void {

--- a/server/src/backends/codex/port.ts
+++ b/server/src/backends/codex/port.ts
@@ -244,6 +244,14 @@ class CodexPort implements BackendPort {
     return s.sessionId
   }
 
+  /** handoff 播种线程的重键（xn|→x|）：线程句柄不换，map 键跟随真实 threadId。
+   *  xn| 时代的 spawnOpts.resumeThreadId 是显式 undefined，回收重生时会经扩散合并盖掉
+   *  parseKey(x|) 的 resumeThreadId 而 thread/start 出全新线程——重键时对齐当前线程身份。 */
+  rekeySession(hub: Hub, oldKey: string, newKey: string, newSessionId: string): void {
+    codexRuntime.rekey(oldKey, newKey)
+    if (hub.spawnOpts) (hub.spawnOpts as { resumeThreadId?: string }).resumeThreadId = newSessionId
+  }
+
   // ---------- REST 管理面（官方 RPC：loaded/stored thread 均可） ----------
 
   /** thread 管理 RPC 共享核：splitThreadId 守卫 + rpcRequest + RouteResult 信封只有一份，

--- a/server/src/backends/codex/runtime.test.ts
+++ b/server/src/backends/codex/runtime.test.ts
@@ -472,3 +472,21 @@ describe('thread/reverted 通知与回滚 RPC', () => {
     expect(calls[1].params.includeTurns).toBe(false)
   })
 })
+
+describe('CodexRuntime.rekey（handoff 播种线程 xn|→x| 重键）', () => {
+  test('会话对象不换、map 键跟随真实 threadId；旧键摘除且重复重键返回 false', () => {
+    const runtime = new CodexRuntime()
+    const s = runtime.ensure('xn|%2Ftmp', { cwd: '/tmp' }, {
+      onMessage: () => {},
+      onApprovalRequest: () => {},
+      onExit: () => {},
+      onStatusChange: () => {},
+    })
+    expect(runtime.get('xn|%2Ftmp')).toBe(s)
+    expect(runtime.rekey('xn|%2Ftmp', 'x|tid-1')).toBe(true)
+    expect(runtime.get('xn|%2Ftmp')).toBeUndefined()
+    expect(runtime.get('x|tid-1')).toBe(s)
+    expect(s.key).toBe('x|tid-1')
+    expect(runtime.rekey('xn|%2Ftmp', 'x|tid-2')).toBe(false)
+  })
+})

--- a/server/src/backends/codex/runtime.ts
+++ b/server/src/backends/codex/runtime.ts
@@ -2,7 +2,7 @@
 // CodexSession 实现与 ClaudeSession 同形的会话句柄（契约见 backends/types.ts 末尾注释），
 // 事件经 ThreadTranslator 翻译成 claude stream-json 形状后走统一回调。
 
-import type { ApprovalDecision, BackgroundTask, SessionCallbacks } from '../types'
+import type { ApprovalDecision, SessionCallbacks } from '../types'
 import type { CliMessage } from '../claude/protocol'
 import { saveUpload } from '../../uploads'
 import { errorMessage } from '../../util'
@@ -135,7 +135,6 @@ export function extractTokenCountFromRolloutTail(text: string): RolloutTokenCoun
 
 interface PendingCodexApproval {
   rpcId: number | string
-  kind: string
 }
 
 /** 工具流式部分结果的合并窗口：outputDelta 按字节块到达（高频时每 token 一批），
@@ -237,12 +236,6 @@ export class CodexSession {
   }
   get connectedClients(): number {
     return this.clientCount
-  }
-  get activeTaskCount(): number {
-    return 0 // codex 的后台终端管理（backgroundTerminals/*）留待后续版本
-  }
-  get backgroundTasks(): BackgroundTask[] {
-    return []
   }
   get cwd(): string | undefined {
     return this.opts.cwd
@@ -558,6 +551,9 @@ export class CodexSession {
         // 否则 approvals.size 守卫永久短路 thread/status/changed，runState 卡在 requires_action
         const rid = (params as { requestId?: string | number }).requestId
         if (rid !== undefined && this.approvals.delete(`cx-${rid}`)) {
+          // Hub 侧 pendingApprovals 同步清理（广播撤卡）：只清了 session 表会让死审批
+          // 随重连重放、status 恒 waiting
+          this.cb.onApprovalResolved?.(`cx-${rid}`)
           if (this.approvals.size === 0 && this.runState === 'requires_action') {
             this.setRunState(this.currentTurnId ? 'running' : 'idle')
           }
@@ -616,7 +612,7 @@ export class CodexSession {
         this.runtime.respondSafe(id, { decision: 'decline' })
         return
     }
-    this.approvals.set(requestId, { rpcId: id, kind: method })
+    this.approvals.set(requestId, { rpcId: id })
     this.setRunState('requires_action')
     this.cb.onApprovalRequest({ requestId, toolName, input, toolUseId: String(params.itemId ?? '') })
   }
@@ -746,12 +742,6 @@ export class CodexSession {
         this.emitError(`codex 后端暂不支持控制请求 ${subtype}`)
     }
     return reqId
-  }
-
-  /** codex 没有可等待的控制请求通道：rewind 走 thread/fork，查询走 mcpServerStatus/list，
-   *  两者都在 index.ts 提前分流，不会到这里 */
-  sendControlAndWait(subtype: string, _extra: Record<string, unknown> = {}, _timeoutMs = 15_000): Promise<unknown> {
-    return Promise.reject(new Error(`codex 后端暂不支持控制请求 ${subtype}`))
   }
 
   sendApproval(requestId: string, decision: ApprovalDecision): void {

--- a/server/src/backends/codex/runtime.ts
+++ b/server/src/backends/codex/runtime.ts
@@ -173,7 +173,8 @@ function mapTokenUsage(u: Record<string, number> | undefined) {
 }
 
 export class CodexSession {
-  readonly key: string
+  /** 会话 key；handoff 播种线程拿到真实 threadId 后由 CodexRuntime.rekey 改写（会话不换，键跟随 xn|→x|） */
+  key: string
   threadId: string | undefined
   exited = false
 
@@ -1170,6 +1171,17 @@ export class CodexRuntime {
     if (!s) return
     this.sessions.delete(key)
     s.dispose()
+  }
+
+  /** handoff 播种线程拿到真实 threadId 后的重键：会话不换，map 键跟随 xn|→x|。
+   *  不迁的话 hub 按新 key 查不到会话会再 thread/resume 一次（同线程双会话句柄）。 */
+  rekey(oldKey: string, newKey: string): boolean {
+    const s = this.sessions.get(oldKey)
+    if (!s) return false
+    this.sessions.delete(oldKey)
+    s.key = newKey
+    this.sessions.set(newKey, s)
+    return true
   }
 
   disposeAll(): void {

--- a/server/src/backends/port.ts
+++ b/server/src/backends/port.ts
@@ -178,6 +178,11 @@ export interface BackendPort {
   ): Promise<{ text: string; usage?: Record<string, number> }>
   /** 目标会话播种首条消息，返回目标 sessionId（claude 含 init 前 30s 轮询）；启动失败抛错 */
   seedHandoffTarget(hub: Hub, seed: string): Promise<string | undefined>
+  /** 播种拿到真实 id 后的会话重键（n|→s| / xn|→x|）：进程/线程句柄不换，map 键跟随，
+   *  并对齐 spawnOpts 里的会话身份（回收重生须续跑当前会话）。由 hub/handoff.ts 在广播
+   *  handoff_done 前调用——不同步的话浏览器导航到 resolved key 查不到播种进程，live 事件
+   *  进无客户端的旧 Hub，首条用户消息还会再 spawn 一个进程同写一份 transcript。 */
+  rekeySession?(hub: Hub, oldKey: string, newKey: string, newSessionId: string): void
 
   // ---------- REST 管理面（归档/恢复/改名） ----------
   archive(key: string): Promise<RouteResult>

--- a/server/src/backends/port.ts
+++ b/server/src/backends/port.ts
@@ -67,10 +67,14 @@ export interface SessionHandle {
   /** 会话 cwd（codex 句柄有 getter；claude 缺席——x| key 的 sessionNameOf 反查用，
    *  可选属性使 ClaudeSession 无需改动即结构化兼容） */
   readonly cwd?: string
+  /** 后台任务表（claude 专属；codex 缺席——恒空数组会被 hydrateTasks 误读为权威空） */
+  readonly activeTaskCount?: number
+  readonly backgroundTasks?: unknown[]
   sendUserText(text: string, sendMode?: 'steer' | 'queue', images?: ImageAttachment[]): void
   sendApproval(requestId: string, decision: ApprovalDecision): void
   sendControl(subtype: string, extra?: Record<string, unknown>): void
-  sendControlAndWait(
+  /** 可等待的控制请求通道（claude 专属；codex 的 rewind/查询走专用 RPC，无对应物） */
+  sendControlAndWait?(
     subtype: string,
     extra?: Record<string, unknown>,
     timeoutMs?: number,

--- a/server/src/backends/types.ts
+++ b/server/src/backends/types.ts
@@ -136,6 +136,9 @@ export interface SessionCallbacks {
   }): void
   /** 进程退出（仅当前仍登记在管理器中的实例会回调） */
   onExit(code: number): void
+  /** 审批被上游终结（如 codex serverRequest/resolved：app-server 超时/中断/他端应答）——
+   *  宿主据此清掉自己维护的 pending 表；claude 无此路径 */
+  onApprovalResolved?(requestId: string): void
   /** busy / sessionState 变化时通知宿主广播 status */
   onStatusChange?(): void
 }

--- a/server/src/cliReplay.test.ts
+++ b/server/src/cliReplay.test.ts
@@ -101,7 +101,26 @@ describe('cli 事件环形缓冲与补发', () => {
     expect(replaySince(h, 2).gap).toBe(true)
   })
 
-  test('空环补发不报缺口（会话刚起、还没产生任何可落盘 cli 事件）', () => {
-    expect(replaySince(mk(), 7)).toEqual({ sent: [], gap: false })
+  test('空环 + fromSeq=0 不报缺口（会话刚起、还没产生任何可落盘 cli 事件）', () => {
+    expect(replaySince(mk(), 0)).toEqual({ sent: [], gap: false })
+  })
+
+  test('空环但客户端有高水位 → 纪元失配报缺口（服务端重启，旧高水位无法衔接）', () => {
+    expect(replaySince(mk(), 7)).toEqual({ sent: [], gap: true })
+  })
+
+  test('环内 seq 全部低于客户端高水位 → 纪元失配报缺口（服务端重启后重计）', () => {
+    const h = mk()
+    for (let i = 1; i <= 3; i++) pushDurable(h, i) // 重启后新 Hub 从 1 重计
+    const r = replaySince(h, 1473)
+    expect(r.gap).toBe(true)
+    expect(r.sent).toEqual([]) // 旧纪元的任何事件都不该补发
+  })
+
+  test('revert 清环但 cliSeq 保留：同纪元高水位衔接不算缺口', () => {
+    const h = mk()
+    for (let i = 1; i <= 5; i++) pushDurable(h, i)
+    h.cliRing = [] // 模拟 revert 成功清环（cliSeq 不动保持单调）
+    expect(replaySince(h, 5).gap).toBe(false)
   })
 })

--- a/server/src/cliReplay.ts
+++ b/server/src/cliReplay.ts
@@ -46,11 +46,15 @@ export function pushCliRing(state: CliRingState, payload: Record<string, unknown
 }
 
 /** 把环里 seq > fromSeq 的 cli 事件交给 send。
- *  返回是否发生了「缺口」——请求的起点已被环挤掉，客户端需要重载历史才能补全。 */
+ *  返回是否发生了「缺口」——请求的起点已被环挤掉、或服务端序号纪元低于客户端高水位
+ *  （服务端重启后 Hub/cliSeq 归零，旧高水位再也无法衔接），客户端需要重载历史才能补全。 */
 export function replayCliSince(state: CliRingState, fromSeq: number, send: (payload: unknown) => void): boolean {
   const ring = state.cliRing ?? []
-  if (ring.length === 0) return false
-  const gap = ring[0].seq > fromSeq + 1
+  // 纪元失配：客户端声称收过 fromSeq 条，而我们发过的总数（含已被挤掉的）比这还少——
+  // 只有服务端重启（新 Hub 从 1 重计）会产生这种倒挂，此时环里的一切都不能补发旧账。
+  const epochMismatch = fromSeq > (state.cliSeq ?? 0)
+  if (ring.length === 0) return epochMismatch
+  const gap = ring[0].seq > fromSeq + 1 || epochMismatch
   for (const e of ring) if (e.seq > fromSeq) send({ ...e.payload, replay: true })
   return gap
 }

--- a/server/src/driftGuard.ts
+++ b/server/src/driftGuard.ts
@@ -10,15 +10,14 @@
 // 仓库约定：本模块只被服务端入口与两个 check 脚本引用，不产生任何外发请求
 // （告警走 push.ts 的既有 webhook 扇出，配置即信任边界不变）。
 
-import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
 import { config } from './config'
 import { pushWebhooksToAll } from './push'
 import { log } from './log'
+import { ccDataDir, childEnv, readJsonFile, writeJsonFile } from './util'
 
-const STATE_PATH = join(homedir(), '.anyplane', 'protocol-checks.json')
+const STATE_PATH = join(ccDataDir(), 'protocol-checks.json')
 
 interface DriftState {
   /** 各 CLI 最近一次「该版本无漂移或基线已更新」的记录 */
@@ -28,20 +27,15 @@ interface DriftState {
 }
 
 function loadState(): DriftState {
-  try {
-    if (existsSync(STATE_PATH)) {
-      return JSON.parse(readFileSync(STATE_PATH, 'utf8')) as DriftState
-    }
-  } catch (e) {
-    log.warn(`[drift] 状态文件解析失败（当空处理）:`, e)
-  }
+  const s = readJsonFile<DriftState>(STATE_PATH)
+  if (s && typeof s === 'object' && s.checked && typeof s.checked === 'object') return s
+  if (s !== undefined) log.warn(`[drift] 状态文件形状异常（当空处理）:`, s)
   return { checked: {} }
 }
 
 function saveState(s: DriftState): void {
   try {
-    mkdirSync(join(homedir(), '.anyplane'), { recursive: true })
-    writeFileSync(STATE_PATH, JSON.stringify(s, null, 2))
+    writeJsonFile(STATE_PATH, s, { pretty: true })
   } catch (e) {
     log.warn(`[drift] 状态写入失败:`, e)
   }
@@ -60,7 +54,9 @@ export function cliVersionOf(cli: 'claude' | 'codex'): string | null {
         : ['codex']
   for (const cmd of candidates) {
     try {
-      const r = spawnSync(cmd, ['--version'], { encoding: 'utf8', timeout: 10_000, shell: cmd.endsWith('.cmd') })
+      // childEnv() 剥离 ANYPLANE_TOKEN：这是全仓唯一绕开 childEnv 的 spawn 点，
+      // 缺省继承全量 process.env 会把服务端凭据泄给任意同名 PATH 可执行文件
+      const r = spawnSync(cmd, ['--version'], { encoding: 'utf8', timeout: 10_000, shell: cmd.endsWith('.cmd'), env: childEnv() })
       const out = (r.stdout ?? '').trim()
       if (r.status === 0 && out) return out.split('\n')[0]!.trim()
     } catch {

--- a/server/src/hub/broadcast.ts
+++ b/server/src/hub/broadcast.ts
@@ -32,7 +32,8 @@ export function publishInbox(ev: InboxEvent): void {
   inboxSink.publish(ev)
 }
 
-/** 待审批重放：WS 接入（单播）与 attach（广播）共用——未裁决的审批补发给目标 */
+/** 待审批重放：socket 接入（socket.ts，单播）与 attach（messages.ts，单播给发起连接）共用——
+ *  未裁决的审批补发给目标，不向 Hub 内其他在线客户端广播（重复审批卡） */
 export function replayApprovals(hub: Hub, send: (payload: unknown) => void): void {
   for (const a of hub.pendingApprovals.values()) {
     send({ kind: 'approval_request', ...a })

--- a/server/src/hub/callbacks.ts
+++ b/server/src/hub/callbacks.ts
@@ -111,7 +111,25 @@ export function sessionCallbacks(hub: Hub) {
       portFor(hub.key).notifyExternalGate(hub.key)
     },
     onStatusChange: () => throttledPushStatus(hub),
+    /** 审批被上游终结（app-server 超时/中断/其他客户端应答，codex serverRequest/resolved）：
+     *  同步清掉 Hub 侧 pending，否则死审批会随重连重放、status 恒 waiting。 */
+    onApprovalResolved: (requestId: string) => {
+      if (!hub.pendingApprovals.delete(requestId)) return
+      broadcast(hub, { kind: 'approval_resolved', requestId })
+      publishInbox({ type: 'approval_resolved', key: hub.key, requestId })
+      pushStatus(hub)
+    },
     onExit: (code: number) => {
+      // 进程已死，待审批随之失效：清表并逐条广播 approval_resolved 让客户端撤卡。
+      // 否则重连时 replayApprovals 会把死审批重放成可点击卡片（点击后投递给一个不认识
+      // 该 request_id 的新进程），此后任何 status 推送也都因 pending>0 显示 waiting。
+      if (hub.pendingApprovals.size > 0) {
+        for (const requestId of hub.pendingApprovals.keys()) {
+          broadcast(hub, { kind: 'approval_resolved', requestId })
+          publishInbox({ type: 'approval_resolved', key: hub.key, requestId })
+        }
+        hub.pendingApprovals.clear()
+      }
       pushStatus(hub, { exited: true, exitCode: code, spawned: false, busy: false, waiting: false })
     },
   }

--- a/server/src/hub/handoff.ts
+++ b/server/src/hub/handoff.ts
@@ -63,6 +63,20 @@ export function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detai
         return tidNow ? `x|${tidNow}` : undefined
       })()
 
+      // 播种进程/线程落在 n|/xn| key 上，而 handoff_done 导航走 resolved key：立即三层重键
+      // （Hub / 进程 map / 存活 WS data.key，镜像 callbacks.ts 的 /clear 重键）。不重键的话
+      // 目标页查不到播种进程——live 事件进无客户端的旧 Hub，首条用户消息还会再 spawn
+      // 一个进程与播种进程同写一份 transcript。
+      if (toResolvedKey && targetSessionId && toResolvedKey !== targetKey) {
+        hubs.delete(targetKey)
+        targetHub.key = toResolvedKey
+        hubs.set(toResolvedKey, targetHub)
+        portFor(toResolvedKey).rekeySession?.(targetHub, targetKey, toResolvedKey, targetSessionId)
+        for (const ws of targetHub.clients) {
+          if (!ws.data.inbox) ws.data.key = toResolvedKey
+        }
+      }
+
       // 3. 血缘
       appendLineage({
         id: `ho-${Date.now().toString(36)}`,
@@ -83,6 +97,10 @@ export function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detai
           kind: 'handoff_done',
           targetKey: toResolvedKey ?? targetKey,
           targetSessionId,
+          // 目标 slug/cwd 以下发为准：源会话是 codex 时 session.slug 恒为 'codex'，
+          // 前端若沿用源 slug 会把 claude 目标的历史请求打到 projects/codex/（空白）
+          targetSlug: toBackend === 'codex' ? 'codex' : sanitizePath(sourceCwd),
+          targetCwd: sourceCwd,
           toBackend,
           brief,
         })

--- a/server/src/hub/messages.ts
+++ b/server/src/hub/messages.ts
@@ -32,7 +32,19 @@ export function handleClientMessage(
       // 浏览历史只握手，不 spawn。发消息 / 切 model·mode·effort / rewind / btw 时再启动 CLI。
       // 各后端的 attach 策略（warm 预热、codex x| 即 resume）见适配器 onAttach。
       portFor(hub.key).onAttach(hub, data)
-      replayApprovals(hub, (p) => broadcast(hub, p))
+      // 待审批补发只给本次 attach 的连接：走 broadcast 会让已在线的其他客户端
+      // 重复收到同一张审批卡（requestId 相同，纯噪声）
+      if (ws) {
+        replayApprovals(hub, (p) => {
+          try {
+            ws.send(JSON.stringify(p))
+          } catch (e) {
+            log.debug(`[ws ${hub.key}] 审批补发单播失败`, errFields(e))
+          }
+        })
+      } else {
+        replayApprovals(hub, (p) => broadcast(hub, p))
+      }
       // 重连补发：客户端带上断线前的最高 seq，取回这期间错过的 cli 事件。
       // **必须单播**：走 broadcast 会让补发内容重新入环并分配新序号（自我污染），
       // 且已在线的其他客户端会收到重复投递。

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -462,7 +462,7 @@ async function sendSct(wh: { type: 'sct'; sendkey: string }, payload: PushPayloa
   const lines = [payload.body]
   if (payload.type === 'approval') {
     const page = approvalPageLink(wh, payload)
-    if (page) lines.push('', `[👉 前往审批（允许 / 拒绝）](${page})`)
+    if (page) lines.push('', `[前往审批（允许 / 拒绝）](${page})`)
   } else {
     const click = sessionLink(payload.key)
     if (click) lines.push('', `[查看会话](${click})`)

--- a/server/src/routes/misc.ts
+++ b/server/src/routes/misc.ts
@@ -91,16 +91,19 @@ export async function handleMiscRoutes(req: Request, url: URL): Promise<Response
     // fileBytes = 本次实际读取的字节数，前端拿它作为 tailer 的起始偏移；
     // ?before=<行号> 翻更早的页（响应 nextBefore 续传），?limit= 覆盖默认 300
     //（上限 10000：replay_gap 保载重载按已加载数+余量拉取，长会话需要突破首窗 300）
-    const num = (k: string) => {
+    const num = (k: string, allowZero = false) => {
       const v = url.searchParams.get(k)
       if (v == null) return undefined
       const n = Number(v)
-      return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined
+      // before 是行号游标，0 合法：最老可入历史消息在文件第 0 行时 nextBefore=0，
+      // 吞掉它会让前端按无 before 处理拿到最新一页，翻页死循环重复 prepend。
+      // limit 不允许 0（slice(-0) 会退化成全量），保持 n > 0。
+      return Number.isFinite(n) && (allowZero ? n >= 0 : n > 0) ? Math.floor(n) : undefined
     }
     const limit = num('limit')
     return json(
       readHistory(slug, sessionId, {
-        before: num('before'),
+        before: num('before', true),
         limit: limit == null ? undefined : Math.min(limit, 10_000),
       }),
     )

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -3,11 +3,20 @@
 import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { config } from './config'
 import { log } from './log'
 
 /** anyplane 运行数据根目录（~/.anyplane/，约定见 AGENTS.md）；权限收紧由 ensurePrivateDir 完成 */
 export function ccDataDir(): string {
   return ensurePrivateDir(join(homedir(), '.anyplane'))
+}
+
+/** claude transcript 文件路径（~/.claude/projects/<slug>/<sessionId>.jsonl）。
+ *  放叶子层而非 discovery：discovery → agents → processManager，processManager 水合也要
+ *  用本函数，放 discovery 会成环（sanitizePath 同理，正本在此）。调用方自负责路径安全闸
+ *  （slug/sessionId 的字符校验见 splitExistingKey）。 */
+export function transcriptPathOf(slug: string, sessionId: string): string {
+  return join(config.claudeConfigDir, 'projects', slug, `${sessionId}.jsonl`)
 }
 
 /** 读 JSON 文件；不存在或解析失败返回 undefined（调用方决定回退值） */

--- a/web/src/hooks/useSessionSocket.ts
+++ b/web/src/hooks/useSessionSocket.ts
@@ -240,11 +240,13 @@ export function useSessionSocket(opts: {
             onNavigate?.(
               makeSessionInfo({
                 key: ev.targetKey,
-                slug: ev.toBackend === 'codex' ? 'codex' : session.slug,
+                // slug/cwd 以下发值为准：codex→claude 接力时源会话 slug 恒为 'codex'，
+                // 沿用会把 claude 目标的历史请求打到 projects/codex/（历史空白）
+                slug: ev.toBackend === 'codex' ? 'codex' : (ev.targetSlug ?? session.slug),
                 // 目标已 spawn 时 targetKey 是 resolved key（s|/x|）：必须带真实 id，
                 // 否则 codex 侧 fetchCodexHistory('new') 必失败、历史视图永远空白
                 sessionId: ev.targetSessionId ?? 'new',
-                cwd: session.cwd,
+                cwd: ev.targetCwd ?? session.cwd,
                 backend: ev.toBackend,
                 status: 'busy',
                 managed: { spawned: true, busy: true, clients: 0 },

--- a/web/src/hooks/useTranscriptIngest.ts
+++ b/web/src/hooks/useTranscriptIngest.ts
@@ -328,7 +328,10 @@ export function useTranscriptIngest(opts: {
       const blocks = Array.isArray(content) ? content : []
       const msgId = (rec.message as { id?: string } | undefined)?.id
       const d = draftRef.current
-      if (!d || msgId !== d.msgId) {
+      // 兜底草稿（中途接入没见过 message_start，msgId 为 undefined）与本轮快照同源，
+      // 必须落入合并分支——否则快照直推一份、message_stop 的 commitDraft 再推一份，
+      // 同一轮回复在抄本里渲染两次（且同 id 工具块互相污染配对）
+      if (!d || (d.msgId !== undefined && msgId !== d.msgId)) {
         const toolIds = blocks.filter((c) => c?.type === 'tool_use' && c.id).map((c) => String(c.id))
         const keys = liveMessageKeys({ uuid: msg.uuid, messageId: msgId, toolIds })
         // uuid / message.id / 工具块 id 任一已在抄本（HTTP 历史或先前 live）即跳过——

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -25,7 +25,7 @@ export type ServerEvent =
   /** 接力进度：源会话 fork 摘要中 */
   | { kind: 'handoff_pending'; toBackend: 'claude' | 'codex' }
   | { kind: 'handoff_brief'; brief: string }
-  | { kind: 'handoff_done'; targetKey: string; targetSessionId?: string; toBackend: 'claude' | 'codex'; brief: string }
+  | { kind: 'handoff_done'; targetKey: string; targetSessionId?: string; targetSlug?: string; targetCwd?: string; toBackend: 'claude' | 'codex'; brief: string }
   | { kind: 'handoff_error'; message: string }
   /** 只读控制查询应答（mcp_status / get_settings / get_context_usage） */
   | { kind: 'query_result'; id: string; ok: boolean; data?: unknown; error?: string }


### PR DESCRIPTION
> 本 PR 由 `/code-review --fix`（high effort，审查范围 `server/ web/ scripts/`，分支无 diff 故对目录全量审查）生成，经逐项复核后按主题拆为 9 个 commit。`bun test` 464 全绿，`tsc --noEmit` 干净。
>
> 复核过程中对全部晚到的 finder 扫描结果做了逐项二次核对：Angle A/B/C、Altitude、Simplification、Efficiency、Conventions、Reuse 八份报告的结论全部在此正文中闭环（修复 / 证伪 / 列入观察三类归宿见下文）。

## 发现的问题（按严重度排序，14 项）

1. **cliReplay 序号纪元失配不识别**（server/src/cliReplay.ts）：服务端重启后 Hub/cliSeq 归零，客户端带着旧高水位 attach 时，空环/低 seq 环不报缺口也不补发，断线期间的消息永久丢失且无 `replay_gap` 引导重载。
2. **历史翻页 `before=0` 被吞**（server/src/routes/misc.ts）：游标参数校验要求 `n > 0`，而最老消息在第 0 行时 `nextBefore=0` 完全合法——被吞后前端按无 before 重拉最新页，`prependHistory` 无去重 → 翻页死循环重复 prepend。
3. **codex start 失败留下僵尸句柄**（backends/codex/port.ts `ensure`）：-32600 等 start 失败后 exited=false 的会话留在 map 里，`hasLiveSession` 恒真——Hub 永不回收，下次 ensure 永远复用同一坏对象不自愈。修复：失败即 `dispose()`。
4. **进程退出后待审批变幽灵卡**（hub/callbacks.ts `onExit`）：`pendingApprovals` 不清理，重连时 `replayApprovals` 把死审批重放成可点击卡片（点击投递给不认识该 requestId 的新进程），且任何 status 都因 pending>0 显示 waiting。修复：退出时清表并逐条广播 `approval_resolved`。
5. **codex 回滚缺并发门控**（backends/codex/port.ts `rewindConversation`）：`thread/revert` 是长 RPC，期间用户消息可进入，`beforeTurnId` 截断会切掉刚开始的 turn。修复：全程 `rewindPending` 门控（与 claude 对齐）+ 入口 `rewindBusy` 重入守卫。
6. **外部 CLI 占用时会话可被 --resume-session-at 双写**（backends/claude/port.ts `rewindConversationAt`）：与 archive/rename 同款边界缺失，活进程与重 spawn 交错写同一 transcript 损坏截断点后内容。修复：非 anyplane 托管且 `liveSessionInfo` 命中时拒绝（外部截断由 tail_reset 承接）。
7. **rewind_both 超时误报"回滚文件失败"**（backends/claude/port.ts）：`rewind_files` 无 CLI 侧超时，120s 断点后文件恢复可能仍静默完成（半回滚），旧文案让用户误以为"什么都没发生"。修复：按错误文案区分超时与真实失败。
8. **全零 usage 水合成假 0 占用**（backends/claude/processManager.ts `extractUsageFromTranscriptTail`）：中断/截断写盘的行 usage 全 0，原先视其为命中直接返回，离线水合把环形 UI 显示成 0/窗口大小。修复：全零跳过继续回扫。
9. **readHistory 每页全量重解析**（backends/claude/discovery.ts）：翻 N 页付 N 次全文件读 + 逐行 JSON.parse（长会话每页数百 ms 阻塞事件循环）。修复：按 (mtimeMs,size) 键 LRU 缓存全量解析（cap 8），transcript 只追加故键变即失效。
10. **tailer 无条件 2s 心跳广播**（backends/claude/tailer.ts）：空闲外部会话每 2s 广播一次 status，页面常开 N 个外部会话即 N 路 2s 广播。修复：仅文件增长或 30s 心跳到期才打 onTick。
11. **handoff 目标会话 key 分裂**（hub/handoff.ts，二次复核 Angle C 确认）：播种进程/线程注册在 `n|/xn|` key，而 `handoff_done` 把浏览器导航到 resolved key（`s|/x|`）——目标页 attach 查不到播种进程（live 事件进无客户端的旧 Hub），首条用户消息还会按 `s|` key 再 spawn 一个进程与播种进程同写一份 transcript。e2e-handoff 只验证 handoff_done 与血缘（claude 目标跳过 live 验证、codex 目标走 REST 历史），该分裂无测试覆盖。修复：拿到真实 id 后立即三层重键（Hub / 进程 map / 存活 WS data.key，镜像 /clear 重键），BackendPort 新增 `rekeySession`（codex 侧同步对齐 `spawnOpts.resumeThreadId`，否则回收重生会 thread/start 出全新线程）。
12. **codex→claude 接力导航 slug 错**（web/src/hooks/useSessionSocket.ts，Angle C）：`slug: session.slug` 用的是源会话字段，codex 源恒为 `'codex'` → claude 目标的历史请求打到 `projects/codex/`，历史视图空白。修复：`handoff_done` 补发 `targetSlug/targetCwd`，前端以下发值为准。
13. **中途接入的兜底草稿与快照双份渲染**（web/src/hooks/useTranscriptIngest.ts，Angle A）：turn 进行中接入的客户端没见过 message_start，delta 建出 msgId undefined 的兜底草稿；随后 assistant 快照按 `msgId !== d.msgId` 误判为另一条消息直推一份，message_stop 的 commitDraft 再推一份。修复：msgId undefined 的草稿与本轮快照同源，落入合并分支。
14. **重键后 spawnOpts.resumeSessionId 陈旧**（backends/claude/port.ts，复核中独立确认）：`...hub.spawnOpts` 扩散合并会盖掉 parseKey 的 resumeSessionId——/clear 重键后若进程空闲回收再重生，会 resume 回 /clear 前的旧 transcript（n| 会话则静默开空白新会话）。修复：ensureSpawned 加身份权威行，`hub.sessionId`（最新 init 记下）覆盖 spawnOpts 陈旧值；与 #11 同 commit。

## 修复清单（9 commits）

| commit | 内容 |
|---|---|
| `abd8cd0` | cliReplay 纪元失配 + `before=0` 游标（含 cliReplay 测试改写，4 个新用例覆盖空环/高水位/清环场景） |
| `dc2e2f9` | 审批生命周期：onExit 清 pending、`onApprovalResolved` 新回调（codex serverRequest/resolved 路径）、attach 审批重放改单播、codex 句柄死代码清理（SessionHandle 相应成员改可选） |
| `02556e7` | codex 回滚 rewindPending 门控 + start 失败 dispose |
| `ddaa887` | claude 回滚外部 CLI 守卫 + 超时文案如实播报 |
| `266a495` | 全零 usage 水合修复 |
| `3384ecb` | readHistory 解析缓存 + tailer 心跳降噪 + daemonAgents TTL 15s→60s（列表页 10s 轮询下不再每 ~15s 白 spawn 一个全量 CLI） |
| `1d7321b` | transcriptPathOf 收口 6 处路径拼写；driftGuard 复用 readJsonFile/writeJsonFile/ccDataDir 并给 spawnSync 补 childEnv()（原是全仓唯一绕开 childEnv 的 spawn 点，会把 ANYPLANE_TOKEN 泄给任意同名 PATH 可执行文件）；Server酱文案去 emoji |
| `c99c48c` | handoff 目标三层重键 + codex spawnOpts 线程身份对齐 + claude ensureSpawned 身份权威行（同修 /clear 陈旧 resume）+ handoff_done 携带 targetSlug/targetCwd（含 CodexRuntime.rekey 单测） |
| `b70c77b` | 中途接入兜底草稿与快照同源合并（一行条件 + 不变量注释） |

## 复核中回退/未采纳的 finder 候选（含理由）

- **Chat.tsx:369 `rewindable !== false` 放过 undefined**：不成立——codex `itemsToHistory` 对每条 userMessage 都显式写 `rewindable` 布尔（translate.ts:597-601，非锚点恒 false），claude `readHistory` 对每条消息都赋值，不存在 undefined 漏网。
- **/branch 后 tailer 与 fork live 流永久交织**：不成立——懒 fork 首条消息走 `sessionForSend → ensureSpawned`，其中同步 `stopTailer`（claude/port.ts spawn 成功路径）；且 fork 之前 b| 页 tail 的正是源会话（懒分叉语义如此），fork 会携带这部分历史。
- **/clear 重键时 `pendingApprovals.clear()` 丢弃挂起审批**：疑似但无法离线确认 CLI 侧 `/clear` 对 pending can_use_tool 的实际处理（turn 中止时 CLI 可能自行取消请求）。修复方向（clear 前逐条 decline）在 CLI 已取消时会向 stdin 写无效裁决，收益不确定，**列入观察不强行改**。
- **hydrateTasks 跳过无 toolUseId 的 activeTasks 条目**（useTaskBuckets.ts:180，Angle C）：服务端 `BackgroundTask.toolUseId` 确为可选，但 claude `task_started` 实测是否可能缺 `tool_use_id` 无法离线确认（Agent/local_bash 任务均有工具块 id）；若存在此类任务，中途接入客户端会漏建 running 桶。**列入观察**（修复需桶键回退到 task_id，牵动终态反查寻址，无复现不强行改）。
- **前端纯挪动类去重**（key.ts 复用 makeSessionInfo、fmtDuration/truncateWithMarker 共享、useTranscriptScroll 的 streaming 入 deps、loadEarlierRef/scrollRefApi 双层 ref 镜像）：逐一核对后均为无行为变化（streaming 翻转必然伴随 messages/draft 引用变化，effect 不会漏跑），按"保持改动最小化"原则不制造纯重构。
- **listSessions 目录扫描无 TTL**（discovery.ts，Efficiency）：每标签页 10s 轮询各触发一次全量 readdir+stat（metaCache 只省重解析不省 syscall）。加 TTL 会牺牲归档/改名/新建后的列表新鲜度，收益仅在对齐多标签页同拍轮询，**列入观察**。
- **既有跳过清单**：Chat.tsx 草稿重建 O(n)（渲染层重构风险大）、useTaskBuckets 无条件 fetchCodexHistory、ingest.ts pairToolResult/Partial 重复、misc.ts key 解析第三份拷贝、6 项架构层建议（服务端 btw id、echo 抑制、ingest 锚定等）——均记入观察，不在本 PR 范围内。

## 测试

- `bun test`：464 pass / 0 fail（42 文件）
- `tsc --noEmit`：干净
- 真实 CLI 链路（e2e 脚本）需运行中服务端，未在本环境执行；涉及真实 CLI 行为的改动（回滚守卫、回滚门控）建议合并后跑一次 `e2e-rewind.ts` / `e2e-codex-paginated.ts` 回归。
- **handoff 重键建议同步补强 e2e-handoff**：当前 claude 目标只验证 handoff_done 与血缘（line 64-66 显式跳过 live 验证），建议补"attach resolved key 能看到播种 turn 的 live 流 + 发消息复用播种进程"断言。
