### PR TITLE
test: 补三个零覆盖核心逻辑模块的单测（hub 广播/审批裁决、web api 共享口径）

### DIFF
--- a/server/src/hub/broadcast.test.ts
+++ b/server/src/hub/broadcast.test.ts
@@ -1,0 +1,126 @@
+// Hub 级广播与 inbox 事件出口（hub/broadcast.ts）：
+// - broadcast：全客户端投递同一 JSON；kind=cli 才入环（重连补发的数据源）；kind=error 同步进 inbox
+// - replayApprovals：待审批只补发给目标连接（attach/socket 单播路径共用）
+// - publishInbox：sink 未注册是装配错误——warn 留痕一次但绝不 throw（error 广播路径会经过这里，
+//   throw 会把普通错误广播变成异常）
+import { describe, expect, test } from 'bun:test'
+import { broadcast, broadcastError, publishInbox, replayApprovals, setInboxSink } from './broadcast'
+import type { Hub, InboxEvent } from './types'
+
+interface FakeWs {
+  sent: string[]
+  fail?: boolean
+  send(text: string): void
+}
+
+function fakeWs(fail = false): FakeWs {
+  return {
+    sent: [],
+    fail,
+    send(text: string) {
+      if (this.fail) throw new Error('connection closed')
+      this.sent.push(text)
+    },
+  }
+}
+
+function makeHub(key = 'n|%2Ftmp%2Fanyplane-test'): Hub {
+  return { key, clients: new Set(), pendingApprovals: new Map() } as unknown as Hub
+}
+
+/** 收集 sink 事件的注册器（publishInbox 的唯一出口） */
+function collectInbox(): InboxEvent[] {
+  const events: InboxEvent[] = []
+  setInboxSink({ publish: (ev) => events.push(ev) })
+  return events
+}
+
+describe('publishInbox：sink 注册语义', () => {
+  // 本用例必须先于任何 setInboxSink 调用执行（sink 是一次性装配，模块级状态无法复位）
+  test('sink 未注册时丢弃事件：warn 留痕一次、不 throw', () => {
+    const warns: unknown[][] = []
+    const origWarn = console.warn
+    console.warn = (...a: unknown[]) => {
+      warns.push(a)
+    }
+    try {
+      publishInbox({ type: 'done', key: 'n|x', ok: true })
+      publishInbox({ type: 'done', key: 'n|x', ok: true })
+    } finally {
+      console.warn = origWarn
+    }
+    expect(warns).toHaveLength(1) // 两次调用只留痕一次（不刷屏）
+    expect(String(warns[0]![0])).toContain('sink 未注册')
+  })
+
+  test('注册后事件原样经 sink.publish 流出', () => {
+    const events = collectInbox()
+    const ev: InboxEvent = { type: 'approval', key: 'n|x', requestId: 'r1', toolName: 'Bash', input: {} }
+    publishInbox(ev)
+    expect(events).toEqual([ev])
+  })
+})
+
+describe('replayApprovals：待审批单播重放', () => {
+  test('逐条补发全部 pending，形状为 approval_request', () => {
+    const hub = makeHub()
+    hub.pendingApprovals.set('r1', { requestId: 'r1', toolName: 'Bash', input: { command: 'ls' } })
+    hub.pendingApprovals.set('r2', { requestId: 'r2', toolName: 'Write', input: {} })
+    const sent: unknown[] = []
+    replayApprovals(hub, (p) => sent.push(p))
+    expect(sent).toEqual([
+      { kind: 'approval_request', requestId: 'r1', toolName: 'Bash', input: { command: 'ls' } },
+      { kind: 'approval_request', requestId: 'r2', toolName: 'Write', input: {} },
+    ])
+  })
+
+  test('无 pending 时零调用', () => {
+    const sent: unknown[] = []
+    replayApprovals(makeHub(), (p) => sent.push(p))
+    expect(sent).toEqual([])
+  })
+})
+
+describe('broadcast：投递与环/收件箱接线', () => {
+  test('向全部客户端投递同一 JSON；单连接 send 抛错不影响其余连接', () => {
+    const hub = makeHub()
+    const dead = fakeWs(true)
+    const alive = fakeWs()
+    hub.clients.add(dead as never)
+    hub.clients.add(alive as never)
+    collectInbox()
+    broadcast(hub, { kind: 'status', state: { busy: true } })
+    expect(alive.sent).toEqual([JSON.stringify({ kind: 'status', state: { busy: true } })])
+  })
+
+  test('kind=cli 分配单调 seq 并入环；其他 kind 不占环、不带 seq', () => {
+    const hub = makeHub()
+    collectInbox()
+    const first = { kind: 'cli', msg: { type: 'user' } }
+    const second = { kind: 'cli', msg: { type: 'assistant' } }
+    broadcast(hub, first)
+    broadcast(hub, { kind: 'status', state: {} })
+    broadcast(hub, second)
+    expect(hub.cliSeq).toBe(2)
+    expect(first).toMatchObject({ seq: 1 })
+    expect(second).toMatchObject({ seq: 2 })
+    expect(hub.cliRing?.map((s) => s.seq)).toEqual([1, 2])
+  })
+
+  test('kind=error 同步发布 inbox error 事件；其他 kind 不进 inbox', () => {
+    const hub = makeHub('s|slug|sid')
+    const events = collectInbox()
+    broadcastError(hub, 'boom')
+    broadcast(hub, { kind: 'status', state: {} })
+    expect(events).toEqual([{ type: 'error', key: 's|slug|sid', message: 'boom' }])
+  })
+
+  test('空客户端集合投递不抛（含 error kind 的 inbox 路径）', () => {
+    const hub = makeHub()
+    const events = collectInbox()
+    broadcast(hub, { kind: 'cli', msg: { type: 'result' } })
+    broadcastError(hub, 'no clients')
+    expect(hub.cliSeq).toBe(1)
+    expect(events).toEqual([{ type: 'error', key: hub.key, message: 'no clients' }])
+  })
+})

