### PR TITLE
fix: 体验批修——上下文环清零、hash 路由、codex 耗时、tail 模型回填等

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -254,6 +254,26 @@ replay_gap 重载按「已加载数+500」保载拉取（append-only 下零漂�
 1. **轻量自托管 Relay 脚本**：提供用户可在自己的便宜 VPS 上一键运行的极轻量反向打洞中继（仅做 TCP / WebSocket 的公网 rendezvous 与帧中转，不做业务解析）。
 2. **端到端加密（E2EE）**：AnyPlane 服务端与浏览器客户端直接协商一次性会话密钥（如 X25519 + ChaCha20-Poly1305），中继 VPS 仅转发密文，无法窥视命令与代码内容，彻底保住本地主权与隐私防线。
 
+## 方向九：Codex 会话 AI 标题
+
+**问题**：Codex 线程无标题时侧栏只显示线程 id 前缀（如 `01a090c2`），多开无法区分；
+Claude 侧有 `generate_session_title` 自动标题（2026-08-27 已接入），体验不对等。
+`/rename` 手动可救（走官方 `thread/name/set`），但无人记得改。
+
+**上游调查结论（2026-09-11，codex 最新源码快照 + 0.149.0 实测）**：app-server 协议
+**只有手动命名**（`thread/name/set` + `thread/name/updated` 通知），没有任何自动标题生成机制；
+云端 tasks API 的 `has_generated_title` 是云任务特性，不在本地协议面。
+上游若补齐自动命名，`thread/name/updated` 通知会让列表自动接住——届时本方向直接作废。
+
+**可行路径（未做）**：复用 handoff 的 ephemeral fork 问答（`runEphemeralQuestion`，
+只读沙箱 + 无审批，不动现场）——首个 turn 完成后让它用一两句话概括会话目标，
+再 `thread/name/set` 写回。触发条件对齐 Claude 侧（首条真实 user 消息 × 首个 turn 完成，
+按 threadId 去重；AnyPlane 侧不落状态，thread name 即唯一状态源）。
+
+**暂不做的原因**：标题质量依赖一次额外问答（每新线程几百 token 成本），且 fork 问答
+在 turn 刚结束时与主线程共享进程管道、可能撞上用户的连续输入；先观察上游是否补齐。
+若做，必须复用现有 collector 超时/拒绝路径，不为标题引入新状态机。
+
 ## 已验证但暂不做的（决策记录）
 
 - **~~daemon socket 深度集成~~（保留结论）+ ~~`claude agents --json --all` 状态增强~~** ✅ 已接入（2026-08-27）：

--- a/server/src/backends/claude/port.test.ts
+++ b/server/src/backends/claude/port.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { claudePort } from './port'
+import { rememberSessionModel, setStoreFileForTest } from './sessionModels'
+
+// statusOf 的 model 字段三级回退：spawnOpts.model（用户显式选择）→ initModel（live 权威）
+// → sessionModels 持久化表（离线/tail 回填）。本文件只锁第三级与前两级缺席时的行为——
+// 前两级的优先级由编排结构保证（?? 链），live 会话另有 processManager 测试覆盖。
+describe('claudePort.statusOf model 离线回填', () => {
+  // sessionModels 是 ~/.anyplane 下的真实文件：重定向到临时目录，避免污染与跨测试文件串扰
+  const modelsTmp = join(mkdtempSync(join(tmpdir(), 'anyplane-port-models-')), 'session-models.json')
+  beforeEach(() => setStoreFileForTest(modelsTmp))
+  afterEach(() => setStoreFileForTest(undefined))
+
+  const cx = { hub: undefined, liveHint: null, hydrateContext: false } as const
+
+  test('离线 s| 会话：表中有模型则回填（tail/外部会话不再显示 … 占位）', () => {
+    rememberSessionModel('sess-offline', 'k3[1m]')
+    const st = claudePort.statusOf('s|-tmp-proj|sess-offline', cx)
+    expect(st.model).toBe('k3[1m]')
+  })
+
+  test('离线 s| 会话：表中无模型则 undefined（从未 live 见过的会话不编造）', () => {
+    const st = claudePort.statusOf('s|-tmp-proj|sess-never-seen', cx)
+    expect(st.model).toBeUndefined()
+  })
+
+  test('n| 新会话 key 无表可查，model undefined', () => {
+    const st = claudePort.statusOf('n|%2Ftmp%2Fproj', cx)
+    expect(st.model).toBeUndefined()
+  })
+
+  test('畸形 s| key（非法字符段）不炸，model undefined', () => {
+    const st = claudePort.statusOf('s|bad slug|sess', cx)
+    expect(st.model).toBeUndefined()
+  })
+})

--- a/server/src/backends/claude/port.ts
+++ b/server/src/backends/claude/port.ts
@@ -23,7 +23,14 @@ import type { SpawnOptions } from '../types'
 import { hydratedContextOf, keyForBranch, parseKey, splitExistingKey, type ParsedKey } from './backend'
 import { liveSessionInfo } from './discovery'
 import { processManager, type ClaudeSession } from './processManager'
+import { sessionModelOf } from './sessionModels'
 import { TranscriptTailer } from './tailer'
