### PR TITLE
refactor: 全仓库质量审查——复用/简化/效率/altitude 四维度清理

### DIFF
--- a/scripts/gateway.ts
+++ b/scripts/gateway.ts
@@ -12,8 +12,9 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { detectProtocol, isOwnGatewayCmd, modeCookie, parseSsListenPids, pickMode, type Mode } from './gateway-lib'
+import { detectProtocol, isOwnGatewayCmd, modeCookie, pickMode, type Mode } from './gateway-lib'
 import { loadAnyplaneConfigFile } from '../server/src/config'
+import { describePid, listListenPids, terminatePids } from '../server/src/portTakeover'
 import { ensurePrivateDir, escapeHtml as htmlEscape } from '../server/src/util'
 
 type GatewayCfg = {
@@ -393,31 +394,23 @@ async function pipeTo(
   }
 }
 
-function cmdlineOf(pid: number): string {
-  try {
-    return readFileSync(`/proc/${pid}/cmdline`, 'utf8')
-  } catch {
-    return ''
-  }
-}
-
-async function listenPids(port: number): Promise<number[]> {
-  const proc = Bun.spawn(['ss', '-tlnp'], { stdout: 'pipe', stderr: 'pipe' })
-  const out = await new Response(proc.stdout).text()
-  await proc.exited
-  return parseSsListenPids(out, port)
-}
-
-/** 只结束上一份 scripts/gateway.ts；nginx/sshd 等外来进程拒绝覆盖。 */
+/** 只结束上一份 scripts/gateway.ts；nginx/sshd 等外来进程拒绝覆盖。
+ *  所有权校验只有 cmdline 一条（无稳定子目录 cwd 可查，与 portTakeover 的双校验分歧是有意的）；
+ *  杀进程流（SIGTERM/轮询/SIGKILL 节奏）共用 portTakeover.terminatePids 一份实现。 */
 async function replaceStaleGateway(ports: number[]): Promise<void> {
   const seen = new Set<number>()
   const own: number[] = []
   const foreign: Array<{ pid: number; cmd: string; port: number }> = []
   for (const port of ports) {
-    for (const pid of await listenPids(port)) {
+    const pids = await listListenPids(port)
+    if (pids === null) {
+      console.warn('[gateway] 当前平台不支持自动列监听进程，跳过 --replace（端口被占时启动会报错）')
+      return
+    }
+    for (const pid of pids) {
       if (pid === process.pid || seen.has(pid)) continue
       seen.add(pid)
-      const cmd = cmdlineOf(pid)
+      const cmd = (await describePid(pid))?.cmdline ?? ''
       if (isOwnGatewayCmd(cmd)) own.push(pid)
       else foreign.push({ pid, cmd: cmd.replace(/\0/g, ' ').trim() || '(unknown)', port })
     }
@@ -429,31 +422,23 @@ async function replaceStaleGateway(ports: number[]): Promise<void> {
     console.error('[gateway] 拒绝覆盖。确认后手动结束该进程，或改 gateway.httpPort。')
     process.exit(1)
   }
-  for (const pid of own) {
-    console.warn(`[gateway] 结束上一份网关 pid=${pid}`)
-    try {
-      process.kill(pid, 'SIGTERM')
-    } catch {}
-  }
   if (!own.length) return
-  const deadline = Date.now() + 2000
-  while (Date.now() < deadline) {
-    let leftover = false
-    for (const port of ports) {
-      for (const pid of await listenPids(port)) {
-        if (own.includes(pid)) leftover = true
+  const cleared = await terminatePids(
+    own,
+    // 清场 = own pid 不再监听任何网关端口（按 pid 判，端口可能被无关新进程抢占）
+    async () => {
+      for (const port of ports) {
+        const pids = await listListenPids(port)
+        if (pids === null || pids.some((p) => own.includes(p))) return false
       }
-    }
-    if (!leftover) return
-    await Bun.sleep(50)
-  }
-  for (const pid of own) {
-    try {
-      process.kill(pid, 'SIGKILL')
-      console.warn(`[gateway] pid=${pid} 未退出，已 SIGKILL`)
-    } catch {}
-  }
-  await Bun.sleep(50)
+      return true
+    },
+    (pid, signal) => {
+      if (signal === 'SIGTERM') console.warn(`[gateway] 结束上一份网关 pid=${pid}`)
+      else console.warn(`[gateway] pid=${pid} 未退出，已 SIGKILL`)
+    },
+  )
+  if (!cleared) console.error('[gateway] SIGKILL 后端口仍被占用，启动可能失败')
 }
 
 function startMux(

--- a/server/scripts/e2e-approval.ts
+++ b/server/scripts/e2e-approval.ts
@@ -2,12 +2,12 @@
 // 用法：bun run server/scripts/e2e-approval.ts [cwd]
 // 不传 cwd 则默认 process.cwd()，与 smoke.ts 一致。
 import path from 'node:path'
+import { connect } from './e2e-lib'
 
 const cwd = process.argv[2] ?? process.cwd()
 const marker = `${path.basename(cwd)}-approval-ok`
 const key = `n|${encodeURIComponent(cwd)}`
-const tokenQ = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN}` : ''
-const ws = new WebSocket(`ws://localhost:7480/ws/sessions/${encodeURIComponent(key)}${tokenQ}`)
+const { ws, on, send, open } = connect(key)
 
 const timeout = setTimeout(() => {
   console.error('TIMEOUT: 未收到 result')
@@ -15,28 +15,26 @@ const timeout = setTimeout(() => {
 }, 180_000)
 
 let approved = false
-ws.onopen = () => {
-  console.log('>> attach')
-  ws.send(JSON.stringify({ kind: 'attach' }))
-  setTimeout(() => {
-    console.log('>> user: 写文件（触发审批）')
-    ws.send(JSON.stringify({ kind: 'user', text: `请立即用 Write 工具创建文件 ${path.join(cwd, 'approval-test.txt')}，内容写 ${marker}。只做这一件事。` }))
-  }, 3000)
-}
+await open()
+console.log('>> attach')
+send({ kind: 'attach' })
+setTimeout(() => {
+  console.log('>> user: 写文件（触发审批）')
+  send({ kind: 'user', text: `请立即用 Write 工具创建文件 ${path.join(cwd, 'approval-test.txt')}，内容写 ${marker}。只做这一件事。` })
+}, 3000)
 
-ws.onmessage = (e) => {
-  const ev = JSON.parse(e.data)
+on((ev) => {
   if (ev.kind === 'approval_request') {
     console.log('<< approval_request:', ev.toolName, JSON.stringify(ev.input)?.slice(0, 200))
     if (!approved) {
       approved = true
       console.log('>> 允许')
-      ws.send(JSON.stringify({ kind: 'approval', requestId: ev.requestId, decision: { behavior: 'allow', updatedInput: ev.input } }))
+      send({ kind: 'approval', requestId: ev.requestId, decision: { behavior: 'allow', updatedInput: ev.input } })
     }
     return
   }
   if (ev.kind === 'cli') {
-    const m = ev.msg
+    const m = ev.msg as Record<string, any>
     if (m.type === 'assistant') {
       const s = JSON.stringify(m.message?.content)
       if (s.includes('tool_use')) console.log('<< assistant 调用工具')
@@ -51,5 +49,5 @@ ws.onmessage = (e) => {
       process.exit(approved ? 0 : 1)
     }
   }
-}
+})
 ws.onerror = (e) => console.error('ws error', e)

--- a/server/scripts/e2e-handoff.ts
+++ b/server/scripts/e2e-handoff.ts
@@ -2,9 +2,10 @@
 // 双向：claude → codex、codex → claude。需服务端已启动（默认 :7480，ANYPLANE_PORT 覆盖）。
 // 用法：bun run server/scripts/e2e-handoff.ts <claudeSessionKey> <codexThreadKey>（均为要操作的源会话 key）
 
+import { connect } from './e2e-lib'
+
 const PORT = process.env.ANYPLANE_PORT ?? '7480'
 const BASE = `http://localhost:${PORT}`
-const tokenQ = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN}` : ''
 
 const CLAUDE_KEY = process.argv[2] ?? ''
 const CODEX_KEY = process.argv[3] ?? ''
@@ -23,28 +24,12 @@ interface HandoffOutcome {
 /** 连源会话 WS（触发 hub 存在），发 POST /api/handoff，等待 handoff_done/error */
 function handoff(fromKey: string, toBackend: 'claude' | 'codex', label: string): Promise<HandoffOutcome> {
   return new Promise(async (resolve) => {
-    const ws = new WebSocket(`ws://localhost:${PORT}/ws/sessions/${encodeURIComponent(fromKey)}${tokenQ}`)
+    const { ws, on, send, open } = connect(fromKey)
     const timeout = setTimeout(() => resolve({ error: 'TIMEOUT 等待 handoff_done' }), 420_000)
-    ws.onopen = async () => {
-      ws.send(JSON.stringify({ kind: 'attach' }))
-      const r = await fetch(`${BASE}/api/handoff`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ fromKey, toBackend, detail: 'standard' }),
-      })
-      const body = (await r.json().catch(() => ({}))) as { error?: string }
-      if (!r.ok) {
-        clearTimeout(timeout)
-        resolve({ error: `POST /api/handoff ${r.status}: ${body.error ?? ''}` })
-      } else {
-        console.log(`[${label}] 接力已发起，等待简报与播种…`)
-      }
-    }
-    ws.onmessage = (e) => {
-      const ev = JSON.parse(String(e.data))
+    on((ev) => {
       if (ev.kind === 'handoff_pending') console.log(`[${label}] 简报生成中…`)
       if (ev.kind === 'handoff_done') {
-        console.log(`[${label}] handoff_done target=${ev.targetKey.slice(0, 60)} sid=${String(ev.targetSessionId ?? '').slice(0, 8)}`)
+        console.log(`[${label}] handoff_done target=${String(ev.targetKey ?? '').slice(0, 60)} sid=${String(ev.targetSessionId ?? '').slice(0, 8)}`)
         clearTimeout(timeout)
         ws.close()
         resolve({ targetKey: ev.targetKey as string, targetSessionId: ev.targetSessionId as string | undefined, brief: ev.brief as string })
@@ -54,6 +39,20 @@ function handoff(fromKey: string, toBackend: 'claude' | 'codex', label: string):
         ws.close()
         resolve({ error: ev.message as string })
       }
+    })
+    await open()
+    send({ kind: 'attach' })
+    const r = await fetch(`${BASE}/api/handoff`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ fromKey, toBackend, detail: 'standard' }),
+    })
+    const body = (await r.json().catch(() => ({}))) as { error?: string }
+    if (!r.ok) {
+      clearTimeout(timeout)
+      resolve({ error: `POST /api/handoff ${r.status}: ${body.error ?? ''}` })
+    } else {
+      console.log(`[${label}] 接力已发起，等待简报与播种…`)
     }
   })
 }

