### PR TITLE
test: 清理同义反复测试——replay-fixture 的 init 恒真断言重写为宽松透传行为断言

### DIFF
--- a/scripts/replay-fixture.test.ts
+++ b/scripts/replay-fixture.test.ts
@@ -17,6 +17,7 @@ function replay(fixturePath: string) {
     assistant: 0,
     result: 0,
     errors: 0,
+    lines: 0,
   }
   const session = new ClaudeSession(
     'replay|fixture',
@@ -35,6 +36,7 @@ function replay(fixturePath: string) {
   for (const raw of readFileSync(fixturePath, 'utf8').split('\n')) {
     const line = raw.trim()
     if (!line) continue
+    seen.lines++
     try {
       session.injectLine(line)
     } catch {
@@ -51,10 +53,13 @@ describe('replay: claude-turn-basic', () => {
     expect(seen.errors).toBe(0)
   })
 
-  test('init 消息被消费（不进入普通消息流）', () => {
-    // fixture 含 1 条 system/init；ClaudeSession 不应把它当普通消息转发
-    const initForwarded = seen.messages > 0 && seen.assistant === 0 && seen.result === 0
-    expect(initForwarded).toBe(false)
+  test('宽松透传：fixture 全部行（含 init/thinking_tokens）都进入消息流', () => {
+    // session 层只做副作用提取（init 的 model/sessionId、usage 累计），不做抄本过滤——
+    // isMeta/sidechain/system-reminder 的过滤在 Hub 与前端 ingest 层。
+    // 仅两类不转发：被 sendControlAndWait 消费的应答、can_use_tool 审批请求（fixture 均无）。
+    // 原断言（messages>0 && assistant===0 && result===0 → false）恒真：
+    // fixture 必有 assistant/result，与 init 是否被转发无关，且与真实行为（全转发）相反。
+    expect(seen.messages).toBe(seen.lines)
   })
 
   test('assistant 消息到达', () => {


### PR DESCRIPTION
## 审计范围

全量通读 server/、scripts/、web/ 下 46 个 `*.test.ts`（6675 行，500 个测试），逐条对照被测源码判定。基线与最终均为 `bun test` 500 pass / 0 fail。

## 处理清单

### 重写（1 个）

**`scripts/replay-fixture.test.ts` › `init 消息被消费（不进入普通消息流）`** → **`宽松透传：fixture 全部行（含 init/thinking_tokens）都进入消息流`**

- **同义反复**：原断言 `messages > 0 && assistant === 0 && result === 0 → false` 中，fixture 固定含 2 条 assistant + 1 条 result 且正常实现必然转发，`assistant===0` 恒假使合取式恒假——**即使 session 把 init 误转发给 onMessage，该测试也照样通过**，防不住它声称要防的任何回归。
- **名实相反**：核实 `handleLine` 实现后确认，session 层对 init 只做副作用提取（sessionId/model/窗口习得），随后仍落到 `onMessage`——宽松透传是既定契约（抄本过滤在 Hub 与前端 ingest 层）。原测试名声称的行为与实现恰好相反，恒真断言掩盖了这一点。
- **重写内容**：断言真实契约——fixture 全部非空行都进入消息流（`messages === 行数`，行数动态计数不写魔术数），注释注明仅有的两类不转发消息（被 `sendControlAndWait` 消费的应答、`can_use_tool` 审批请求）。
- **变异验证**：临时让 `handleLine` 的 init 分支 `return` 不透传，新断言如期变红；还原源码后全绿。被测源码无任何改动。

### 删除

无。

## 保留待人工判断（按保守原则一律未动）

| 文件 | 边界点 | 保留理由 |
| --- | --- | --- |
| `web/src/components/PopupPanel.test.ts` | 断言表达式（`vp.height - ring.bottom`）与实现公式同形，有重述实现的味道 | 断言非恒过（实现写错会失败），且含几何语义（右下角重合）；等价重构（改 top 定位）会碎，但定位字段集合本身就是 CSS 契约 |
| `web/src/lib/transcriptWindow.test.ts` | 断言用被测模块常量参数化（`n - WINDOW_TAIL_ROWS`），常量改动自动跟随 | 锁的是行为随常量联动而非具体数值；窗口起点=行数-尾窗行数即对外行为 |
| `web/src/lib/reconnectingSocket.test.ts` | 钉死退避序列 `[1s,2s,4s,8s,15s,15s]` 具体数值 | 退避策略是用户可观察行为，文件头明确声明要锁定；改策略时测试碎裂是有意义的提醒 |
| `server/src/handoff.test.ts` | `briefPrompt`/`seedMessage` 断言 prompt 文案关键词（300字以内 等） | 措辞改动会碎，但字数上限与简报要素是接力质量的契约性前提（源会话看不到对话外上下文） |
| `server/src/log.test.ts` | 钉死日志行格式字符串 | `ANYPLANE_LOG_FORMAT=json` 与文本格式是日志聚合的机器解析契约 |
| `server/src/backends/codex/translate.test.ts` › live/历史同形 | 断言较浅（只验 `type: assistant/user`） | 能抓到 live 侧漏 dispatch 新 ThreadItem（返回 `[]` 即失败）；可考虑加深但非假测试 |
| `web/src/lib/slashIntercept.test.ts` › 表序即优先级 | 注释自称钉住逐字保序的意图 | 断言的仍是外部可观察的拦截结果（`/btw /branch` → btw 带参），非内部数据结构 |

## 其余 45 个文件

均为行为级测试：协议形状契约（translate/端口/key 编码）、安全防线（auth CSWSH/DNS rebinding、uploads 路径闸、push endpoint 白名单、approvalRules 链式命令封堵）、状态机（回收守卫、重连、乱序配对性质测试）、真实子进程/fixture 驱动（rpc/config/handoff/replay）。FakeWebSocket/captureFetch 等替身均用于驱动生产代码，无只测 mock 自身的情况；web/server 同名工具（`errorMessage`、key 解析）是不同实现，不构成重复覆盖。