--- a/server/src/hub/broadcast.test.ts
+++ b/server/src/hub/broadcast.test.ts
@@ -4,7 +4,7 @@
 // - publishInbox：sink 未注册是装配错误——warn 留痕一次但绝不 throw（error 广播路径会经过这里，
 //   throw 会把普通错误广播变成异常）
 import { describe, expect, test } from 'bun:test'
-import { broadcast, broadcastError, publishInbox, replayApprovals, setInboxSink } from './broadcast'
+import { broadcast, broadcastError, publishInbox, replayApprovals, resetInboxSinkForTest, setInboxSink } from './broadcast'
 import type { Hub, InboxEvent } from './types'
 
 interface FakeWs {
@@ -36,8 +36,10 @@ function collectInbox(): InboxEvent[] {
 }
 
 describe('publishInbox：sink 注册语义', () => {
-  // 本用例必须先于任何 setInboxSink 调用执行（sink 是一次性装配，模块级状态无法复位）
+  // 模块级 sink/warn-once 单态跨测试文件共享（bun test 单进程），用例开头显式复位，
+  // 不依赖文件执行顺序（各平台枚举顺序不同，顺序敏感曾在 ubuntu CI 误红）
   test('sink 未注册时丢弃事件：warn 留痕一次、不 throw', () => {
+    resetInboxSinkForTest()
     const warns: unknown[][] = []
     const origWarn = console.warn
     console.warn = (...a: unknown[]) => {

--- a/server/src/hub/broadcast.ts
+++ b/server/src/hub/broadcast.ts
@@ -19,6 +19,14 @@ export function setInboxSink(s: InboxSink): void {
   inboxSink = s
 }
 
+/** 测试专用复位：bun test 单进程跨文件共享模块实例，sink/warn-once 状态无法靠重 import
+ *  隔离——断言「sink 未注册」行为的用例必须先复位，否则依赖测试文件执行顺序（各平台
+ *  文件枚举顺序不同，ubuntu CI 曾因此误红）。 */
+export function resetInboxSinkForTest(): void {
+  inboxSink = undefined
+  sinkWarned = false
+}
+
 /** hub 各模块的 inbox 事件统一出口。sink 缺失是装配错误：warn 留痕但不 throw
  * （broadcast 的 error 路径会走到这里，throw 会把普通错误广播变成异常）。 */
 export function publishInbox(ev: InboxEvent): void {

--- a/server/src/hub/lifecycle.test.ts
+++ b/server/src/hub/lifecycle.test.ts
@@ -1,0 +1,112 @@
+// 审批裁决共享路径与回滚互斥守卫（hub/lifecycle.ts）：
+// - rewindBusy：回滚进行中拒绝新操作（错误已广播）
+// - resolveApproval：WS approval 消息与推送能力 URL 共用——requestId 出 pending 才裁决，
+//   重复点击/别处已处理返回 false（幂等）；裁决后 approval_resolved 广播 + inbox 留痕 + status 刷新
+// - deliverApproval：会话句柄缺席时决定无处投递——广播明确错误而不静默吞掉
+//
+// 会话存活投递成功（sendApproval）的路径由 e2e-approval.ts 覆盖，这里只测无进程的边界与错误路径。
+// 注意：resolveApproval 内部走真实 pushStatus → claudePort.statusOf；用 n| key（新会话）时
+// 无 pid 扫描、无 transcript 读（splitExistingKey/hydratedContextOf 对 n| 快路径返回）。
+import { afterEach, describe, expect, test } from 'bun:test'
+import { setInboxSink } from './broadcast'
+import { deliverApproval, resolveApproval, rewindBusy } from './lifecycle'
+import { getHub, hubs } from './registry'
+import type { Hub, InboxEvent } from './types'
+
+const KEY = 'n|%2Ftmp%2Fanyplane-lifecycle-test'
+
+const inboxEvents: InboxEvent[] = []
+// 文件加载即注册：本文件的广播路径（broadcastError 等）都会触发 publishInbox，
+// 提前注册避免触发 sink 缺失的 warn-once 路径（该路径由 broadcast.test.ts 专测）
+setInboxSink({ publish: (ev) => inboxEvents.push(ev) })
+
+interface FakeWs {
+  sent: string[]
+  send(text: string): void
+}
+
+function fakeWs(): FakeWs {
+  return { sent: [], send(text: string) { this.sent.push(text) } }
+}
+
+function sentPayloads(ws: FakeWs): Array<Record<string, unknown>> {
+  return ws.sent.map((t) => JSON.parse(t) as Record<string, unknown>)
+}
+
+function freshHub(): { hub: Hub; ws: FakeWs } {
+  hubs.delete(KEY)
+  const hub = getHub(KEY)
+  const ws = fakeWs()
+  hub.clients.add(ws as never)
+  return { hub, ws }
+}
+
+afterEach(() => {
+  hubs.delete(KEY)
+  inboxEvents.length = 0
+})
+
+describe('rewindBusy：回滚互斥守卫', () => {
+  test('无回滚进行时放行（false）且零广播', () => {
+    const { hub, ws } = freshHub()
+    expect(rewindBusy(hub)).toBe(false)
+    expect(ws.sent).toEqual([])
+  })
+
+  test('rewindPending 时拒绝（true）并广播指定错误', () => {
+    const { hub, ws } = freshHub()
+    hub.rewindPending = true
+    expect(rewindBusy(hub, '正在恢复文件，请等待回滚完成后再发送消息')).toBe(true)
+    expect(sentPayloads(ws)).toEqual([
+      { kind: 'error', message: '正在恢复文件，请等待回滚完成后再发送消息' },
+    ])
+    // 默认文案路径
+    expect(rewindBusy(hub)).toBe(true)
+    expect(sentPayloads(ws)[1]).toEqual({ kind: 'error', message: '已有回滚操作正在进行' })
+  })
+})
+
+describe('resolveApproval：裁决幂等与留痕', () => {
+  test('requestId 不在 pending：返回 false，零广播零 inbox（重复点击/别处已处理）', () => {
+    const { hub, ws } = freshHub()
+    expect(resolveApproval(hub, 'r-unknown', { behavior: 'allow' })).toBe(false)
+    expect(ws.sent).toEqual([])
+    expect(inboxEvents).toEqual([])
+  })
+
+  test('pending 中裁决：出 pending、广播 resolved 与 status、inbox 留痕；重复裁决幂等', () => {
+    const { hub, ws } = freshHub()
+    hub.pendingApprovals.set('r1', { requestId: 'r1', toolName: 'Bash', input: { command: 'ls' } })
+    expect(resolveApproval(hub, 'r1', { behavior: 'allow' })).toBe(true)
+    expect(hub.pendingApprovals.size).toBe(0)
+
+    const payloads = sentPayloads(ws)
+    const kinds = payloads.map((p) => p.kind)
+    // 会话未运行（无进程）：先广播投递失败错误，再 resolved，最后 status 刷新
+    expect(kinds).toEqual(['error', 'approval_resolved', 'status'])
+    expect(payloads[0]!.message).toContain('会话未在运行')
+    expect(payloads[1]).toMatchObject({ requestId: 'r1' })
+    // status 反映裁决后状态：pending 已清 → waiting=false
+    expect(payloads[2]!.state).toMatchObject({ waiting: false, spawned: false })
+
+    expect(inboxEvents).toEqual([
+      { type: 'error', key: KEY, message: expect.stringContaining('会话未在运行') },
+      { type: 'approval_resolved', key: KEY, requestId: 'r1' },
+    ])
+
+    // 同一 requestId 再次裁决：已出 pending，幂等返回 false，无新增广播
+    const before = ws.sent.length
+    expect(resolveApproval(hub, 'r1', { behavior: 'deny', message: 'x' })).toBe(false)
+    expect(ws.sent.length).toBe(before)
+  })
+})
+
+describe('deliverApproval：投递半段的错误路径', () => {
+  test('会话句柄缺席时广播明确错误且不 throw（外部门禁 no-op）', () => {
+    const { hub, ws } = freshHub()
+    expect(() => deliverApproval(hub, 'r2', { behavior: 'allow' })).not.toThrow()
+    expect(sentPayloads(ws)).toEqual([
+      { kind: 'error', message: '会话未在运行，审批未能送达（该请求会在上游自行超时）' },
+    ])
+  })
+})

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,183 @@
+// web/src/lib/api.ts 纯逻辑：共享口径的四块——
+// - resolveModel：模型值 → 显示名/tooltip 的三级回退（tier 直查 → 按模型 ID 大小写不敏感反查 →
+//   原样降级），StatusPill/DetailDrawer/Composer 共用同一口径（4d85e26 归并产物）
+// - apiError：非 2xx 应答的错误提取（服务端 {error} 优先，空串/非 JSON 回退 HTTP 状态码）
+// - makeSessionInfo：本地导航会话条目的缺省值
+// - apiFetch/postJson：认证头合并与 401 → AuthRequiredError 语义
+// 网络与存储走 FakeWebSocket 同款 globalThis 替换模式（见 ws.test.ts），不发真实请求。
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  apiError,
+  apiFetch,
+  AuthRequiredError,
+  errorMessage,
+  makeSessionInfo,
+  postJson,
+  resolveModel,
+} from './api'
+import { onAuthRequired } from './auth'
+
+describe('resolveModel：模型显示名三级回退', () => {
+  const names = {
+    haiku: { name: 'Haiku 4.5', id: 'claude-haiku-4-5' },
+    sonnet: { name: 'Sonnet 5', id: 'claude-sonnet-5' },
+    fable: { name: 'Fable', id: 'k3[1m]' },
+  }
+
+  test('tier 直查命中：显示名 + id 进 tooltip（id 与 name 不同时）', () => {
+    expect(resolveModel(names, 'sonnet')).toEqual({ label: 'Sonnet 5', title: 'claude-sonnet-5' })
+  })
+
+  test('直查命中但 id 缺席或 id 与 name 相同：无 tooltip（不显示冗余信息）', () => {
+    expect(resolveModel({ x: { name: 'Only Name' } }, 'x')).toEqual({ label: 'Only Name', title: undefined })
+    expect(resolveModel({ y: { name: 'm', id: 'm' } }, 'y')).toEqual({ label: 'm', title: undefined })
+  })
+
+  test('tier 未命中时按模型 ID 反查（大小写不敏感），原始值进 tooltip', () => {
+    // init 报的是解析后 ID（如 k3[1m]），设置里的 ID 写法大小写可能不同
+    expect(resolveModel(names, 'K3[1M]')).toEqual({ label: 'Fable', title: 'K3[1M]' })
+    expect(resolveModel(names, 'claude-haiku-4-5')).toEqual({ label: 'Haiku 4.5', title: 'claude-haiku-4-5' })
+  })
+
+  test('反查只匹配配置了 id 的档：name 巧合命中不算', () => {
+    expect(resolveModel({ x: { name: 'Only' } }, 'only')).toEqual({ label: 'only', title: undefined })
+  })
+
+  test('直查优先于反查（tier 键与另一档的 id 撞名时）', () => {
+    const clash = { x: { name: 'X 档', id: 'foo' }, y: { name: 'Y 档', id: 'x' } }
+    expect(resolveModel(clash, 'x')).toEqual({ label: 'X 档', title: 'foo' })
+  })
+
+  test('未配置与 modelNames 缺省：原样显示降级', () => {
+    expect(resolveModel(names, 'unknown-model')).toEqual({ label: 'unknown-model', title: undefined })
+    expect(resolveModel(null, 'v')).toEqual({ label: 'v', title: undefined })
+    expect(resolveModel(undefined, 'v')).toEqual({ label: 'v', title: undefined })
+  })
+})
+
+describe('apiError：非 2xx 错误提取', () => {
+  test('服务端 {error} 字段优先', async () => {
+    const r = new Response(JSON.stringify({ error: '会话正在运行，无法归档' }), { status: 409 })
+    expect((await apiError(r)).message).toBe('会话正在运行，无法归档')
+  })
+
+  test('error 为空串视同缺失，回退 HTTP 状态码', async () => {
+    const r = new Response(JSON.stringify({ error: '' }), { status: 500 })
+    expect((await apiError(r)).message).toBe('HTTP 500')
+  })
+
+  test('非 JSON 应答（网关错误页等）回退 HTTP 状态码', async () => {
+    const r = new Response('<html>bad gateway</html>', { status: 502 })
+    expect((await apiError(r)).message).toBe('HTTP 502')
+  })
+})
+
+describe('makeSessionInfo：本地导航条目缺省值', () => {
+  test('只给必填字段时补齐占位状态（随后由 WS status 覆盖）', () => {
+    const s = makeSessionInfo({ key: 'n|x', slug: 'slug', sessionId: 'sid', backend: 'claude' })
+    expect(s.status).toBe('idle')
+    expect(s.sizeBytes).toBe(0)
+    expect(typeof s.mtime).toBe('number')
+    expect(s.managed).toEqual({ spawned: false, busy: false, clients: 0 })
+    expect(s.key).toBe('n|x')
+  })
+
+  test('显式字段覆盖缺省', () => {
+    const s = makeSessionInfo({ key: 'x|th', slug: 'codex', sessionId: 'th', backend: 'codex', status: 'busy', cwd: '/p' })
+    expect(s.status).toBe('busy')
+    expect(s.cwd).toBe('/p')
+  })
+})
+
+describe('errorMessage：unknown 错误单行化', () => {
+  test('Error 取 message；其余 String() 化', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom')
+    expect(errorMessage('plain')).toBe('plain')
+    expect(errorMessage(42)).toBe('42')
+    expect(errorMessage(undefined)).toBe('undefined')
+  })
+})
+
+// ---------- apiFetch/postJson：替换 fetch/location/localStorage 全局 ----------
+
+interface FetchCall {
+  input: unknown
+  init?: RequestInit
+}
+
+let fetchCalls: FetchCall[] = []
+let nextResponse: Response
+let authRequiredCount = 0
+
+const real = {
+  fetch: globalThis.fetch,
+  location: (globalThis as Record<string, unknown>).location,
+  localStorage: (globalThis as Record<string, unknown>).localStorage,
+}
+
+beforeEach(() => {
+  fetchCalls = []
+  authRequiredCount = 0
+  nextResponse = new Response('{}', { status: 200 })
+  const store = new Map<string, string>()
+  ;(globalThis as Record<string, unknown>).location = { search: '' }
+  ;(globalThis as Record<string, unknown>).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  }
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    fetchCalls.push({ input, init })
+    return nextResponse
+  }) as typeof fetch
+})
+
+onAuthRequired(() => {
+  authRequiredCount++
+})
+
+afterEach(() => {
+  globalThis.fetch = real.fetch
+  const g = globalThis as Record<string, unknown>
+  if (real.location === undefined) delete g.location
+  else g.location = real.location
+  if (real.localStorage === undefined) delete g.localStorage
+  else g.localStorage = real.localStorage
+})
+
+describe('apiFetch：认证头与 401 语义', () => {
+  test('无 token 时只带调用方 headers', async () => {
+    const r = await apiFetch('/api/sessions', { headers: { 'x-custom': '1' } })
+    expect(r.status).toBe(200)
+    expect(fetchCalls[0]!.init?.headers).toEqual({ 'x-custom': '1' })
+  })
+
+  test('localStorage 有 token 时自动并上 authorization', async () => {
+    ;(globalThis as { localStorage: Storage }).localStorage.setItem('anyplane-token', 'tok-1')
+    await apiFetch('/api/sessions')
+    expect(fetchCalls[0]!.init?.headers).toEqual({ authorization: 'Bearer tok-1' })
+  })
+
+  test('401 抛 AuthRequiredError 并通知 App 层弹令牌页', async () => {
+    nextResponse = new Response('unauthorized', { status: 401 })
+    await expect(apiFetch('/api/sessions')).rejects.toBeInstanceOf(AuthRequiredError)
+    expect(authRequiredCount).toBe(1)
+  })
+
+  test('其他失败状态不抛（错误检查由调用方按需补）', async () => {
+    nextResponse = new Response('x', { status: 500 })
+    const r = await apiFetch('/api/sessions')
+    expect(r.status).toBe(500)
+    expect(authRequiredCount).toBe(0)
+  })
+})
+
+describe('postJson：method/headers/body 组装', () => {
+  test('统一 POST + JSON content-type + 序列化 body', async () => {
+    await postJson('/api/sessions/archive', { key: 's|a|b' })
+    const init = fetchCalls[0]!.init
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toMatchObject({ 'content-type': 'application/json' })
+    expect(init?.body).toBe(JSON.stringify({ key: 's|a|b' }))
+  })
+})


### PR DESCRIPTION
## 概述

分析 server/src 与 web/src 的测试分布后，选出 3 个此前完全没有测试、且属于核心纯逻辑（非真实 CLI 链路）的模块补 `*.test.ts`。真实 CLI 链路（spawn/审批投递成功路径等）已由 e2e 脚本覆盖，本 PR 不重复造。

## 模块与覆盖行为

### 1. `server/src/hub/broadcast.test.ts`（hub 广播与 inbox 出口，8 例）
- `publishInbox` sink 注册语义：未注册时丢弃事件、只 warn 一次且绝不 throw（broadcast 的 error 路径会经过这里，throw 会把普通错误广播变成异常）；注册后事件原样流出
- `replayApprovals`：待审批逐条单播重放（approval_request 形状），空 pending 零调用
- `broadcast`：全客户端投递同一 JSON；单连接 send 抛错（连接已关竞态）不影响其余连接
- kind=cli 才分配单调 seq 入环（重连补发数据源）；其他 kind 不占环
- kind=error 同步发布 inbox error 事件；空客户端集合投递不抛

### 2. `server/src/hub/lifecycle.test.ts`（审批裁决共享路径与回滚互斥，5 例）
- `rewindBusy`：无回滚放行且零广播；rewindPending 时拒绝并广播指定/默认错误文案
- `resolveApproval`：requestId 不在 pending 返回 false（重复点击/别处已处理幂等），零广播零 inbox；pending 中裁决 → 出 pending、广播 approval_resolved + status（waiting=false）、inbox 留痕；同一 requestId 二次裁决幂等
- `deliverApproval`：会话句柄缺席时广播「会话未在运行」明确错误而不静默吞掉，且不 throw
- 用 n| key 走真实 pushStatus → claudePort.statusOf（无 pid 扫描、无 transcript 读）；会话存活投递成功路径由 e2e-approval.ts 覆盖

### 3. `web/src/lib/api.test.ts`（web 端 api 共享口径，17 例）
- `resolveModel` 三级回退：tier 直查（id≠name 才出 tooltip）→ 按模型 ID 大小写不敏感反查（原始值进 tooltip）→ 未配置原样降级；直查优先于反查；modelNames 为 null/undefined 降级
- `apiError`：服务端 `{error}` 优先，空串视同缺失、非 JSON 应答回退 HTTP 状态码
- `makeSessionInfo`：本地导航条目缺省值与显式覆盖
- `apiFetch`/`postJson`：token 存在时自动并 authorization 头、401 抛 AuthRequiredError 并通知 App 层、其他失败状态不抛；POST JSON 组装（globalThis 替换模式仿 ws.test.ts，无真实请求）

## 测试总数

470 → **500**（+30 例，3 个新文件），`bun test` 全绿。每个模块单独 commit。