+
+/** 离线/tail 会话的模型回填：s| key 的 sessionId → init 持久化表；其余 key 形状（n|/b|）无表可查 */
+function offlineModelOf(key: string): string | undefined {
+  const ek = splitExistingKey(key)
+  return ek ? sessionModelOf(ek.sessionId) : undefined
+}
 
 class ClaudePort implements BackendPort {
   readonly name = 'claude' as const
@@ -62,8 +69,10 @@ class ClaudePort implements BackendPort {
       activeTasks: s?.backgroundTasks ?? [],
       slashCommands: s?.slashCommands,
       // spawnOpts.model 是用户显式选择（未 spawn 时的待应用值）；initModel 是进程 init 报告的解析后 ID。
-      // 后者让重连 attach 的页面不必等下一轮就能显示模型（StatusPill 再经 modelNames 映射成配置名）
-      model: hub?.spawnOpts?.model ?? s?.initModel,
+      // 后者让重连 attach 的页面不必等下一轮就能显示模型（StatusPill 再经 modelNames 映射成配置名）。
+      // 都缺席（离线/tail 外部会话）时回退 init 持久化的 sessionId→model 表——与 hydratedContextOf
+      // 的窗口推断同源，避免 StatusPill 退化成 "…" 占位
+      model: hub?.spawnOpts?.model ?? s?.initModel ?? offlineModelOf(key),
       tailing: !!hub?.tailer,
       liveStatus: live?.status,
       goal: hub?.goal ?? null,

--- a/server/src/backends/claude/processManager.test.ts
+++ b/server/src/backends/claude/processManager.test.ts
@@ -305,6 +305,36 @@ describe('ClaudeSession contextUsage（官方 statusline current_usage 的 headl
     expect(session.contextUsage).toBeUndefined()
   })
 
+  test('全零 usage（本地斜杠命令回合）不清空已有占用', () => {
+    const { session, handleLine } = makeSession()
+    handleLine(JSON.stringify({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: { id: 'msg-1', role: 'assistant', content: [], usage },
+    }))
+    const before = session.contextUsage
+    expect(before?.usedTokens).toBe(1500)
+    // /model 等不过 API 的本地命令会发 usage 全零的 assistant 流事件（不落 transcript）；
+    // 收下会把环形 UI 清零直到下一真实回合——全零视为无信息，保持上一真实值
+    const zero = { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 }
+    handleLine(JSON.stringify({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: { id: 'msg-local', role: 'assistant', content: [], usage: zero },
+    }))
+    expect(session.contextUsage).toEqual(before)
+  })
+
+  test('首个 usage 即全零时保持 undefined（不误水合成 0/窗口）', () => {
+    const { session, handleLine } = makeSession()
+    handleLine(JSON.stringify({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      message: { id: 'msg-local', role: 'assistant', content: [], usage: {} },
+    }))
+    expect(session.contextUsage).toBeUndefined()
+  })
+
   test('相同 usage 按值去重不重复广播；init 的 [1m] 模型驱动 windowSize', () => {
     const { session, handleLine, pushes } = makeSession()
     handleLine(JSON.stringify({ type: 'system', subtype: 'init', session_id: 's-1', model: 'k3[1m]' }))

--- a/server/src/backends/claude/processManager.ts
+++ b/server/src/backends/claude/processManager.ts
@@ -248,6 +248,10 @@ export class ClaudeSession {
   private noteContextUsage(u: unknown): void {
     const next = coerceCallUsage(u)
     if (!next) return
+    // 全零 usage 不算命中：本地斜杠命令（/model 等不过 API 的回合）会发 usage 全零的
+    // assistant 流事件（不落 transcript），收下会把环形 UI 清零直到下一真实回合。
+    // 真实 API 应答 input+cache 恒 > 0，守卫与离线回扫（extractUsageFromTranscriptTail）同口径
+    if (next.inputTokens + next.outputTokens + next.cacheReadTokens + next.cacheWriteTokens === 0) return
     const prev = this.lastCallUsage
     if (
       prev &&

--- a/server/src/backends/codex/translate.test.ts
+++ b/server/src/backends/codex/translate.test.ts
@@ -211,6 +211,22 @@ describe('mapThreadStatus / turnCompletedMsg', () => {
     const badNoMsg = turnCompletedMsg('thread-1', { status: 'failed' })
     expect(badNoMsg).toMatchObject({ result: 'turn failed' })
   })
+
+  test('turn/completed 耗时映射：durationMs 优先，snake_case 防御，startedAt/completedAt 兜底', () => {
+    // wire 正本（ts-rs Turn.durationMs，0.149.0 实测已下发）
+    expect(turnCompletedMsg('t', { status: 'completed', durationMs: 7047 }).duration_ms).toBe(7047)
+    // snake_case 防御（rollout 序列化是 snake，wire 漂移时仍有值）
+    expect(turnCompletedMsg('t', { status: 'completed', duration_ms: 3000 }).duration_ms).toBe(3000)
+    // durationMs 缺席时按秒级时间戳差值兜底
+    expect(turnCompletedMsg('t', { status: 'completed', startedAt: 100, completedAt: 107 }).duration_ms).toBe(7000)
+    // durationMs 优先于时间戳差值
+    expect(
+      turnCompletedMsg('t', { status: 'completed', durationMs: 500, startedAt: 100, completedAt: 107 }).duration_ms,
+    ).toBe(500)
+    // 全部缺席 → 不带字段（页脚只显示 tok，不显示伪 0s）
+    expect(turnCompletedMsg('t', { status: 'completed' }).duration_ms).toBeUndefined()
+    expect(turnCompletedMsg('t', { status: 'completed', durationMs: null }).duration_ms).toBeUndefined()
+  })
 })
 
 describe('itemsToHistory', () => {

--- a/server/src/backends/codex/translate.ts
+++ b/server/src/backends/codex/translate.ts
@@ -548,6 +548,14 @@ export function mapThreadStatus(status: { type?: string } | undefined): 'idle' |
 export function turnCompletedMsg(threadId: string, turn: Params, lastUsage?: Record<string, number>): CliMessage {
   const failed = turn.status === 'failed'
   const err = turn.error as { message?: string } | null | undefined
+  // 回合耗时：协议正本 Turn.durationMs（0.149.0 实测已下发，见 rollout task_complete.duration_ms）。
+  // 兜底链：snake_case 防御 → startedAt/completedAt（秒）差值；都没有则缺省（页脚只显示 tok）
+  const started = numOr(turn.startedAt)
+  const completed = numOr(turn.completedAt)
+  const durMs =
+    numOr(turn.durationMs) ??
+    numOr(turn.duration_ms) ??
+    (started != null && completed != null ? (completed - started) * 1000 : undefined)
   return {
     type: 'result',
     subtype: failed ? 'error' : 'success',
@@ -556,7 +564,12 @@ export function turnCompletedMsg(threadId: string, turn: Params, lastUsage?: Rec
     session_id: threadId,
     total_cost_usd: 0,
     usage: lastUsage?.outputTokens != null ? { output_tokens: lastUsage.outputTokens } : {},
+    ...(durMs != null && durMs >= 0 ? { duration_ms: Math.round(durMs) } : {}),
   }
+}
+
+function numOr(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined
 }
 
 // ---------- 历史（thread.turns）→ HistoryMessage ----------

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
 import { SessionList } from './pages/SessionList'
 import { Chat } from './pages/Chat'
 import { AnyPlaneMark } from './components/AnyPlaneMark'
@@ -12,6 +12,12 @@ import { sessionFromKey } from './lib/key'
 function deepLinkKey(): string | null {
   const m = location.hash.match(/^#s=(.+)$/)
   return m ? decodeURIComponent(m[1]) : null
+}
+
+/** 选中态写入 URL（#s=<key>，与 sw.js 深链同编码）；undefined 清回无 hash 路径 */
+function writeHash(key: string | undefined, replace: boolean): void {
+  const url = key ? `#s=${encodeURIComponent(key)}` : location.pathname + location.search
+  history[replace ? 'replaceState' : 'pushState'](null, '', url)
 }
 
 const SIDEBAR_KEY = 'anyplane-sidebar-width'
@@ -36,7 +42,43 @@ export default function App() {
 
   useEffect(() => onAuthRequired(() => setAuthNeeded(true)), [])
 
-  // 深链引导：启动时读 #s=<key>（推送通知点击直达），选中后清掉 hash
+  // hash 路由：选中态镜像到 #s=<key>，刷新/分享链接直达当前会话（原深链消费即弃，
+  // 刷新就回列表）。selected 是唯一状态源，hash 是它的持久化投影 + 后退/前进入口。
+  // 用户主动选择 pushState（后退 = 回列表）；会话内导航（/clear 重键、fork、handoff）
+  // replaceState——旧 key 已死，不该留在历史里复活。
+  const selectSession = (s: SessionInfo | undefined, opts?: { replace?: boolean }) => {
+    setSelected(s)
+    writeHash(s?.key, opts?.replace ?? false)
+  }
+
+  // 后退/前进：hashchange 只由浏览器导航（或直接改 location.hash）触发，
+  // pushState/replaceState 不触发——不会与 selectSession 循环
+  const selectedRef = useRef(selected)
+  selectedRef.current = selected
+  useEffect(() => {
+    const onHash = () => {
+      const key = deepLinkKey()
+      if (!key) {
+        setSelected(undefined)
+        return
+      }
+      if (selectedRef.current?.key === key) return // 已在目标会话（selectSession 后的历史项回退）
+      // 列表里找全量信息；找不到按 key 构造最小 SessionInfo（s|/x|/b| 可纯 key 构造，
+      // 归档会话/深链直达靠它）；n|/xn| 新会话不可构造——清掉无效 hash 回列表
+      fetchSessions()
+        .then((list) => {
+          if (deepLinkKey() !== key) return // fetch 期间用户又导航了，以最新 hash 为准
+          const target = list.find((s) => s.key === key) ?? sessionFromKey(key)
+          if (target) setSelected(target)
+          else history.replaceState(null, '', location.pathname + location.search)
+        })
+        .catch(() => {})
+    }
+    window.addEventListener('hashchange', onHash)
+    return () => window.removeEventListener('hashchange', onHash)
+  }, [])
+
+  // 深链引导：启动时读 #s=<key>（推送通知点击直达 / 刷新恢复），选中后 hash 保留
   useEffect(() => {
     const key = deepLinkKey()
     if (!key) return
@@ -46,7 +88,9 @@ export default function App() {
         const target = found ?? sessionFromKey(key)
         if (target) {
           setSelected(target)
-          history.replaceState(null, '', location.pathname)
+        } else {
+          // n|/xn| 新会话或已删除的 key：不可恢复，清掉无效 hash
+          history.replaceState(null, '', location.pathname + location.search)
         }
       })
       .catch(() => {})
@@ -122,7 +166,7 @@ export default function App() {
       {import.meta.env.DEV && <ModeBadge />}
       {/* 移动端：选中后隐藏列表；桌面端：双栏常显，右缘可拖宽 */}
       <div className={`relative h-full bg-surface/40 ${selected ? 'hidden md:block' : 'block'}`}>
-        <SessionList selectedKey={selected?.key} onSelect={setSelected} />
+        <SessionList selectedKey={selected?.key} onSelect={(s) => selectSession(s)} />
         <div
           role="separator"
           aria-orientation="vertical"
@@ -143,7 +187,11 @@ export default function App() {
       </div>
       <div className={`h-full min-w-0 ${selected ? 'block' : 'hidden md:block'}`}>
         {selected ? (
-          <Chat session={selected} onBack={() => setSelected(undefined)} onNavigate={setSelected} />
+          <Chat
+            session={selected}
+            onBack={() => selectSession(undefined)}
+            onNavigate={(s) => selectSession(s, { replace: true })}
+          />
         ) : (
           <div className="hidden h-full flex-col items-center justify-center gap-3 text-faint md:flex">
             <AnyPlaneMark className="h-10 w-10 text-ink/80 opacity-25" />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,17 +7,31 @@ import { ModeBadge } from './components/ModeBadge'
 import { getToken, onAuthRequired, setToken } from './lib/auth'
 import { fetchSessions, type SessionInfo } from './lib/api'
 import { sessionFromKey } from './lib/key'
+import { parseDeepLinkHash, sessionHashUrl, shouldWriteHash } from './lib/sessionHash'
 
-/** 推送通知深链：`/#s=<sessionKey>` 直达会话（SW notificationclick 写入） */
 function deepLinkKey(): string | null {
-  const m = location.hash.match(/^#s=(.+)$/)
-  return m ? decodeURIComponent(m[1]) : null
+  return parseDeepLinkHash(location.hash)
 }
 
 /** 选中态写入 URL（#s=<key>，与 sw.js 深链同编码）；undefined 清回无 hash 路径 */
 function writeHash(key: string | undefined, replace: boolean): void {
-  const url = key ? `#s=${encodeURIComponent(key)}` : location.pathname + location.search
-  history[replace ? 'replaceState' : 'pushState'](null, '', url)
+  const url = sessionHashUrl(key, location.pathname, location.search)
+  history[replace ? 'replaceState' : 'pushState']({ ap: key ? 'session' : 'list' }, '', url)
+}
+
+function restoreFromHash(key: string, setSelected: (s: SessionInfo | undefined) => void): void {
+  fetchSessions()
+    .then((list) => {
+      if (deepLinkKey() !== key) return // fetch 期间用户又导航了，以最新 hash 为准
+      const target = list.find((s) => s.key === key) ?? sessionFromKey(key)
+      if (target) setSelected(target)
+      else history.replaceState({ ap: 'list' }, '', location.pathname + location.search)
+    })
+    .catch(() => {
+      if (deepLinkKey() !== key) return
+      const target = sessionFromKey(key)
+      if (target) setSelected(target)
+    })
 }
 
 const SIDEBAR_KEY = 'anyplane-sidebar-width'
@@ -42,37 +56,67 @@ export default function App() {
 
   useEffect(() => onAuthRequired(() => setAuthNeeded(true)), [])
 
-  // hash 路由：选中态镜像到 #s=<key>，刷新/分享链接直达当前会话（原深链消费即弃，
-  // 刷新就回列表）。selected 是唯一状态源，hash 是它的持久化投影 + 后退/前进入口。
-  // 用户主动选择 pushState（后退 = 回列表）；会话内导航（/clear 重键、fork、handoff）
-  // replaceState——旧 key 已死，不该留在历史里复活。
+  // hash 路由：选中态镜像到 #s=<key>，刷新/分享链接直达当前会话。
+  // 用户主动选择 pushState（浏览器后退 = 回列表）。
+  // 会话内导航：旧 key 已死（/clear 重键）replace；旧会话还活着（fork/handoff/接力链）push。
+  // 应用内「返回列表」禁止再 push 一帧空 hash——否则系统返回会重开刚关掉的会话。
+  const selectedRef = useRef(selected)
+  selectedRef.current = selected
+  /** 我们 push 出去的会话帧数；应用内返回一次 pop 掉 */
+  const sessionPushesRef = useRef(0)
+  /** history.go(-n) 进行中：hashchange 若没落到列表则 replace 清掉 */
+  const pendingListPopRef = useRef(false)
+
   const selectSession = (s: SessionInfo | undefined, opts?: { replace?: boolean }) => {
+    const replace = opts?.replace ?? false
+    const nextKey = s?.key
+    if (!shouldWriteHash(deepLinkKey(), nextKey)) {
+      setSelected(s)
+      return
+    }
     setSelected(s)
-    writeHash(s?.key, opts?.replace ?? false)
+    writeHash(nextKey, replace)
+    if (!nextKey) sessionPushesRef.current = 0
+    else if (!replace) sessionPushesRef.current += 1
+  }
+
+  const backToList = () => {
+    const n = sessionPushesRef.current
+    if (n > 0) {
+      pendingListPopRef.current = true
+      sessionPushesRef.current = 0
+      history.go(-n)
+      return
+    }
+    selectSession(undefined, { replace: true })
   }
 
   // 后退/前进：hashchange 只由浏览器导航（或直接改 location.hash）触发，
   // pushState/replaceState 不触发——不会与 selectSession 循环
-  const selectedRef = useRef(selected)
-  selectedRef.current = selected
   useEffect(() => {
     const onHash = () => {
       const key = deepLinkKey()
+      if (pendingListPopRef.current) {
+        pendingListPopRef.current = false
+        if (!key) {
+          setSelected(undefined)
+          return
+        }
+        // 没落到列表（中间还有会话帧）：replace 清 hash，避免系统返回再打开
+        setSelected(undefined)
+        writeHash(undefined, true)
+        sessionPushesRef.current = 0
+        return
+      }
       if (!key) {
+        sessionPushesRef.current = 0
         setSelected(undefined)
         return
       }
-      if (selectedRef.current?.key === key) return // 已在目标会话（selectSession 后的历史项回退）
-      // 列表里找全量信息；找不到按 key 构造最小 SessionInfo（s|/x|/b| 可纯 key 构造，
-      // 归档会话/深链直达靠它）；n|/xn| 新会话不可构造——清掉无效 hash 回列表
-      fetchSessions()
-        .then((list) => {
-          if (deepLinkKey() !== key) return // fetch 期间用户又导航了，以最新 hash 为准
-          const target = list.find((s) => s.key === key) ?? sessionFromKey(key)
-          if (target) setSelected(target)
-          else history.replaceState(null, '', location.pathname + location.search)
-        })
-        .catch(() => {})
+      if (selectedRef.current?.key === key) return
+      // 浏览器后退/前进落到某会话：后续应用内返回至少 pop 1 帧
+      sessionPushesRef.current = 1
+      restoreFromHash(key, setSelected)
     }
     window.addEventListener('hashchange', onHash)
     return () => window.removeEventListener('hashchange', onHash)
@@ -81,19 +125,12 @@ export default function App() {
   // 深链引导：启动时读 #s=<key>（推送通知点击直达 / 刷新恢复），选中后 hash 保留
   useEffect(() => {
     const key = deepLinkKey()
-    if (!key) return
-    fetchSessions()
-      .then((list) => {
-        const found = list.find((s) => s.key === key)
-        const target = found ?? sessionFromKey(key)
-        if (target) {
-          setSelected(target)
-        } else {
-          // n|/xn| 新会话或已删除的 key：不可恢复，清掉无效 hash
-          history.replaceState(null, '', location.pathname + location.search)
-        }
-      })
-      .catch(() => {})
+    if (!key) {
+      // `#s=` 形状但解不出 key（损坏编码）：清掉，避免地址栏留着无效 hash
+      if (/^#s=/.test(location.hash)) writeHash(undefined, true)
+      return
+    }
+    restoreFromHash(key, setSelected)
   }, [])
 
   const persistWidth = (w: number) => {
@@ -189,8 +226,8 @@ export default function App() {
         {selected ? (
           <Chat
             session={selected}
-            onBack={() => selectSession(undefined)}
-            onNavigate={(s) => selectSession(s, { replace: true })}
+            onBack={backToList}
+            onNavigate={(s, opts) => selectSession(s, { replace: opts?.replace ?? false })}
           />
         ) : (
           <div className="hidden h-full flex-col items-center justify-center gap-3 text-faint md:flex">

--- a/web/src/components/ChatHeader.tsx
+++ b/web/src/components/ChatHeader.tsx
@@ -4,6 +4,7 @@
 
 import { useRef, useState } from 'react'
 import type { LineageResponse, SessionInfo } from '../lib/api'
+import type { NavigateSession } from '../lib/sessionHash'
 import { copyText } from '../lib/chatText'
 import type { SessionState } from '../lib/ws'
 import { ClaudeMark } from './ClaudeMark'
@@ -47,7 +48,7 @@ export function ChatHeader(props: {
   handoffBusy: boolean
   onHandoff: () => void
   lineage?: LineageResponse
-  onNavigate?: (s: SessionInfo) => void
+  onNavigate?: NavigateSession
   /** 玻璃横带内的尾部插槽（详情抽屉在 DOM 上与顶栏/接力链同属 glass-bar，由组合层传入） */
   children?: React.ReactNode
 }) {

--- a/web/src/components/Markdown.test.ts
+++ b/web/src/components/Markdown.test.ts
@@ -1,20 +1,36 @@
 import { describe, expect, test } from 'bun:test'
 import { shouldInterceptLink } from './Markdown'
 
-describe('shouldInterceptLink（Markdown 空链接/锚点拦截）', () => {
+describe('shouldInterceptLink（Markdown 空链接/锚点/相对路径拦截）', () => {
   test('空 href 与缺省 href 拦截（<a href=""> 点击 = 刷新当前页）', () => {
     expect(shouldInterceptLink('')).toBe(true)
+    expect(shouldInterceptLink('   ')).toBe(true)
     expect(shouldInterceptLink(null)).toBe(true)
   })
 
   test('# 锚点拦截（改 hash 会与 #s=<key> 路由打架，弹回列表）', () => {
     expect(shouldInterceptLink('#')).toBe(true)
     expect(shouldInterceptLink('#anchor')).toBe(true)
+    expect(shouldInterceptLink('#s=s%7Cslug%7Csid')).toBe(true)
+  })
+
+  test('javascript:/data: 拦截', () => {
+    expect(shouldInterceptLink('javascript:alert(1)')).toBe(true)
+    expect(shouldInterceptLink('JavaScript:void(0)')).toBe(true)
+    expect(shouldInterceptLink('data:text/html,x')).toBe(true)
+  })
+
+  test('相对路径 / Windows 路径 / 同站绝对路径拦截（会卸掉 SPA）', () => {
+    expect(shouldInterceptLink('foo.ts')).toBe(true)
+    expect(shouldInterceptLink('./README.md')).toBe(true)
+    expect(shouldInterceptLink('/abs/path')).toBe(true)
+    expect(shouldInterceptLink('D:\\Coder\\x.ts')).toBe(true)
   })
 
   test('真实外链放行', () => {
     expect(shouldInterceptLink('https://example.com/x')).toBe(false)
+    expect(shouldInterceptLink('http://example.com/x')).toBe(false)
+    expect(shouldInterceptLink('mailto:a@b.c')).toBe(false)
     expect(shouldInterceptLink('file:///C:/tmp/a.txt')).toBe(false)
-    expect(shouldInterceptLink('D:\\Coder\\x.ts')).toBe(false)
   })
 })

--- a/web/src/components/Markdown.test.ts
+++ b/web/src/components/Markdown.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test'
+import { shouldInterceptLink } from './Markdown'
+
+describe('shouldInterceptLink（Markdown 空链接/锚点拦截）', () => {
+  test('空 href 与缺省 href 拦截（<a href=""> 点击 = 刷新当前页）', () => {
+    expect(shouldInterceptLink('')).toBe(true)
+    expect(shouldInterceptLink(null)).toBe(true)
+  })
+
+  test('# 锚点拦截（改 hash 会与 #s=<key> 路由打架，弹回列表）', () => {
+    expect(shouldInterceptLink('#')).toBe(true)
+    expect(shouldInterceptLink('#anchor')).toBe(true)
+  })
+
+  test('真实外链放行', () => {
+    expect(shouldInterceptLink('https://example.com/x')).toBe(false)
+    expect(shouldInterceptLink('file:///C:/tmp/a.txt')).toBe(false)
+    expect(shouldInterceptLink('D:\\Coder\\x.ts')).toBe(false)
+  })
+})

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -2,12 +2,21 @@ import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
-/** 链接点击是否拦截（preventDefault）：AI 输出的 markdown 常把文件名渲染成 <a href="">，
- *  空 href 点击 = 重新加载当前页；# 锚点会改 location.hash，与 App 的 #s=<key> hash 路由
- *  打架（hashchange 解析不到会话 key 会被弹回列表）。两类都拦。
- *  此处是未来「点击文件名 → 文件预览」的天然挂点（拦截后可改走预览面板）。 */
+/** 链接点击是否拦截（preventDefault）：
+ *  - 空 href / 空白：AI 常把文件名渲染成 <a href="">，点击 = 刷新当前页
+ *  - # 锚点：改 location.hash，与 App 的 #s=<key> 路由打架（弹回列表）
+ *  - javascript:/data:/vbscript:：不让 markdown 当脚本入口
+ *  - 相对路径 / Windows 路径 / 同站绝对路径：会卸掉 SPA
+ *  显式 http(s)/mailto/file 外链放行。
+ *  此处是未来「点击文件名 → 文件预览」的天然挂点。 */
 export function shouldInterceptLink(href: string | null): boolean {
-  return href === null || href === '' || href.startsWith('#')
+  if (href == null) return true
+  const t = href.trim()
+  if (!t) return true
+  if (t.startsWith('#')) return true
+  if (/^(javascript|data|vbscript):/i.test(t)) return true
+  if (/^(https?:|mailto:|file:)/i.test(t)) return false
+  return true
 }
 
 /** AI/用户文本的 Markdown 渲染（GFM：表格、删除线、任务列表）。

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -2,11 +2,25 @@ import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
+/** 链接点击是否拦截（preventDefault）：AI 输出的 markdown 常把文件名渲染成 <a href="">，
+ *  空 href 点击 = 重新加载当前页；# 锚点会改 location.hash，与 App 的 #s=<key> hash 路由
+ *  打架（hashchange 解析不到会话 key 会被弹回列表）。两类都拦。
+ *  此处是未来「点击文件名 → 文件预览」的天然挂点（拦截后可改走预览面板）。 */
+export function shouldInterceptLink(href: string | null): boolean {
+  return href === null || href === '' || href.startsWith('#')
+}
+
 /** AI/用户文本的 Markdown 渲染（GFM：表格、删除线、任务列表）。
  *  memo：text 不变时跳过 ReactMarkdown 重解析（渲染链里最重的单项）。 */
 export const Markdown = memo(function Markdown(props: { text: string }) {
   return (
-    <div className="prose-cc">
+    <div
+      className="prose-cc"
+      onClick={(e) => {
+        const a = (e.target as HTMLElement).closest('a')
+        if (a && shouldInterceptLink(a.getAttribute('href'))) e.preventDefault()
+      }}
+    >
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{props.text}</ReactMarkdown>
     </div>
   )

--- a/web/src/components/MessageView.tsx
+++ b/web/src/components/MessageView.tsx
@@ -97,7 +97,11 @@ export const MessageView = memo(function MessageView(props: { msg: ChatMsg; comp
         <div className="flex items-center gap-2 px-3 py-2">
           <span className="font-mono text-[10px] tracking-widest text-muted uppercase">侧问</span>
           <span className="truncate text-xs text-muted">{msg.btw}</span>
-          {msg.btwPending && <span className="ml-auto font-mono text-[10px] text-faint">回答中…</span>}
+          <span className="ml-auto flex shrink-0 items-center gap-2 font-mono text-[10px] text-faint">
+            {msg.btwPending && <span>回答中…</span>}
+            {/* side_question 不写入 transcript，刷新/重进后卡片即消失——常驻提示避免用户误以为丢失 */}
+            <span title="侧问不写入会话历史，刷新或重进后不再显示">不进历史</span>
+          </span>
         </div>
         <div className="px-3 pb-2">
           {msg.blocks.length === 0 && msg.btwPending && (

--- a/web/src/hooks/useSessionSocket.ts
+++ b/web/src/hooks/useSessionSocket.ts
@@ -9,6 +9,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { fetchHistory, makeSessionInfo, type HistoryResponse, type SessionInfo } from '../lib/api'
+import type { NavigateSession } from '../lib/sessionHash'
 import { nextId, type Block } from '../lib/blocks'
 import { appendHistoryMsg, flushStrayResults, type IngestState } from '../lib/ingest'
 import { SessionSocket, type ServerEvent, type SessionState } from '../lib/ws'
@@ -30,7 +31,7 @@ export function useSessionSocket(opts: {
   taskApi: TaskBucketsApi
   /** limit：replay_gap 保载重载时按「已加载数+余量」拉取，避免丢掉用户已翻到的更早页 */
   loadSessionHistory: (opts?: { limit?: number }) => Promise<HistoryResponse>
-  onNavigate?: (s: SessionInfo) => void
+  onNavigate?: NavigateSession
   /** codex 分叉完成时收起回滚面板 */
   onCloseRewind: () => void
   /** query_result 详情域分发（MCP 动作应答辨认 + 结构化面板），实现在组合层 */
@@ -206,7 +207,7 @@ export function useSessionSocket(opts: {
                   cwd: session.cwd,
                   backend: 'claude',
                 }),
-              )
+              ) // 原会话还活着：默认 push，浏览器后退回得去
               break
             }
             // codex 分叉回滚完成：原线程不动，跳到携带截断历史的新线程
@@ -222,7 +223,7 @@ export function useSessionSocket(opts: {
                 backend: 'codex',
                 managed: { spawned: true, busy: false, clients: 0 },
               }),
-            )
+            ) // 原线程还活着：默认 push
             break
           }
           case 'handoff_pending':
@@ -251,7 +252,7 @@ export function useSessionSocket(opts: {
                 status: 'busy',
                 managed: { spawned: true, busy: true, clients: 0 },
               }),
-            )
+            ) // 源会话还活着：默认 push
             break
           }
           case 'handoff_error':
@@ -325,7 +326,7 @@ export function useSessionSocket(opts: {
           }
           case 'moved': {
             // /clear 对话重置：进程已换新 sessionId 续跑，Hub 重键完毕——跳到新会话页
-            //（旧 transcript 在磁盘原样保留，列表页可见）
+            //（旧 transcript 在磁盘原样保留，列表页可见）。旧 key 已作废，replace 不留历史。
             const parts = ev.targetKey.split('|')
             onNavigate?.(
               makeSessionInfo({
@@ -336,6 +337,7 @@ export function useSessionSocket(opts: {
                 backend: 'claude',
                 managed: { spawned: true, busy: false, clients: 0 },
               }),
+              { replace: true },
             )
             break
           }

--- a/web/src/lib/sessionHash.test.ts
+++ b/web/src/lib/sessionHash.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+import { parseDeepLinkHash, sessionHashUrl, shouldWriteHash } from './sessionHash'
+
+describe('parseDeepLinkHash', () => {
+  test('标准 #s=<encodeURIComponent(key)> 解出原 key', () => {
+    const key = 's|-srv|01a03cac-3fdc-7b80-9c5d-f14ba518f4dc'
+    expect(parseDeepLinkHash(`#s=${encodeURIComponent(key)}`)).toBe(key)
+  })
+
+  test('无 hash / 空 #s= / 非会话 hash → null', () => {
+    expect(parseDeepLinkHash('')).toBeNull()
+    expect(parseDeepLinkHash('#')).toBeNull()
+    expect(parseDeepLinkHash('#s=')).toBeNull()
+    expect(parseDeepLinkHash('#other')).toBeNull()
+  })
+
+  test('损坏百分号编码 → null（不抛 URIError）', () => {
+    expect(parseDeepLinkHash('#s=%')).toBeNull()
+    expect(parseDeepLinkHash('#s=%E0%A4%A')).toBeNull()
+    expect(parseDeepLinkHash('#s=b|%E4%B8')).toBeNull()
+  })
+})
+
+describe('sessionHashUrl', () => {
+  test('有 key 只写 hash 段（与 sw.js 深链同编码）', () => {
+    expect(sessionHashUrl('s|slug|sid')).toBe('#s=s%7Cslug%7Csid')
+  })
+
+  test('无 key 回到 pathname+search', () => {
+    expect(sessionHashUrl(undefined, '/', '')).toBe('/')
+    expect(sessionHashUrl(undefined, '/app', '?x=1')).toBe('/app?x=1')
+  })
+})
+
+describe('shouldWriteHash', () => {
+  test('同 key 不写（避免重复 push 吞后退）', () => {
+    expect(shouldWriteHash('s|a|1', 's|a|1')).toBe(false)
+    expect(shouldWriteHash(null, undefined)).toBe(false)
+  })
+
+  test('切会话或回列表要写', () => {
+    expect(shouldWriteHash('s|a|1', 's|b|2')).toBe(true)
+    expect(shouldWriteHash('s|a|1', undefined)).toBe(true)
+    expect(shouldWriteHash(null, 's|a|1')).toBe(true)
+  })
+})

--- a/web/src/lib/sessionHash.ts
+++ b/web/src/lib/sessionHash.ts
@@ -1,0 +1,25 @@
+import type { SessionInfo } from './api'
+
+/** 会话导航：默认 push（旧会话还活着）；replace 仅用于旧 key 已作废（如 /clear 重键） */
+export type NavigateSession = (s: SessionInfo, opts?: { replace?: boolean }) => void
+
+/** 从 location.hash 解析 `#s=<key>`。损坏编码返回 null，不抛 URIError。 */
+export function parseDeepLinkHash(hash: string): string | null {
+  const m = hash.match(/^#s=(.+)$/)
+  if (!m) return null
+  try {
+    return decodeURIComponent(m[1])
+  } catch {
+    return null
+  }
+}
+
+/** 选中态对应的 URL：有 key 写 `#s=<encode>`，无 key 回到 pathname+search */
+export function sessionHashUrl(key: string | undefined, path = '', search = ''): string {
+  return key ? `#s=${encodeURIComponent(key)}` : path + search
+}
+
+/** hash 已是目标 key 时不要再写历史（重复点击同一会话会吞掉后退） */
+export function shouldWriteHash(currentKey: string | null, nextKey: string | undefined): boolean {
+  return (nextKey ?? null) !== currentKey
+}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -14,12 +14,13 @@ import { buildTranscriptRows, nextId, rewindPreview, usageSummary, type Block, t
 import { statusLineOf } from '../lib/chatText'
 import { interceptSlash, type SlashAction } from '../lib/slashIntercept'
 import { isCodexKey, isExistingKey } from '../lib/key'
+import type { NavigateSession } from '../lib/sessionHash'
 import { useTaskBuckets } from '../hooks/useTaskBuckets'
 import { useTranscriptIngest } from '../hooks/useTranscriptIngest'
 import { useSessionSocket, type QueryResultEvent } from '../hooks/useSessionSocket'
 import { useTranscriptScroll } from '../hooks/useTranscriptScroll'
 
-export function Chat(props: { session: SessionInfo; onBack: () => void; onNavigate?: (s: SessionInfo) => void }) {
+export function Chat(props: { session: SessionInfo; onBack: () => void; onNavigate?: NavigateSession }) {
   const { session } = props
   const isCodex = isCodexKey(session.key)
   const isExisting = isExistingKey(session.key)

--- a/web/src/pages/SessionList.tsx
+++ b/web/src/pages/SessionList.tsx
@@ -604,53 +604,53 @@ export function SessionList(props: {
               const st = STATUS_META[stKey] ?? STATUS_META.offline
               const active = props.selectedKey === s.key
               const busyRow = stKey === 'busy'
+              // 行 = 两个平级按钮（主按钮打开会话 + 更多操作），不再是 role=button 套 button
+              // 的嵌套交互——嵌套时行的无障碍名会把子按钮名也吞进去
+              //（"标题 时间 会话操作：标题 状态 …"），屏幕阅读器与 a11y 树定位都受干扰
               return (
                 <div
                   key={s.key}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => props.onSelect(s)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault()
-                      props.onSelect(s)
-                    }
-                  }}
-                  className={`group mx-1 mb-0.5 block w-[calc(100%-0.5rem)] cursor-pointer rounded-[14px] px-3 py-2.5 text-left transition-colors ${
+                  className={`group relative mx-1 mb-0.5 w-[calc(100%-0.5rem)] rounded-[14px] transition-colors ${
                     busyRow ? 'wave-surface bg-surface' : 'hover:bg-surface'
                   } ${active ? 'bg-surface2' : ''}`}
                 >
-                  <div className="flex items-center gap-2.5">
-                    <span className={`h-2 w-2 shrink-0 rounded-full ${st.cls}`} />
-                    <span className="truncate text-[15px] font-semibold">{s.title ?? s.sessionId.slice(0, 8)}</span>
-                    <span className="ml-auto shrink-0 font-mono text-[11px] text-faint">
-                      {timeAgo(s.mtime)}
-                    </span>
-                    <button
-                      type="button"
-                      className="flex h-[18px] w-[18px] shrink-0 items-center justify-center overflow-hidden rounded-full transition-colors hover:bg-surface2"
-                      title="更多操作"
-                      aria-label={`会话操作：${s.title ?? s.sessionId.slice(0, 8)}`}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setMenu(menu?.session.key === s.key ? null : { session: s, anchor: e.currentTarget })
-                      }}
-                    >
-                      {s.backend === 'codex' ? (
-                        <CodexMark size={15} static />
-                      ) : (
-                        <ClaudeMark className="h-[15px] w-[15px]" />
+                  <button
+                    type="button"
+                    onClick={() => props.onSelect(s)}
+                    className="block w-full cursor-pointer rounded-[14px] px-3 py-2.5 text-left"
+                  >
+                    <div className="flex items-center gap-2.5 pr-[22px]">
+                      <span className={`h-2 w-2 shrink-0 rounded-full ${st.cls}`} />
+                      <span className="truncate text-[15px] font-semibold">{s.title ?? s.sessionId.slice(0, 8)}</span>
+                      <span className="ml-auto shrink-0 font-mono text-[11px] text-faint">
+                        {timeAgo(s.mtime)}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex items-center gap-1.5 pl-[18px] text-[12px]">
+                      <span className={`shrink-0 font-medium ${stKey === 'waiting' ? 'text-accent' : 'text-muted'}`}>
+                        {st.label}
+                      </span>
+                      {s.lastPrompt && (
+                        <span className="truncate font-mono text-[11px] text-faint">{s.lastPrompt}</span>
                       )}
-                    </button>
-                  </div>
-                  <div className="mt-1 flex items-center gap-1.5 pl-[18px] text-[12px]">
-                    <span className={`shrink-0 font-medium ${stKey === 'waiting' ? 'text-accent' : 'text-muted'}`}>
-                      {st.label}
-                    </span>
-                    {s.lastPrompt && (
-                      <span className="truncate font-mono text-[11px] text-faint">{s.lastPrompt}</span>
+                    </div>
+                  </button>
+                  <button
+                    type="button"
+                    className="absolute right-3 top-2.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center overflow-hidden rounded-full transition-colors hover:bg-surface2"
+                    title="更多操作"
+                    aria-label={`会话操作：${s.title ?? s.sessionId.slice(0, 8)}`}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setMenu(menu?.session.key === s.key ? null : { session: s, anchor: e.currentTarget })
+                    }}
+                  >
+                    {s.backend === 'codex' ? (
+                      <CodexMark size={15} static />
+                    ) : (
+                      <ClaudeMark className="h-[15px] w-[15px]" />
                     )}
-                  </div>
+                  </button>
                 </div>
               )
             })}


### PR DESCRIPTION
## 背景

chrome-devtools MCP 人类式使用体检（双后端收发 / 审批 / 斜杠命令 / 长历史翻页 / 刷新重连 / tail 跟踪 / 回收站）发现的体验问题批修。UX-4（本地命令应答历史回放）与 UX-5（跨后端审批不一致）经评估不修（前者不追加不落 transcript 的信息，后者设计如此）。

## 修复清单

### 服务端（ef7ce5c）
- **BUG-1**：本地斜杠命令（/model 等不过 API 的回合）发 usage 全零的 assistant 流事件，`noteContextUsage` 收下后把上下文环清零直到下一真实回合。全零视为无信息忽略，与离线回扫 `extractUsageFromTranscriptTail` 同口径。
- **UX-3**：codex 回合页脚补耗时——`turnCompletedMsg` 映射 `Turn.durationMs`（协议正本字段，0.149.0 实测已下发）→ `result.duration_ms`，snake_case 防御 + startedAt/completedAt 兜底。
- **UX-6**：tail/离线会话 StatusPill 不再显示 `…` 占位——`statusOf` model 末级回退到 init 持久化的 sessionId→model 表（与 `hydratedContextOf` 窗口推断同源）。

### 前端（94711b9）
- **UX-1**：刷新恢复当前会话。选中态镜像到 `#s=<key>`（与 sw.js 深链同编码）；主动选择 pushState（后退回列表），会话内导航（/clear 重键、fork、handoff）replaceState；hashchange 承接浏览器后退/前进；n|/xn| 不可恢复时清无效 hash。
- **BUG-2**：Markdown 空链接（`<a href="">文件名</a>`）与 # 锚点点击拦截——空 href 点击 = 刷新整页；# 锚点与 hash 路由打架会被弹回列表。拦截点预留「点击文件名 → 文件预览」挂点。
- **/btw**：侧问卡常驻「不进历史」提示（side_question 不写 transcript，刷新即消失，避免误以为丢失）。
- **a11y**：会话行 `role=button` 套 `button` 的嵌套交互改平级双按钮，行的无障碍名不再混入子按钮名。

### 文档（c61a847）
- **UX-2 → ROADMAP 方向九**：codex 上游调查结论——app-server 协议只有手动 `thread/name/set`，无自动标题机制（云端 `has_generated_title` 是云任务特性，不在本地协议面）。可行路径（复用 `runEphemeralQuestion` + name/set）与暂不做的原因已记录。

## 验证

- `bun test` 510 pass（新增 processManager +2 / translate +1 / port +4 / Markdown +3）
- `bunx tsc --noEmit` 无错；`bun run build` 成功
- chrome-devtools 实测（真实 CLI 调用）：
  - /model 后上下文环保持 14% 不清零（修复前必现清零）
  - codex 页脚「─ 本轮 1s · 2 tok」带出耗时
  - tail 模式 StatusPill 显示 `default [k3-256k] high`
  - 选中会话 → hash 写入 → 刷新恢复 → 后退回列表 → 前进回会话
  - 空链接点击无导航；侧问卡提示渲染；会话行视觉无回归（结构 div+button×2）

## 未覆盖 / 风险点

- `/clear` 的 moved 导航 replaceState 路径已 review 未现场实测（不想破坏测试会话历史）
- 升级 CLI 后建议跑 `e2e-slash.ts` 回归（BUG-1 涉及本地命令流事件口径）