--- a/server/scripts/e2e-lib.ts
+++ b/server/scripts/e2e-lib.ts
@@ -1,5 +1,7 @@
-// e2e 脚本共享小工具：结果记录（note）与 WS 连接封装（connect）。
-// 各 e2e-*.ts 脚本是独立运行的手工验证入口，只共享这两段逐字重复的样板。
+// e2e 脚本共享小工具：结果记录（note）、WS 连接封装（connect）、app-server 探针（spawnAppServer）。
+// 各 e2e-*.ts 脚本是独立运行的手工验证入口，共享此处的样板以免逐字复制漂移。
+
+import { pumpLines } from '../src/util'
 
 /** 结果汇总：note() 记录并打印一行，results 供超时/结尾汇总 */
 export function makeNote(): { note: (ok: boolean, label: string, detail?: string) => void; results: string[] } {
@@ -19,10 +21,12 @@ export function exitWithSummary(results: string[]): never {
 }
 
 /** WS 连接封装：handlers 数组 + send + open Promise。
- *  服务端配置 authToken 时需要 ANYPLANE_TOKEN 环境变量（否则握手 401）。 */
+ *  服务端配置 authToken 时需要 ANYPLANE_TOKEN 环境变量（否则握手 401）。
+ *  端口随 ANYPLANE_PORT（默认 7480），与 e2e-handoff 的 REST BASE 口径一致。 */
 export function connect(key: string) {
   const tokenQ = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN}` : ''
-  const ws = new WebSocket(`ws://localhost:7480/ws/sessions/${encodeURIComponent(key)}${tokenQ}`)
+  const port = process.env.ANYPLANE_PORT ?? '7480'
+  const ws = new WebSocket(`ws://localhost:${port}/ws/sessions/${encodeURIComponent(key)}${tokenQ}`)
   const handlers: Array<(ev: Record<string, unknown>) => void> = []
   ws.onmessage = (e) => {
     const ev = JSON.parse(e.data)
@@ -57,49 +61,35 @@ export function spawnAppServer(): {
   const handlers: Array<(msg: { method?: string; id?: number | string; params?: Record<string, unknown> }) => void> = []
   const send = (msg: Record<string, unknown>) => proc.stdin.write(JSON.stringify(msg) + '\n')
 
-  void (async () => {
-    const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader()
-    const decoder = new TextDecoder()
-    let buf = ''
-    for (;;) {
-      const { done, value } = await reader.read()
-      if (done) break
-      buf += decoder.decode(value, { stream: true })
-      let idx: number
-      while ((idx = buf.indexOf('\n')) >= 0) {
-        const line = buf.slice(0, idx).trim()
-        buf = buf.slice(idx + 1)
-        if (!line) continue
-        let msg: {
-          id?: number | string
-          method?: string
-          params?: Record<string, unknown>
-          result?: unknown
-          error?: { code: number; message: string }
-        }
-        try {
-          msg = JSON.parse(line)
-        } catch {
-          continue // 非 JSON 行（启动横幅等）
-        }
-        if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
-          const p = pending.get(Number(msg.id))
-          if (p) {
-            pending.delete(Number(msg.id))
-            if (msg.error) p.reject(new Error(`${msg.error.code}: ${msg.error.message}`))
-            else p.resolve(msg.result)
-          }
-          continue
-        }
-        if (msg.id !== undefined) {
-          send({ id: msg.id, result: { decision: 'decline' } })
-          for (const h of handlers) h({ method: `serverRequest:${msg.method}`, id: msg.id, params: msg.params })
-          continue
-        }
-        for (const h of handlers) h(msg)
-      }
+  void pumpLines(proc.stdout as ReadableStream<Uint8Array>, (line) => {
+    let msg: {
+      id?: number | string
+      method?: string
+      params?: Record<string, unknown>
+      result?: unknown
+      error?: { code: number; message: string }
     }
-  })()
+    try {
+      msg = JSON.parse(line)
+    } catch {
+      return // 非 JSON 行（启动横幅等）
+    }
+    if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+      const p = pending.get(Number(msg.id))
+      if (p) {
+        pending.delete(Number(msg.id))
+        if (msg.error) p.reject(new Error(`${msg.error.code}: ${msg.error.message}`))
+        else p.resolve(msg.result)
+      }
+      return
+    }
+    if (msg.id !== undefined) {
+      send({ id: msg.id, result: { decision: 'decline' } })
+      for (const h of handlers) h({ method: `serverRequest:${msg.method}`, id: msg.id, params: msg.params })
+      return
+    }
+    for (const h of handlers) h(msg)
+  })
 
   return {
     request: (method, params) =>

--- a/server/scripts/e2e-rewind.ts
+++ b/server/scripts/e2e-rewind.ts
@@ -1,13 +1,14 @@
 // E2E-回滚：串行覆盖三条路径 —— rewind_files 控制请求 → rewind_conversation → rewind_both
 // 三条都打到同一个目标消息（幂等：空恢复快照 + 同一截断点），最后发问验证会话可用。
 // 用法：bun run server/scripts/e2e-rewind.ts [cwd] [sessionId]
-const sanitizePath = (p: string) => p.replace(/[^a-zA-Z0-9]/g, '-')
+import { sanitizePath } from '../src/util'
+import { connect } from './e2e-lib'
+
 const cwd = process.argv[2] ?? process.cwd()
 const slug = sanitizePath(cwd)
 const sessionId = process.argv[3] ?? 'ee01d38e-b1f9-4c3d-8110-518aa465cdb0'
 const key = `s|${slug}|${sessionId}`
 
-const tokenQ = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN}` : ''
 // 从 REST 拿一条用户消息 uuid。取最后一条带文本的用户消息：
 // 最早的消息通常早于文件检查点（无快照可恢复），最近的消息最可能有 checkpoint。
 const hist = await (await fetch(`http://localhost:7480/api/history/${slug}/${sessionId}`)).json()
@@ -30,7 +31,7 @@ const preview = (target.blocks ?? [])
   .join(' ')
 console.log('回滚目标:', target.uuid, (preview || '(非文本消息)').slice(0, 50))
 
-const ws = new WebSocket(`ws://localhost:7480/ws/sessions/${encodeURIComponent(key)}${tokenQ}`)
+const { ws, on, send, open } = connect(key)
 const timeout = setTimeout(() => {
   console.error('TIMEOUT')
   process.exit(1)
@@ -46,27 +47,25 @@ const fail = (why: string): never => {
 // → 3=等待 rewound(both) → 4=等待回滚后问答 result
 let phase = 0
 
-ws.onopen = () => {
-  ws.send(JSON.stringify({ kind: 'attach' }))
-  setTimeout(() => {
-    if (phase !== 0) return
-    phase = 1
-    console.log('>> 路径1: rewind_files（通用 control 通道，透传语义）')
-    ws.send(JSON.stringify({ kind: 'control', subtype: 'rewind_files', extra: { user_message_id: target.uuid } }))
-  }, 3000)
-}
+await open()
+send({ kind: 'attach' })
+setTimeout(() => {
+  if (phase !== 0) return
+  phase = 1
+  console.log('>> 路径1: rewind_files（通用 control 通道，透传语义）')
+  send({ kind: 'control', subtype: 'rewind_files', extra: { user_message_id: target.uuid } })
+}, 3000)
 
-ws.onmessage = (e) => {
-  const ev = JSON.parse(e.data)
+on((ev) => {
   if (ev.kind === 'cli') {
-    const m = ev.msg
+    const m = ev.msg as Record<string, any>
     if (m.type === 'control_response') {
       console.log('<< control_response:', JSON.stringify(m.response)?.slice(0, 300))
       if (phase !== 1) return
       if (m.response?.subtype !== 'success') fail(`rewind_files 被拒绝: ${m.response?.error}`)
       phase = 2
       console.log('>> 路径2: rewind_conversation（重生进程截断对话）')
-      ws.send(JSON.stringify({ kind: 'rewind_conversation', userMessageId: target.uuid }))
+      send({ kind: 'rewind_conversation', userMessageId: target.uuid })
       return
     }
     if (m.type === 'result') {
@@ -86,7 +85,7 @@ ws.onmessage = (e) => {
       setTimeout(() => {
         if (phase !== 3) return
         console.log('>> 路径3: rewind_both（先恢复文件，成功后回滚对话）')
-        ws.send(JSON.stringify({ kind: 'rewind_both', userMessageId: target.uuid }))
+        send({ kind: 'rewind_both', userMessageId: target.uuid })
       }, 3000)
       return
     }
@@ -96,15 +95,15 @@ ws.onmessage = (e) => {
       setTimeout(() => {
         if (phase !== 4) return
         console.log('>> 回滚后发问')
-        ws.send(JSON.stringify({ kind: 'user', text: '用两个字回答：2+2等于几？' }))
+        send({ kind: 'user', text: '用两个字回答：2+2等于几？' })
       }, 5000)
       return
     }
-    fail(`意外的 rewound: phase=${phase} scope=${ev.scope}`)
+    fail(`意外的 rewound: phase=${phase} scope=${String(ev.scope)}`)
     return
   }
   if (ev.kind === 'error') {
-    fail(ev.message)
+    fail(String(ev.message))
   }
-}
+})
 ws.onerror = (e) => console.error('ws error', e)

--- a/server/scripts/e2e-slash.ts
+++ b/server/scripts/e2e-slash.ts
@@ -1,12 +1,13 @@
 // E2E-斜杠命令：/compact 透传 + /btw 侧问
 // 用法：bun run server/scripts/e2e-slash.ts [cwd] [sessionId]
-const sanitizePath = (p: string) => p.replace(/[^a-zA-Z0-9]/g, '-')
+import { sanitizePath } from '../src/util'
+import { connect } from './e2e-lib'
+
 const cwd = process.argv[2] ?? process.cwd()
 const slug = sanitizePath(cwd)
 const sessionId = process.argv[3] ?? 'ee01d38e-b1f9-4c3d-8110-518aa465cdb0'
 const key = `s|${slug}|${sessionId}`
-const tokenQ = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN}` : ''
-const ws = new WebSocket(`ws://localhost:7480/ws/sessions/${encodeURIComponent(key)}${tokenQ}`)
+const { ws, on, send, open } = connect(key)
 
 const timeout = setTimeout(() => {
   console.error('TIMEOUT')
@@ -14,22 +15,20 @@ const timeout = setTimeout(() => {
 }, 180_000)
 
 let compactDone = false
-ws.onopen = () => {
-  ws.send(JSON.stringify({ kind: 'attach' }))
-  setTimeout(() => {
-    console.log('>> /compact')
-    ws.send(JSON.stringify({ kind: 'user', text: '/compact' }))
-  }, 3000)
-  setTimeout(() => {
-    console.log('>> /btw 当前会话聊了什么？')
-    ws.send(JSON.stringify({ kind: 'btw', question: '用一句话总结这个会话到目前为止聊了什么' }))
-  }, 6000)
-}
+await open()
+send({ kind: 'attach' })
+setTimeout(() => {
+  console.log('>> /compact')
+  send({ kind: 'user', text: '/compact' })
+}, 3000)
+setTimeout(() => {
+  console.log('>> /btw 当前会话聊了什么？')
+  send({ kind: 'btw', question: '用一句话总结这个会话到目前为止聊了什么' })
+}, 6000)
 
-ws.onmessage = (e) => {
-  const ev = JSON.parse(e.data)
+on((ev) => {
   if (ev.kind === 'cli') {
-    const m = ev.msg
+    const m = ev.msg as Record<string, any>
     if (m.type === 'system' && (m.subtype === 'compact_boundary' || String(m.subtype).includes('compact'))) {
       console.log('<< ✅ compact 事件:', m.subtype)
       compactDone = true
@@ -39,11 +38,11 @@ ws.onmessage = (e) => {
     }
     if (m.type === 'result') console.log('<< result', m.subtype)
   } else if (ev.kind === 'btw_result') {
-    console.log(`<< btw_result ok=${ev.ok}:`, ev.text.slice(0, 300))
+    console.log(`<< btw_result ok=${String(ev.ok)}:`, String(ev.text ?? '').slice(0, 300))
     clearTimeout(timeout)
     process.exit(compactDone ? 0 : 1)
   } else if (ev.kind === 'error') {
     console.log('<< error:', ev.message)
   }
-}
+})
 ws.onerror = (e) => console.error('ws error', e)

--- a/server/scripts/e2e-ws.ts
+++ b/server/scripts/e2e-ws.ts
@@ -1,41 +1,39 @@
 // E2E：模拟浏览器 WS 客户端，走 attach → user → 收 assistant/result 全流程
 // 用法：bun run server/scripts/e2e-ws.ts [cwd] [sessionId]
 // cwd 默认 process.cwd()，slug 由 cwd 按 discovery sanitizePath 推导；sessionId 默认 smoke 会话。
-const sanitizePath = (p: string) => p.replace(/[^a-zA-Z0-9]/g, '-')
+import { sanitizePath } from '../src/util'
+import { connect } from './e2e-lib'
+
 const cwd = process.argv[2] ?? process.cwd()
 const slug = sanitizePath(cwd)
 const sessionId = process.argv[3] ?? 'ee01d38e-b1f9-4c3d-8110-518aa465cdb0' // smoke 测试产生的会话
 const key = `s|${slug}|${sessionId}`
-
-const tokenQ = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN}` : ''
-const ws = new WebSocket(`ws://localhost:7480/ws/sessions/${encodeURIComponent(key)}${tokenQ}`)
+const { ws, on, send, open } = connect(key)
 
 const timeout = setTimeout(() => {
   console.error('TIMEOUT')
   process.exit(1)
 }, 120_000)
 
-ws.onopen = () => {
-  console.log('>> open, attach')
-  ws.send(JSON.stringify({ kind: 'attach' }))
-  setTimeout(() => {
-    console.log('>> 发送控制消息 set_model sonnet')
-    ws.send(JSON.stringify({ kind: 'control', subtype: 'set_model', extra: { model: 'sonnet' } }))
-  }, 2000)
-  setTimeout(() => {
-    console.log('>> 发送用户消息（考察接续：上一个问题是什么？）')
-    ws.send(JSON.stringify({ kind: 'user', text: '用一句话回答：我上一个问题问的是什么？' }))
-  }, 4000)
-}
+await open()
+console.log('>> open, attach')
+send({ kind: 'attach' })
+setTimeout(() => {
+  console.log('>> 发送控制消息 set_model sonnet')
+  send({ kind: 'control', subtype: 'set_model', extra: { model: 'sonnet' } })
+}, 2000)
+setTimeout(() => {
+  console.log('>> 发送用户消息（考察接续：上一个问题是什么？）')
+  send({ kind: 'user', text: '用一句话回答：我上一个问题问的是什么？' })
+}, 4000)
 
-ws.onmessage = (e) => {
-  const ev = JSON.parse(e.data)
+on((ev) => {
   if (ev.kind === 'cli') {
-    const m = ev.msg
+    const m = ev.msg as Record<string, any>
     const brief =
       m.type === 'assistant'
         ? `assistant: ${JSON.stringify(m.message?.content)?.slice(0, 300)}`
-        : `${m.type}${m.subtype ? '/' + m.subtype : ''}`
+        : `${String(m.type)}${m.subtype ? '/' + String(m.subtype) : ''}`
     console.log('<< cli', brief)
     if (m.type === 'control_request') console.log('   控制请求:', JSON.stringify(m.request)?.slice(0, 200))
     if (m.type === 'result') {
@@ -46,5 +44,5 @@ ws.onmessage = (e) => {
   } else {
     console.log('<<', ev.kind, JSON.stringify(ev.state ?? ev.message ?? ev.requestId ?? ''))
   }
-}
+})
 ws.onerror = (e) => console.error('ws error', e)

--- a/server/src/archive.ts
+++ b/server/src/archive.ts
@@ -5,6 +5,7 @@
 
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
+import { keyFor } from './backends/claude/backend'
 import { config } from './config'
 import { ccDataDir, ensurePrivateDir, transcriptPathOf } from './util'
 
@@ -96,7 +97,7 @@ export function listTrash(): TrashEntry[] {
       try {
         sizeBytes = statSync(p).size
       } catch {}
-      out.push({ key: `s|${slug}|${sessionId}`, slug, sessionId, trashedAt, sizeBytes })
+      out.push({ key: keyFor(slug, sessionId), slug, sessionId, trashedAt, sizeBytes })
     }
   }
   return out.sort((a, b) => (b.trashedAt ?? '').localeCompare(a.trashedAt ?? ''))

--- a/server/src/backends/claude/discovery.ts
+++ b/server/src/backends/claude/discovery.ts
@@ -411,14 +411,18 @@ interface ParsedTranscript {
 const PARSE_CACHE_CAP = 8
 const parseCache = new Map<string, { mtimeMs: number; size: number; parsed: ParsedTranscript }>()
 
-function parseTranscriptCached(path: string, mtimeMs: number, size: number, raw: Buffer): ParsedTranscript {
+function peekParseCache(path: string, mtimeMs: number, size: number): ParsedTranscript | undefined {
   const hit = parseCache.get(path)
-  if (hit && hit.mtimeMs === mtimeMs && hit.size === size) {
-    // LRU 触摸：命中即最新，淘汰从最早未用开始
-    parseCache.delete(path)
-    parseCache.set(path, hit)
-    return hit.parsed
-  }
+  if (!hit || hit.mtimeMs !== mtimeMs || hit.size !== size) return undefined
+  // LRU 触摸：命中即最新，淘汰从最早未用开始
+  parseCache.delete(path)
+  parseCache.set(path, hit)
+  return hit.parsed
+}
+
+function parseTranscriptCached(path: string, mtimeMs: number, size: number, raw: Buffer): ParsedTranscript {
+  const hit = peekParseCache(path, mtimeMs, size)
+  if (hit) return hit
   const parsed = parseTranscript(raw)
   parseCache.set(path, { mtimeMs, size, parsed })
   while (parseCache.size > PARSE_CACHE_CAP) {
@@ -476,12 +480,14 @@ export function readHistory(
   const before = opts?.before
   const path = transcriptPathOf(slug, sessionId)
   if (!existsSync(path)) return { messages: [], fileBytes: 0, subagents: readSubagentTranscripts(slug, sessionId), hasMore: false }
-  // 读 Buffer 而非 utf8 文本：fileBytes 必须与本次实际解析的字节精确一致，
-  // tailer 从该偏移续读才不会有缝（statSync 与 read 之间文件可能增长）。
   const st = statSync(path)
-  const raw = readFileSync(path)
-  const { fileBytes, msgs, msgLineIdx, selectable, lastBoundaryLine, legacySidechain } =
-    parseTranscriptCached(path, st.mtimeMs, st.size, raw)
+  // 缓存命中则跳过全文件读（上一条注释承诺的"翻 N 页不再付 N 次全文件读"的读这一半）：
+  // (mtimeMs, size) 键相等即内容相等（transcript 只追加），此时 parsed.fileBytes === st.size。
+  // 未命中才读 Buffer 而非 utf8 文本：fileBytes 必须与本次实际解析的字节精确一致，
+  // tailer 从该偏移续读才不会有缝（statSync 与 read 之间文件可能增长）。
+  const parsed =
+    peekParseCache(path, st.mtimeMs, st.size) ?? parseTranscriptCached(path, st.mtimeMs, st.size, readFileSync(path))
+  const { fileBytes, msgs, msgLineIdx, selectable, lastBoundaryLine, legacySidechain } = parsed
   // 只有最后一个 compact 边界之后的消息才是逻辑上存在、可回滚的；
   // user 消息还需通过官方同款的目标过滤（无 checkpoint 的消息不可作为 rewind 目标）。
   // rewindable 必须基于全量列表计算（lastBoundaryLine 是全文件扫描的产物），与分页窗口无关

--- a/server/src/backends/codex/port.ts
+++ b/server/src/backends/codex/port.ts
@@ -18,7 +18,7 @@ import {
   type StatusContext,
 } from '../port'
 import type { SpawnOptions } from '../types'
-import { listArchivedSessions, parseKey as codexParseKey, splitThreadId } from './backend'
+import { keyFor, listArchivedSessions, parseKey as codexParseKey, splitThreadId } from './backend'
 import { codexRuntime, type CodexSession } from './runtime'
 
 class CodexPort implements BackendPort {
@@ -144,7 +144,7 @@ class CodexPort implements BackendPort {
         const newId = await codexRuntime.forkAt(tid, at)
         hubServices().broadcast(hub, {
           kind: 'forked',
-          targetKey: `x|${newId}`,
+          targetKey: keyFor(newId),
           targetSessionId: newId,
           fromTurnId: at,
         })

--- a/server/src/backends/codex/runtime.ts
+++ b/server/src/backends/codex/runtime.ts
@@ -1267,8 +1267,29 @@ export class CodexRuntime {
   }
 
   /** paginated 历史：turns/list 默认降序（新→旧，实测）——显式 asc 翻页拿元数据；
-   *  items/list 不带 turnId 时跨 turn 升序分页（entry 为 {turnId, item} 包装，非裸 ThreadItem）。 */
+   *  items/list 不带 turnId 时跨 turn 升序分页（entry 为 {turnId, item} 包装，非裸 ThreadItem）。
+   *  两段翻页相互独立（合并只消费两者的终态），并发启动：墙钟时间取较长一段而非相加。 */
   private async readPaginatedTurns(threadId: string): Promise<HistoryTurn[]> {
+    const [turnsMeta, itemsByTurn] = await Promise.all([this.listTurnsMeta(threadId), this.listItemsByTurn(threadId)])
+
+    const seen = new Set<string>()
+    const turns = turnsMeta.map((t) => {
+      if (t.id) seen.add(t.id)
+      return { ...t, items: t.id ? (itemsByTurn.get(t.id) ?? []) : [] }
+    })
+    // 防御：item 的 turnId 不在 turns/list 里（竞态/分页窗口交错）——按首见序追加为末段，不静默丢弃
+    for (const [turnId, items] of itemsByTurn) {
+      if (!seen.has(turnId)) {
+        log.warn('[codex] items/list 出现 turns/list 之外的 turnId，按末段追加', { threadId, turnId })
+        turns.push({ id: turnId, startedAt: null, completedAt: null, items })
+      }
+    }
+    return turns
+  }
+
+  private async listTurnsMeta(
+    threadId: string,
+  ): Promise<Array<{ id?: string; startedAt?: number | null; completedAt?: number | null }>> {
     const turnsMeta: Array<{ id?: string; startedAt?: number | null; completedAt?: number | null }> = []
     let cursor: string | null | undefined
     do {
@@ -1283,9 +1304,12 @@ export class CodexRuntime {
       turnsMeta.push(...(page.data ?? []))
       cursor = page.nextCursor ?? null
     } while (cursor)
+    return turnsMeta
+  }
 
+  private async listItemsByTurn(threadId: string): Promise<Map<string, ThreadItem[]>> {
     const itemsByTurn = new Map<string, ThreadItem[]>()
-    cursor = undefined
+    let cursor: string | null | undefined
     do {
       const page = (await this.rpcRequest(
         'thread/items/list',
@@ -1305,20 +1329,7 @@ export class CodexRuntime {
       }
       cursor = page.nextCursor ?? null
     } while (cursor)
-
-    const seen = new Set<string>()
-    const turns = turnsMeta.map((t) => {
-      if (t.id) seen.add(t.id)
-      return { ...t, items: t.id ? (itemsByTurn.get(t.id) ?? []) : [] }
-    })
-    // 防御：item 的 turnId 不在 turns/list 里（竞态/分页窗口交错）——按首见序追加为末段，不静默丢弃
-    for (const [turnId, items] of itemsByTurn) {
-      if (!seen.has(turnId)) {
-        log.warn('[codex] items/list 出现 turns/list 之外的 turnId，按末段追加', { threadId, turnId })
-        turns.push({ id: turnId, startedAt: null, completedAt: null, items })
-      }
-    }
-    return turns
+    return itemsByTurn
   }
 
   /** turn 序列 → 历史消息：itemsToHistory 翻译 + 侧车 reasoning 按 turn 时间窗回插 */

--- a/server/src/backends/port.test.ts
+++ b/server/src/backends/port.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test'
+import { keyFor as claudeKeyFor, keyForBranch, keyForNew as claudeKeyForNew } from './claude/backend'
+import { keyFor as codexKeyFor, keyForNew as codexKeyForNew } from './codex/backend'
+import { describeKey } from './port'
+
+// describeKey 是 key 形状的零 I/O 解析唯一正本（routes/misc、push/fanout 共用）；
+// 本测试把它与两后端 keyFor/keyForNew/keyForBranch 构造器的一一对应锁死——
+// 构造器改形状时这里必须同步失败，而不是消费方静默落空。
+describe('describeKey', () => {
+  test('claude existing: s|<slug>|<sessionId>', () => {
+    expect(describeKey(claudeKeyFor('-tmp-proj', 'sess-1'))).toEqual({
+      backend: 'claude',
+      kind: 'existing',
+      slug: '-tmp-proj',
+      sessionId: 'sess-1',
+    })
+  })
+
+  test('codex existing: x|<threadId>', () => {
+    expect(describeKey(codexKeyFor('th-1'))).toEqual({
+      backend: 'codex',
+      kind: 'existing',
+      sessionId: 'th-1',
+    })
+  })
+
+  test('claude new: n|<encoded cwd>（含空格与斜杠的 cwd 解码还原）', () => {
+    expect(describeKey(claudeKeyForNew('/tmp/my proj'))).toEqual({
+      backend: 'claude',
+      kind: 'new',
+      cwd: '/tmp/my proj',
+    })
+  })
+
+  test('codex new: xn|<encoded cwd>', () => {
+    expect(describeKey(codexKeyForNew('/tmp/my proj'))).toEqual({
+      backend: 'codex',
+      kind: 'new',
+      cwd: '/tmp/my proj',
+    })
+  })
+
+  test('claude branch: b|<encoded cwd>|<源 sessionId>', () => {
+    expect(describeKey(keyForBranch('/tmp/proj', 'src-9'))).toEqual({
+      backend: 'claude',
+      kind: 'branch',
+      cwd: '/tmp/proj',
+      sessionId: 'src-9',
+    })
+  })
+
+  test('畸形 key 一律 null：未知前缀 / 段数不符 / 非法 % 转义 / 空串', () => {
+    expect(describeKey('z|whatever')).toBeNull()
+    expect(describeKey('s|only-two')).toBeNull()
+    expect(describeKey('xn|a|b')).toBeNull()
+    expect(describeKey('n|%E4%B8')).toBeNull() // 截断的 UTF-8 转义，decodeURIComponent 抛错
+    expect(describeKey('')).toBeNull()
+  })
+})

--- a/server/src/backends/port.ts
+++ b/server/src/backends/port.ts
@@ -217,6 +217,44 @@ export function backendOf(key: string): BackendName {
   return isCodexKey(key) ? 'codex' : 'claude'
 }
 
+/** key 的零 I/O 纯形状解析（与两后端 keyFor/keyForNew/keyForBranch 构造器一一对应）。
+ *  只读 key 本身：不做 listSessions 反查也不做 RPC，故 existing 的 cwd 缺席（要 cwd 走 parseKey）。
+ *  未知前缀或编码段损坏（非法 % 转义）返回 null，消费方各自兜底。 */
+export interface DescribedKey {
+  backend: BackendName
+  kind: 'existing' | 'new' | 'branch'
+  /** existing：真实会话/线程 id；branch：分叉源 sessionId（b| 内嵌的是源 id，见 keyForBranch） */
+  sessionId?: string
+  /** existing(claude s|)：slug 段原样（未过字符闸；要校验用 splitExistingKey） */
+  slug?: string
+  /** new/branch：key 内嵌的 cwd（已解码） */
+  cwd?: string
+}
+
+export function describeKey(key: string): DescribedKey | null {
+  try {
+    const parts = key.split('|')
+    if (parts[0] === 's' && parts.length === 3) {
+      return { backend: 'claude', kind: 'existing', slug: parts[1], sessionId: parts[2] }
+    }
+    if (parts[0] === 'x' && parts.length === 2) {
+      return { backend: 'codex', kind: 'existing', sessionId: parts[1] }
+    }
+    if (parts[0] === 'n' && parts.length === 2) {
+      return { backend: 'claude', kind: 'new', cwd: decodeURIComponent(parts[1]) }
+    }
+    if (parts[0] === 'xn' && parts.length === 2) {
+      return { backend: 'codex', kind: 'new', cwd: decodeURIComponent(parts[1]) }
+    }
+    if (parts[0] === 'b' && parts.length === 3) {
+      return { backend: 'claude', kind: 'branch', cwd: decodeURIComponent(parts[1]), sessionId: parts[2] }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
 /** 编排层唯一的后端分支点：全仓库的能力分发都收敛到这一个三元 */
 export function portFor(key: string): BackendPort {
   return isCodexKey(key) ? codexPort : claudePort

--- a/server/src/hub/broadcast.ts
+++ b/server/src/hub/broadcast.ts
@@ -41,8 +41,8 @@ export function replayApprovals(hub: Hub, send: (payload: unknown) => void): voi
 }
 
 export function broadcast(hub: Hub, payload: unknown): void {
-  const kindForRing = (payload as { kind?: string } | null | undefined)?.kind
-  if (kindForRing === 'cli') pushCliRing(hub, payload as Record<string, unknown>)
+  const kind = (payload as { kind?: string } | null | undefined)?.kind
+  if (kind === 'cli') pushCliRing(hub, payload as Record<string, unknown>)
   const text = JSON.stringify(payload)
   for (const ws of hub.clients) {
     try {
@@ -54,7 +54,6 @@ export function broadcast(hub: Hub, payload: unknown): void {
     }
   }
   // 错误事件同步进全局收件箱（审批/完成由各自路径单独发布）
-  const kind = (payload as { kind?: string } | null | undefined)?.kind
   if (kind === 'error') {
     publishInbox({ type: 'error', key: hub.key, message: String((payload as { message?: unknown }).message ?? '') })
   }

--- a/server/src/hub/handoff.ts
+++ b/server/src/hub/handoff.ts
@@ -3,7 +3,7 @@
 
 import { keyFor, keyForNew } from '../backends/claude/backend'
 import { sanitizePath } from '../backends/claude/discovery'
-import { keyForNew as codexKeyForNew } from '../backends/codex/backend'
+import { keyFor as codexKeyFor, keyForNew as codexKeyForNew } from '../backends/codex/backend'
 import { portFor } from '../backends/port'
 import { appendLineage, seedMessage, type HandoffDetail } from '../handoff'
 import { errorMessage } from '../util'
@@ -47,7 +47,7 @@ export function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detai
       const toResolvedKey =
         toBackend === 'codex'
           ? targetSessionId
-            ? `x|${targetSessionId}`
+            ? codexKeyFor(targetSessionId)
             : undefined
           : targetSessionId
             ? keyFor(sanitizePath(sourceCwd), targetSessionId)
@@ -60,7 +60,7 @@ export function runHandoff(fromKey: string, toBackend: 'claude' | 'codex', detai
         }
         if (fromKey.startsWith('x|')) return fromKey
         const tidNow = fromPort.sessionOf(fromKey)?.sessionId
-        return tidNow ? `x|${tidNow}` : undefined
+        return tidNow ? codexKeyFor(tidNow) : undefined
       })()
 
       // 播种进程/线程落在 n|/xn| key 上，而 handoff_done 导航走 resolved key：立即三层重键

--- a/server/src/portTakeover.ts
+++ b/server/src/portTakeover.ts
@@ -117,14 +117,40 @@ export async function describePid(pid: number): Promise<PidDesc | null> {
 
 export type TakeoverResult = 'noop' | 'freed' | 'refused' | 'unsupported'
 
-/** 在 deadlineMs 内轮询等待端口释放；释放返回 true */
-async function waitForPortFree(port: number, deadlineMs: number): Promise<boolean> {
+/** 在 deadlineMs 内每 50ms 轮询 isClear；清场返回 true，超时返回 false */
+async function pollUntil(isClear: () => Promise<boolean>, deadlineMs: number): Promise<boolean> {
   const deadline = Date.now() + deadlineMs
   while (Date.now() < deadline) {
-    if ((await listListenPids(port))?.length === 0) return true
+    if (await isClear()) return true
     await Bun.sleep(50)
   }
   return false
+}
+
+/**
+ * "自己人"进程的结束流：SIGTERM 全体 → 轮询清场(2s) → 未退者 SIGKILL → 再轮询(1s)。
+ * 破坏性流程只此一份（takeoverStaleListeners 与 scripts/gateway 的 replaceStaleGateway 共用），
+ * 超时/信号节奏调整不会两处漂移。isClear 由调用方定义"清场"（本模块=端口零监听——
+ * 防新进程抢占误判；gateway=own pid 不再监听）；onEvent 供调用方接自家格式的日志。 */
+export async function terminatePids(
+  own: number[],
+  isClear: () => Promise<boolean>,
+  onEvent: (pid: number, signal: 'SIGTERM' | 'SIGKILL') => void,
+): Promise<boolean> {
+  for (const pid of own) {
+    onEvent(pid, 'SIGTERM')
+    try {
+      process.kill(pid, 'SIGTERM')
+    } catch {}
+  }
+  if (await pollUntil(isClear, 2000)) return true
+  for (const pid of own) {
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {}
+    onEvent(pid, 'SIGKILL')
+  }
+  return pollUntil(isClear, 1000)
 }
 
 /**
@@ -162,20 +188,16 @@ export async function takeoverStaleListeners(
     return 'refused'
   }
 
-  for (const pid of own) {
-    log.warn(`[port-takeover] :${port} 结束残留进程 pid=${pid}`)
-    try {
-      process.kill(pid, 'SIGTERM')
-    } catch {}
-  }
-  if (await waitForPortFree(port, 2000)) return 'freed'
-  for (const pid of own) {
-    try {
-      process.kill(pid, 'SIGKILL')
-      log.warn(`[port-takeover] pid=${pid} 未退出，已 SIGKILL`)
-    } catch {}
-  }
-  if (await waitForPortFree(port, 1000)) return 'freed'
+  const cleared = await terminatePids(
+    own,
+    // 清场 = 端口零监听（防kill后新进程抢占同名端口被误判为已释放）
+    async () => (await listListenPids(port))?.length === 0,
+    (pid, signal) => {
+      if (signal === 'SIGTERM') log.warn(`[port-takeover] :${port} 结束残留进程 pid=${pid}`)
+      else log.warn(`[port-takeover] pid=${pid} 未退出，已 SIGKILL`)
+    },
+  )
+  if (cleared) return 'freed'
   log.error(`[port-takeover] :${port} SIGKILL 后仍被占用，接管失败`)
   return 'refused'
 }

--- a/server/src/push/fanout.ts
+++ b/server/src/push/fanout.ts
@@ -2,7 +2,7 @@
 // 依赖方向：push → hub（registry）允许，反向禁止（hub 经 hub/broadcast 的 InboxSink 出口）。
 
 import { parseKey } from '../backends/claude/backend'
-import { portFor } from '../backends/port'
+import { describeKey, portFor } from '../backends/port'
 import { log } from '../log'
 import { pushToAll, pushWebhooksToAll, subscriptionCount, webhookCount, type PushPayload } from '../push'
 import { escapeHtml, summarizeInput } from '../util'
@@ -11,30 +11,23 @@ import type { InboxEvent, PendingApproval } from '../hub/types'
 
 /** 会话显示名：项目目录 basename（approval 只在 spawn 后发生，spawnOpts.cwd 必有）。
  *  s| 未 spawn 时经 parseKey 反查真实 cwd——每 Hub 至多一次（缓存在 hub.nameCwd，
- *  避免推送事件触发反复 listSessions 全盘扫描）；b|/n|/xn| 的 cwd 内嵌在 key 里直接取。
- *  parseKey 也查不到（slug 目录已删）时以 slug 末段近似。 */
+ *  避免推送事件触发反复 listSessions 全盘扫描）；b|/n|/xn| 的 cwd 内嵌在 key 里直接取
+ * （describeKey 零 I/O 形状解析）。parseKey 也查不到（slug 目录已删）时以 slug 末段近似。 */
 export function sessionNameOf(key: string): string {
   const base = (cwd: string) => cwd.replace(/\/+$/, '').split('/').pop() ?? cwd
   const hub = hubs.get(key)
   if (hub?.spawnOpts?.cwd) return base(hub.spawnOpts.cwd)
-  const parts = key.split('|')
-  try {
-    if ((parts[0] === 'b' || parts[0] === 'n' || parts[0] === 'xn') && parts[1]) {
-      return base(decodeURIComponent(parts[1]))
-    }
-  } catch {
-    // key 内嵌 cwd 不是合法 URI 编码（状态损坏/构造输入）：落 key 截断，不影响推送分发
-    return key.slice(0, 18)
-  }
-  if (parts[0] === 's') {
+  const d = describeKey(key)
+  if ((d?.kind === 'new' || d?.kind === 'branch') && d.cwd) return base(d.cwd)
+  if (d?.kind === 'existing' && d.backend === 'claude') {
     if (hub && hub.nameCwd === undefined) hub.nameCwd = parseKey(key)?.cwd ?? ''
     if (hub?.nameCwd) return base(hub.nameCwd)
     // slug 是 sanitizePath(cwd)：末段即目录名（近似，仅推送显示用）
-    if (parts[1]) return parts[1].split('-').pop() ?? key.slice(0, 18)
+    if (d.slug) return d.slug.split('-').pop() ?? key.slice(0, 18)
   }
   // x|：cwd 不在 key 里，取已加载会话句柄的 cwd（thread/read 解析后即有；
   // 推送/审批页恰好在会话存活期触发）。取不到时落 key 截断，不做同步 RPC
-  if (parts[0] === 'x') {
+  if (d?.kind === 'existing' && d.backend === 'codex') {
     if (hub && hub.nameCwd === undefined) hub.nameCwd = portFor(key).sessionOf(key)?.cwd ?? ''
     if (hub?.nameCwd) return base(hub.nameCwd)
   }

--- a/server/src/routes/misc.ts
+++ b/server/src/routes/misc.ts
@@ -5,6 +5,7 @@ import { readHistory, sanitizePath } from '../backends/claude/discovery'
 import { resolveTierModelNames } from '../backends/claude/modelNames'
 import { readHistory as readCodexHistory } from '../backends/codex/backend'
 import { codexRuntime } from '../backends/codex/runtime'
+import { describeKey } from '../backends/port'
 import { config } from '../config'
 import { FsBrowseError, listDirectories } from '../fsbrowse'
 import { lineageFor, type HandoffDetail } from '../handoff'
@@ -44,27 +45,25 @@ export async function handleMiscRoutes(req: Request, url: URL): Promise<Response
     for (const r of records) {
       for (const k of [r.fromKey, r.toKey, r.fromResolvedKey, r.toResolvedKey]) {
         if (!k || nodes[k]) continue
-        const parts = k.split('|')
-        if (parts[0] === 's' && parts.length === 3) {
-          nodes[k] = { key: k, backend: 'claude', slug: parts[1], sessionId: parts[2], cwd: r.cwd }
-        } else if (parts[0] === 'x' && parts.length === 2) {
-          nodes[k] = { key: k, backend: 'codex', slug: 'codex', sessionId: parts[1], cwd: r.cwd }
-        } else if (parts[0] === 'n' || parts[0] === 'xn') {
+        const d = describeKey(k)
+        if (d?.kind === 'existing') {
+          nodes[k] = { key: k, backend: d.backend, slug: d.slug ?? 'codex', sessionId: d.sessionId, cwd: r.cwd }
+        } else if (d?.kind === 'new') {
           nodes[k] = {
             key: k,
-            backend: parts[0] === 'xn' ? 'codex' : 'claude',
-            slug: parts[0] === 'xn' ? 'codex' : sanitizePath(decodeURIComponent(parts[1] ?? '')),
+            backend: d.backend,
+            slug: d.backend === 'codex' ? 'codex' : sanitizePath(d.cwd ?? ''),
             sessionId: 'new',
             cwd: r.cwd,
           }
-        } else if (parts[0] === 'b' && parts.length === 3) {
+        } else if (d?.kind === 'branch') {
           // 懒分叉源（分叉后从未 spawn 或被回收，fromResolvedKey 缺省时记录里仍是 b| key）：
           // 缺节点会让前端接力链按钮 disabled（死按钮）；sessionId 内嵌的是分叉源 id
           nodes[k] = {
             key: k,
             backend: 'claude',
-            slug: sanitizePath(decodeURIComponent(parts[1] ?? '')),
-            sessionId: parts[2],
+            slug: sanitizePath(d.cwd ?? ''),
+            sessionId: d.sessionId,
             cwd: r.cwd,
           }
         }

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -33,6 +33,9 @@ function branchOfCached(cwd?: string): string | undefined {
 
 export async function handleSessionRoutes(req: Request, url: URL): Promise<Response | undefined> {
   if (url.pathname === '/api/sessions' && req.method === 'GET') {
+    // codex RPC 与 claude 同步扫盘相互独立——先发起 RPC 再扫，墙钟取两者较大值而非相加
+    //（此端点被每个打开的标签页 10s 轮询）。中间无 await，rejection 一定先于下方 catch 被接管。
+    const codexP = listCodexSessions()
     const sessions = listSessions()
     const claudeRows = sessions.map((s: SessionInfo) => ({
       ...s,
@@ -48,7 +51,7 @@ export async function handleSessionRoutes(req: Request, url: URL): Promise<Respo
     // codex 线程：app-server 未安装/未登录时静默降级为空列表，不拖垮 claude 列表
     let codexRows: Record<string, unknown>[] = []
     try {
-      const threads = await listCodexSessions()
+      const threads = await codexP
       codexRows = threads.map((t) => ({
         sessionId: t.id,
         cwd: t.cwd,

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -5,7 +5,7 @@
 //（codexCfg/codexModelId/codexEffortLevels/codexModeOf）也一并内聚进来。
 
 import { useEffect, useRef, useState } from 'react'
-import type { CodexModelInfo, ServerConfigInfo, TierModelName } from '../lib/api'
+import { resolveModel, type CodexModelInfo, type ServerConfigInfo, type TierModelName } from '../lib/api'
 import { COMMAND_DESC, filterSlashHints, mergeSlashCommands, type SlashEntry } from '../lib/slashCommands'
 import type { SessionState } from '../lib/ws'
 import { ContextRing } from './ContextRing'
@@ -365,7 +365,9 @@ export function Composer(props: {
               modelLabel={
                 isCodex
                   ? (codexCurrentModel?.label ?? codexModelId)
-                  : (modelNames?.[claudeModel ?? '']?.name ?? claudeModel)
+                  : claudeModel == null
+                    ? undefined
+                    : resolveModel(modelNames, claudeModel).label
               }
               onOpenFullDetail={onOpenFullDetail}
             />

--- a/web/src/components/DetailDrawer.tsx
+++ b/web/src/components/DetailDrawer.tsx
@@ -2,7 +2,7 @@
 // F2 从 pages/Chat.tsx 逐字切出——纯展示组件；查询由 onRunQuery 回调发回组合层
 //（query_result 应答在 Chat 的 WS 分发里落到 detailContent/mcpServers/contextData/settingsData）。
 
-import type { TierModelName } from '../lib/api'
+import { resolveModel, type TierModelName } from '../lib/api'
 import { fmtTokens } from '../lib/blocks'
 
 /** claude mcp_status 应答里的单个服务器（buildMcpServerStatuses 形状） */
@@ -145,7 +145,7 @@ export function DetailDrawer(props: {
             </span>
             {contextData.model && (
               <span className="text-[10px] text-faint">
-                {modelNames?.[contextData.model]?.name ?? contextData.model}
+                {resolveModel(modelNames, contextData.model).label}
               </span>
             )}
           </div>
@@ -181,7 +181,7 @@ export function DetailDrawer(props: {
             <div className="mb-1.5 font-mono text-[11px] text-ink">
               当前生效：
               <span className="text-muted">
-                {modelNames?.[settingsData.applied.model ?? '']?.name ?? settingsData.applied.model ?? 'default'}
+                {settingsData.applied.model == null ? 'default' : resolveModel(modelNames, settingsData.applied.model).label}
               </span>
               <span className="text-faint"> · effort {settingsData.applied.effort ?? '默认'}</span>
             </div>

--- a/web/src/components/StatusPill.tsx
+++ b/web/src/components/StatusPill.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import type { ServerConfigInfo } from '../lib/api'
+import { resolveModel as resolveModelName, type ServerConfigInfo, type TierModelName } from '../lib/api'
 
 // ---- 视觉编码（E2 液态玻璃 token：唯一彩色面 = 审批红，其余走灰阶） ----
 // mode：色点（危险度语义）  effort：档位 glyph（强度渐强）
@@ -65,7 +65,7 @@ export function StatusPill(props: {
   /** effort 档位表（默认 claude 五档；codex 按模型 supportedReasoningEfforts 传入） */
   effortLevels?: readonly string[]
   /** 各档实际配置的模型名（claude 设置透传）；未配置的档缺席 → 显示 tier 名 */
-  modelNames?: Record<string, { name: string; id?: string }> | null
+  modelNames?: Record<string, TierModelName> | null
   /** 面板打开时回调（调用方借机实时拉取 modelNames） */
   onPanelOpen?: () => void
   onSetModel: (m: string) => void
@@ -80,17 +80,9 @@ export function StatusPill(props: {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
 
-  /** 模型值 → {显示名, tooltip}：tier 直查（haiku/sonnet/…）→ 按模型 ID 反查（init 报的是解析后 ID，
-   *  如 k3[1m]——大小写不敏感，设置里的 ID 写法可能不同）→ 未配置原样显示（降级） */
-  const resolveModel = (v?: string): { label: string; title?: string } => {
-    if (!v) return { label: '…' }
-    const names = props.modelNames ?? {}
-    const direct = names[v]
-    if (direct) return { label: direct.name, title: direct.id && direct.id !== direct.name ? direct.id : undefined }
-    const rev = Object.values(names).find((t) => t.id && t.id.toLowerCase() === v.toLowerCase())
-    if (rev) return { label: rev.name, title: v }
-    return { label: v }
-  }
+  /** 模型值 → {显示名, tooltip}（口径收敛在 lib/api resolveModel，此处只补未拿到模型值时的占位） */
+  const resolveModel = (v?: string): { label: string; title?: string } =>
+    v ? resolveModelName(props.modelNames, v) : { label: '…' }
 
   const syncPanelPos = () => {
     // 面板左下角与胶囊左下角重叠，向上展开（触发器 open 时 invisible，由面板盖住原位）

--- a/web/src/hooks/useTranscriptScroll.ts
+++ b/web/src/hooks/useTranscriptScroll.ts
@@ -140,6 +140,23 @@ export function useTranscriptScroll(opts: {
     setRawStart(null)
   }, [resetKey])
 
+  // ---- 扩窗或翻页（onScroll 上翻与顶部哨兵按钮共用）：本地窗口未到顶 → 锚点捕获 +
+  // flushSync 隔离提交扩窗；已到顶 → 服务端还有更早历史（hasMore）时由调用方拉取上一页 ----
+  const expandOrFetchEarlier = (top: number) => {
+    const el = scrollRef.current
+    if (!el) return
+    if (windowStart > 0) {
+      pendingAnchorRef.current = { height: el.scrollHeight, top }
+      // flushSync 隔离提交：滚动事件 lane 可能与同 tick 的 WS draft 更新合并成一个 commit，
+      // 锚定补偿按 scrollHeight 总增量会把尾部新增的草稿行高也算进去（视口跳变）——
+      // 同步提交保证补偿消费到的增量只来自本次 prepend（实测审查发现；preparePrepend
+      // 路径天然安全：捕获与 setMsgs 在同一微任务，宏任务事件插不进来）
+      flushSync(() => setRawStart(expandWindowStart(windowStart)))
+    } else {
+      onReachTop?.()
+    }
+  }
+
   // ---- 滚动事件：atBottom 维护 + 窗口冻结/恢复 + 门控扩窗 ----
   const onScroll = () => {
     const el = scrollRef.current
@@ -165,17 +182,7 @@ export function useTranscriptScroll(opts: {
     if (performance.now() < ignoreScrollUntilRef.current) return
     if (top >= last) return // 仅向上滚动可扩窗
     if (top >= EXPAND_TOP_PX) return
-    if (windowStart > 0) {
-      pendingAnchorRef.current = { height: el.scrollHeight, top }
-      // flushSync 隔离提交：滚动事件 lane 可能与同 tick 的 WS draft 更新合并成一个 commit，
-      // 锚定补偿按 scrollHeight 总增量会把尾部新增的草稿行高也算进去（视口跳变）——
-      // 同步提交保证补偿消费到的增量只来自本次 prepend（实测审查发现；preparePrepend
-      // 路径天然安全：捕获与 setMsgs 在同一微任务，宏任务事件插不进来）
-      flushSync(() => setRawStart(expandWindowStart(windowStart)))
-    } else {
-      // 本地窗口已到顶：服务端还有更早历史（hasMore）时由调用方拉取上一页
-      onReachTop?.()
-    }
+    expandOrFetchEarlier(top)
   }
 
   // ---- ↓ 按钮：恢复尾部窗口 + 直达底部 ----
@@ -192,12 +199,7 @@ export function useTranscriptScroll(opts: {
   const expandWindow = () => {
     const el = scrollRef.current
     if (!el) return
-    if (windowStart > 0) {
-      pendingAnchorRef.current = { height: el.scrollHeight, top: el.scrollTop }
-      flushSync(() => setRawStart(expandWindowStart(windowStart))) // 隔离理由同上
-    } else {
-      onReachTop?.()
-    }
+    expandOrFetchEarlier(el.scrollTop)
   }
 
   // ---- 异步 prepend 锚点捕获：在翻页响应落抄本（setState）之前调用，

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -33,6 +33,11 @@ export async function postJson(path: string, body: unknown): Promise<Response> {
   })
 }
 
+/** unknown 错误 → 单行文案（catch 后展示用；与服务端 util.errorMessage 同规则） */
+export function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e)
+}
+
 export interface SessionInfo {
   sessionId: string
   cwd?: string
@@ -244,6 +249,21 @@ export interface TierModelName {
   /** 显示名（_MODEL_NAME 优先，缺省回退模型 ID） */
   name: string
   id?: string
+}
+
+/** 模型值 → {显示名, tooltip}：tier 直查（haiku/sonnet/…）→ 按模型 ID 反查（init 报的是解析后 ID，
+ *  如 k3[1m]——大小写不敏感，设置里的 ID 写法可能不同）→ 未配置原样显示（降级）。
+ *  只需显示名的场景取 .label；StatusPill/DetailDrawer/Composer 共用同一口径，避免同模型多处显示不一致。 */
+export function resolveModel(
+  modelNames: Record<string, TierModelName> | null | undefined,
+  v: string,
+): { label: string; title?: string } {
+  const names = modelNames ?? {}
+  const direct = names[v]
+  if (direct) return { label: direct.name, title: direct.id && direct.id !== direct.name ? direct.id : undefined }
+  const rev = Object.values(names).find((t) => t.id && t.id.toLowerCase() === v.toLowerCase())
+  if (rev) return { label: rev.name, title: v }
+  return { label: v }
 }
 
 /** 各档实际配置的模型名（haiku/sonnet/opus/fable → 网关真实名）；未配置的档缺席，前端降级 tier 名 */

--- a/web/src/lib/push.ts
+++ b/web/src/lib/push.ts
@@ -1,7 +1,7 @@
 // Web Push 订阅管理：订阅/退订/状态查询
 // 密钥流：服务端 VAPID 公钥 → pushManager.subscribe → 订阅对象 POST 回服务端注册表
 
-import { apiError, apiFetch, postJson } from './api'
+import { apiError, apiFetch, errorMessage, postJson } from './api'
 
 /** 当前浏览器是否支持推送（Service Worker + Push API + 通知） */
 export function pushSupported(): boolean {
@@ -48,7 +48,7 @@ export async function subscribePush(): Promise<{ ok: boolean; error?: string }> 
     if (!r.ok) return { ok: false, error: `注册订阅失败（${(await apiError(r)).message}）` }
     return { ok: true }
   } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : String(e) }
+    return { ok: false, error: errorMessage(e) }
   }
 }
 

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { createSession, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
+import { createSession, errorMessage, fetchClaudeModelNames, fetchCodexHistory, fetchCodexModels, fetchConfig, fetchHistory, fetchLineage, makeSessionInfo, startHandoff, type CodexModelInfo, type LineageResponse, type ServerConfigInfo, type SessionInfo, type TierModelName } from '../lib/api'
 import { SessionSocket } from '../lib/ws'
 import { ApprovalCard } from '../components/ApprovalCard'
 import { ChatHeader } from '../components/ChatHeader'
@@ -484,7 +484,7 @@ export function Chat(props: { session: SessionInfo; onBack: () => void; onNaviga
           const toBackend = isCodex ? 'claude' : 'codex'
           setHandoffBusy(true)
           startHandoff(session.key, toBackend)
-            .catch((e) => ingestApi.pushSystem(`⚠ 接力失败: ${e instanceof Error ? e.message : e}`, 'error'))
+            .catch((e) => ingestApi.pushSystem(`⚠ 接力失败: ${errorMessage(e)}`, 'error'))
             .finally(() => setHandoffBusy(false))
         }}
         lineage={lineage}

--- a/web/src/pages/DirPicker.tsx
+++ b/web/src/pages/DirPicker.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { fetchDirList, type DirEntry, type SessionInfo } from '../lib/api'
+import { errorMessage, fetchDirList, type DirEntry, type SessionInfo } from '../lib/api'
 
 type NodeState =
   | { status: 'loading' }
@@ -69,7 +69,7 @@ export function DirPicker(props: {
       const r = await fetchDirList(path)
       st = { status: 'loaded', entries: r.entries }
     } catch (e) {
-      st = { status: 'error', message: e instanceof Error ? e.message : String(e) }
+      st = { status: 'error', message: errorMessage(e) }
     }
     setTree((prev) => new Map(prev).set(path, st))
     return st


### PR DESCRIPTION
## 本次任务

对 anyplane 全仓库（`server/`、`web/`、`scripts/` 下全部 TypeScript/TSX）按**复用、简化、效率、altitude（实现深度）**四个维度做质量审查并应用修复。共审查出 14 项 findings，应用 13 项、跳过 1 项（理由见下）。

验证：`bun test` 全绿（470 pass / 0 fail）、`bun run typecheck`（tsc --noEmit）干净、被修改的 e2e 脚本经 `bun build` 语法校验通过。

## 关键改动

### 复用
- **e2e 脚本样板收敛**：5 个 e2e 脚本统一改用 `e2e-lib.ts` 的 `connect()`（WS 握手 + token 鉴权 + 事件分发，顺带获得端口环境变量感知）；`e2e-lib` 的 `spawnAppServer` 行泵改复用 `src/util` 的 `pumpLines`；`e2e-slash` 的内联 `sanitizePath` 改从 `src/util` 导入。
- **web 端 helper 收敛**：模型名解析回退链（直连 → 反向 id 匹配 → 原样）从 4 处复制收口为 `lib/api.ts` 的 `resolveModel`（StatusPill/Composer/DetailDrawer 三处复用，显示口径全站一致）；`e instanceof Error ? e.message : String(e)` 错误归一从 3 处内联收口为 `lib/api.ts` 的 `errorMessage`（DirPicker/push/Chat 复用）。

### 效率
- `readHistory`：解析缓存命中时跳过全文件 `readFileSync`（新增 `peekParseCache`），翻 N 页不再付 N 次全文件读的"读"这一半。
- codex paginated 历史：`turns/list` 与 `items/list` 两组串行分页循环改为 `Promise.all` 并行（同一 RpcClient 多路复用，安全）。
- `/api/sessions`：claude 目录扫描与 codex RPC 列表由串行改并行。

### 简化
- 杀残留进程的 TERM→等待→KILL 流程从 `portTakeover.ts` 与 `scripts/gateway.ts` 两处复制收口为共享的 `terminatePids`（各自的"清场"判定谓词保留差异并有注释；gateway 顺带获得 macOS 支持）。
- `broadcast()` 重复的 payload kind 取值表达式合并为一次。
- `useTranscriptScroll` 的 onScroll 上翻扩窗与顶部哨兵按钮扩窗两处重复块合并为 `expandOrFetchEarlier`，三条滚动红线不变量原样保留。

### Altitude
- sessionKey 字符串拼接的 4 处内联点（handoff ×2、codex/port、archive）统一改走后端 `keyFor`/`keyForNew` 构造器。
- key 形状解析从 `routes/misc.ts`、`push/fanout.ts` 两处手卷（且各自只覆盖部分前缀）收口为 `backends/port.ts` 的零 I/O `describeKey`（覆盖全部 5 种前缀，与构造器一一对应），并新增 `port.test.ts` 锁死该对应关系（6 个用例）。

## 跳过项

- **translate.ts 的 6 个 ThreadItem switch 改描述符表**：跳过。该文件是协议关键路径，六处 switch 消费的是同一 union 的不同投影、且分叉多为有意（如历史侧 commandExecution 显示原始命令、子线程桶有意丢弃系统类 item，均有注释记录）；描述符表需 18 类型 × 6 槽位的矩阵，反而掩盖控制流。现行防护（每个 default 分支 log.warn + schema 基线）已是本仓库选择的漂移防线。若要推进应作为独立任务并跑 codex 真机 e2e 验证。