### PR TITLE
fix: e2e 脚本 REST 调用统一带 ANYPLANE_TOKEN（apiFetch 收口）

### DIFF
--- a/server/scripts/e2e-codex-paginated.ts
+++ b/server/scripts/e2e-codex-paginated.ts
@@ -15,7 +15,7 @@
 // 用法：bun run server/scripts/e2e-codex-paginated.ts [cwd] [legacyThreadId]
 
 import { mkdtempSync } from 'node:fs'
-import { connect, exitWithSummary, makeNote } from './e2e-lib'
+import { apiFetch, connect, exitWithSummary, makeNote } from './e2e-lib'
 
 // 默认每次跑独立目录：xn|<cwd> 是会话 key，跨次复用会撞上服务端残留 Hub/旧线程
 //（实测：同 key 二跑时事件静默不进，turn 悬挂——根因未深挖，用唯一 key 规避整类污染）
@@ -23,9 +23,8 @@ const cwd = process.argv[2] ?? mkdtempSync('/tmp/d4-e2e-')
 const legacyTid = process.argv[3] // 可选：用一个真实 legacy 线程验证 D 组
 const { note, results } = makeNote()
 
-const tokenQ = process.env.ANYPLANE_TOKEN ? `?token=${process.env.ANYPLANE_TOKEN}` : ''
 async function fetchCodexHistory(threadId: string): Promise<Array<{ uuid: string; role: string; rewindable?: boolean; blocks: Array<{ kind: string }> }>> {
-  const res = await fetch(`http://localhost:7480/api/codex/history/${threadId}${tokenQ}`)
+  const res = await apiFetch(`/api/codex/history/${threadId}`)
   if (!res.ok) throw new Error(`history HTTP ${res.status}`)
   return ((await res.json()) as { messages: never[] }).messages
 }

--- a/server/scripts/e2e-handoff.ts
+++ b/server/scripts/e2e-handoff.ts
@@ -2,10 +2,7 @@
 // 双向：claude → codex、codex → claude。需服务端已启动（默认 :7480，ANYPLANE_PORT 覆盖）。
 // 用法：bun run server/scripts/e2e-handoff.ts <claudeSessionKey> <codexThreadKey>（均为要操作的源会话 key）
 
-import { connect } from './e2e-lib'
-
-const PORT = process.env.ANYPLANE_PORT ?? '7480'
-const BASE = `http://localhost:${PORT}`
+import { apiFetch, connect } from './e2e-lib'
 
 const CLAUDE_KEY = process.argv[2] ?? ''
 const CODEX_KEY = process.argv[3] ?? ''
@@ -42,7 +39,7 @@ function handoff(fromKey: string, toBackend: 'claude' | 'codex', label: string):
     })
     await open()
     send({ kind: 'attach' })
-    const r = await fetch(`${BASE}/api/handoff`, {
+    const r = await apiFetch('/api/handoff', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ fromKey, toBackend, detail: 'standard' }),
@@ -71,7 +68,7 @@ async function waitTargetFirstTurn(targetKey: string, targetSessionId: string | 
   const deadline = Date.now() + 300_000
   while (Date.now() < deadline) {
     try {
-      const r = await fetch(`${BASE}/api/codex/history/${targetSessionId}`)
+      const r = await apiFetch(`/api/codex/history/${targetSessionId}`)
       const data = (await r.json()) as { messages?: Array<{ role: string; blocks: Array<{ kind: string; text?: string }> }> }
       const assistant = (data.messages ?? []).filter((m) => m.role === 'assistant')
       const text = assistant.flatMap((m) => m.blocks.map((b) => b.text ?? '')).join('\n')
@@ -121,7 +118,7 @@ const PROJECT_KEYWORDS = /notebox|搜索|export|简报/i
 
 // 血缘验证
 {
-  const r = await fetch(`${BASE}/api/lineage?key=${encodeURIComponent(CLAUDE_KEY)}`)
+  const r = await apiFetch(`/api/lineage?key=${encodeURIComponent(CLAUDE_KEY)}`)
   const { records } = (await r.json()) as { records: Array<{ fromKey: string; toKey: string }> }
   console.log(`血缘记录（claude 源）: ${records.length} 条`)
   if (records.length === 0) pass = false

--- a/server/scripts/e2e-lib.ts
+++ b/server/scripts/e2e-lib.ts
@@ -20,6 +20,18 @@ export function exitWithSummary(results: string[]): never {
   process.exit(results.some((r) => r.startsWith('✗')) ? 1 : 0)
 }
 
+/** REST 封装：ANYPLANE_TOKEN 走 Authorization 头（服务端配置 authToken 时裸 fetch 一律 401——
+ *  connect() 的 WS 侧早已带 token，REST 侧曾各自拼 ?token= 或漏带；token 放 header 而非
+ *  query，避免进服务端访问日志）。端口随 ANYPLANE_PORT（默认 7480）。 */
+export function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  const port = process.env.ANYPLANE_PORT ?? '7480'
+  const token = process.env.ANYPLANE_TOKEN
+  return fetch(`http://localhost:${port}${path}`, {
+    ...init,
+    headers: { ...(token ? { authorization: `Bearer ${token}` } : {}), ...init?.headers },
+  })
+}
+
 /** WS 连接封装：handlers 数组 + send + open Promise。
  *  服务端配置 authToken 时需要 ANYPLANE_TOKEN 环境变量（否则握手 401）。
  *  端口随 ANYPLANE_PORT（默认 7480），与 e2e-handoff 的 REST BASE 口径一致。 */

--- a/server/scripts/e2e-rewind.ts
+++ b/server/scripts/e2e-rewind.ts
@@ -2,7 +2,7 @@
 // 三条都打到同一个目标消息（幂等：空恢复快照 + 同一截断点），最后发问验证会话可用。
 // 用法：bun run server/scripts/e2e-rewind.ts [cwd] [sessionId]
 import { sanitizePath } from '../src/util'
-import { connect } from './e2e-lib'
+import { apiFetch, connect } from './e2e-lib'
 
 const cwd = process.argv[2] ?? process.cwd()
 const slug = sanitizePath(cwd)
@@ -11,7 +11,12 @@ const key = `s|${slug}|${sessionId}`
 
 // 从 REST 拿一条用户消息 uuid。取最后一条带文本的用户消息：
 // 最早的消息通常早于文件检查点（无快照可恢复），最近的消息最可能有 checkpoint。
-const hist = await (await fetch(`http://localhost:7480/api/history/${slug}/${sessionId}`)).json()
+const histResp = await apiFetch(`/api/history/${slug}/${sessionId}`)
+if (!histResp.ok) {
+  console.error(`拉取历史失败（HTTP ${histResp.status}）——服务端配置了 authToken 时需 ANYPLANE_TOKEN 环境变量`)
+  process.exit(1)
+}
+const hist = await histResp.json()
 // 端点返回 { messages, fileBytes, subagents }（历史响应带子代理水合字段后不再是裸数组）
 const candidates = (hist.messages ?? []).filter(
   (m) =>
@@ -100,6 +105,13 @@ on((ev) => {
       return
     }
     fail(`意外的 rewound: phase=${phase} scope=${String(ev.scope)}`)
+    return
+  }
+  if (ev.kind === 'approval_request') {
+    // 回滚目标若是需审批的消息（如写文件），resume-session-at 重生后 CLI 会重放该 turn
+    // 并把审批路由回 stdio——不裁决会卡在 requires_action 直到超时。e2e 环境一律放行。
+    console.log(`<< approval_request（${String(ev.toolName)}）自动允许`)
+    send({ kind: 'approval', requestId: ev.requestId, decision: { behavior: 'allow' } })
     return
   }
   if (ev.kind === 'error') {


### PR DESCRIPTION
## 问题

维护周期收尾跑 e2e 回归时逮出的存量缺口：`e2e-lib.connect()` 的 WS 侧早已处理 ANYPLANE_TOKEN，但 REST 侧没有统一处理：

- `e2e-rewind.ts` / `e2e-handoff.ts`：四处裸 `fetch` 完全没带 token。服务端配置 authToken 时返回 401，`hist.messages` 为 undefined 被当成『没有可回滚的用户消息』吞掉——假阴性，看起来像数据问题而非认证问题。
- `e2e-codex-paginated.ts`：自拼 `?token=` query（能工作，但 token 进 URL 会落到访问日志）。

## 修复

- `e2e-lib.ts` 新增 `apiFetch(path, init?)`：端口随 `ANYPLANE_PORT`（与 connect 口径一致），token 走 `Authorization: Bearer` 头（不进 URL/日志）。三个脚本的五处 REST 调用全部收口。
- `e2e-rewind.ts` 顺带补两处健壮性：
  - 历史拉取非 2xx 时明确报错并提示 ANYPLANE_TOKEN（不再静默当成『无消息』）；
  - 补审批自动裁决——回滚目标为需审批的消息（如写文件）时，`--resume-session-at` 重生会重放该 turn 并把审批路由回 stdio，不裁决必卡 `requires_action` 到 180s 超时（本次实测逮出，非 #22 回归：手动裁决后 turn 正常 result）。

## 验证

- `bun test` 500 pass；`tsc --noEmit` 干净；三脚本 `bun build` 通过
- 真实链路（配置了 authToken + kimi-for-coding 网关的本机环境）：
  - `e2e-rewind.ts`：rewind_files / rewind_conversation / rewind_both 三路径 + 回滚后问答 **全绿**
  - `e2e-codex-paginated.ts`：**9/9 全绿**（分页历史 / 原地 revert / 回滚后续聊）