### PR TITLE
fix: 首次上手漏斗修复——npm 无 Bun 安装失败、iOS 通知按钮、README 英文化

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,78 +6,67 @@
 
 > Run your agents, on any plane.
 
-**让 agent 跑着任务，你去生活。它有事叫你，锁屏按一下就好。**
+**Let your agents keep working while you go live your life. When one needs you, the approval is already waiting on your lock screen.**
 
-**官网 [anyplane.run](https://anyplane.run)**（国内访问可试 [anyplane.cn](https://anyplane.cn)） · npm 包 [`anyplane`](https://www.npmjs.com/package/anyplane)
+**[anyplane.run](https://anyplane.run)** · npm: [`anyplane`](https://www.npmjs.com/package/anyplane) · [简体中文](README.zh-CN.md)
 
 <p align="center">
-  <img src="docs/media/Greeting.png" alt="AnyPlane 会话界面：一次真实对话里向 README 读者打招呼" />
+  <img src="docs/media/Greeting.png" alt="AnyPlane session view: project-grouped session list and a live conversation" />
 </p>
 
-## 它能帮你做什么
+AnyPlane is a self-hosted, vendor-neutral control plane for the coding agents already running on your machine. Open it from your phone or any browser to watch Claude Code and Codex sessions stream, approve the file writes and commands they ask for, and pick up conversations where you left them.
 
-- **离开电脑也能盯着 agent**：手机上查看流式输出、审批文件写入和命令执行，锁屏后推送照样到。
-- **一个界面管两家 agent**：Claude Code 和 Codex 的会话按项目目录分组，随时接续历史对话。
-- **长跑任务交给 agent 自己盯**：设定目标让它干到达成为止，完成、出错、等你审批都会通知你。
-- **会活也能玩出花**：一键分叉当前会话、让一个 agent 接力另一个的工作、回滚对话或文件改动。
+## Why this exists
 
-## 原理
+The official remotes (Claude Code Remote Control, Codex remote) require a claude.ai subscription and route your session through the vendor. They are **unavailable** if you use an API key, an LLM gateway, Bedrock, Vertex, or Foundry — [and as of Claude Code v2.1.196, simply pointing `ANTHROPIC_BASE_URL` at a non-Anthropic host disables Remote Control entirely](https://code.claude.com/docs/en/remote-control).
 
-AnyPlane 不修改官方 CLI。服务端以子进程方式驱动两家 CLI 的 headless 协议——与 claude.ai/code 网页版桥接本地 CLI 用的是同一套本地协议；Codex 的事件在服务端翻译成与 Claude 相同的消息形状，前端因此一套界面通吃。
+AnyPlane is the control plane for everyone in that gap: no account, no relay, no telemetry. Your transcripts stay on your disk, your vendor tokens stay on your machine, and Claude Code and Codex share one interface.
 
-## 快速开始
+## What you get
 
-需要：Bun ≥ 1.4.0，PATH 中有已登录的官方 `claude` CLI；使用 Codex 后端则另需 `codex` CLI（≥ 0.147）。
+- **Watch agents from anywhere.** Streaming output, tool calls paired into cards, background sub-agents in a side panel — on a phone screen, over your LAN or your own tunnel.
+- **Rule on approvals from the lock screen.** When an agent wants to write a file or run a command, a push notification carries a one-tap capability secret. On Android and desktop Chrome you approve or deny straight from the notification buttons. On iOS, where Safari ignores notification actions, the tap opens a two-button confirm page instead — either way you never load the full app.
+- **Two runtimes, one interface.** Claude Code and Codex sessions are grouped by project directory and resumed with full context. The same gestures work on both.
+- **Approval rules, not just afk/yolo.** Auto-allow or auto-deny by tool, command prefix, or working directory; everything else still asks. Every automatic ruling is broadcast and logged.
+- **Notifications that actually reach you.** Web Push (VAPID and aes128gcm implemented in-house, no push SDK), plus ntfy, Bark and Server酱 webhook channels for environments where FCM isn't an option.
+- **Rewind, branch, hand off.** Roll back a conversation or the files it touched, fork a session with its full history, or have one agent hand a summarized brief to another.
+
+## How it works
+
+AnyPlane does not patch or wrap the official CLIs. The server drives each vendor's own headless protocol as a subprocess — Claude Code over stream-json NDJSON (the same local protocol claude.ai/code uses to bridge your CLI), Codex over its app-server JSON-RPC. Codex events are translated server-side into the Claude stream-json message shape, so there is exactly one message boundary and the frontend never forks.
+
+## Quick start
+
+You need **Bun ≥ 1.4.0** and a logged-in official `claude` CLI on your PATH. The Codex backend additionally needs `codex` CLI ≥ 0.147.
 
 ```bash
 bunx anyplane
 ```
 
-打开 <http://localhost:7480> 即可。前端已随 npm 包预构建，无需 clone 仓库；配置文件和运行数据默认放在 `~/.anyplane/`。
+Open <http://localhost:7480>. The frontend ships prebuilt in the npm package — no clone, no build step. Config and runtime data live in `~/.anyplane/`.
 
-从源码运行（开发用，本项目仅使用 Bun，请勿用 npm / yarn / pnpm）：
+Don't have Bun? `npm i -g anyplane` and `npx anyplane` work too — they'll tell you how to install Bun if it's missing.
+
+Running from source (Bun only — do not use npm / yarn / pnpm):
 
 ```bash
 bun install
-bun run build && bun run start   # 生产模式
-bun run dev                      # 开发模式：服务端 + Vite 热更新
+bun run build && bun run start   # production
+bun run dev                      # server + Vite HMR
 ```
 
-## 功能一览
+## Security
 
-**会话管理**
-- 会话按项目目录分组，显示 git 分支与状态徽标；新会话自动生成 AI 标题，支持改名、归档（回收站可恢复）。
-- 接续对话：精准恢复 Claude / Codex 的历史会话，上下文原样带回。
+Running AnyPlane means exposing "start a session on this machine" to whoever can reach the port — and starting a session is equivalent to arbitrary command execution. Take the bind address seriously.
 
-**交互与审批**
-- 流式输出实时渲染 Markdown；工具调用与结果配对成卡片，子代理等后台任务收进右侧栏，可随时停止。
-- agent 请求权限时推到浏览器里裁决，允许/拒绝一键完成；也可以配置全自动模式。
-- 模型、权限模式、effort 运行中随时切换；斜杠命令面板两家后端通吃。
-- 图片可直接粘贴发送；会话详情抽屉里有上下文用量、MCP 管理与 token 计量。
+- Listens on `127.0.0.1` only by default.
+- **Binding a non-loopback address (e.g. `0.0.0.0`) requires `authToken`**, or the server refuses to start.
+- With a token configured, startup prints a QR code containing the tokenized URL — scan it from your phone.
+- For access across networks, prefer Tailscale Funnel, Cloudflare Tunnel, or home IPv6 + DDNS over rolling your own ingress. All three recipes and their security tradeoffs are in [docs/public-access.md](docs/public-access.md).
 
-**通知**
-- Web Push：页面关了也能收到审批/完成/错误通知，审批通知自带允许/拒绝按钮，不打开页面直接裁决。
-- webhook 通道（ntfy / Bark / Server酱）：国内无 FCM 环境的出路，Server酱可直达微信。
+## Configuration
 
-**高级玩法**
-- 接力：一键让另一个 agent 接续本目录工作，自带交接简报。
-- 分叉：当前会话开出分支，携带全部历史，原会话不动。
-- 目标：设定完成条件，agent 持续工作直到达成。
-- 回滚：回滚对话或文件改动；Codex 侧可「从此处分叉」。
-- 收件箱汇总所有会话的待办；PWA 可添加到手机主屏。
-
-## 安全
-
-AnyPlane 的本质是把「在本机起会话」开放给能访问该端口的人，而起会话等价于任意命令执行——请认真对待监听地址。
-
-- 默认只监听 `127.0.0.1`（仅本机），这是安全默认值。
-- **绑定非回环地址（如 `0.0.0.0`）必须同时配置 `authToken`**，否则服务端拒绝启动。
-- 配置 token 后，启动时终端会打印带 token 的扫码 URL 二维码，手机扫码即入。
-- 跨网段访问不建议自建公网穿透；Tailscale funnel / Cloudflare Tunnel / IPv6+DDNS 三套免 VPS 配方见 [docs/public-access.md](docs/public-access.md)。
-
-## 配置
-
-配置文件 `anyplane.config.json`（项目根目录）或 `~/.anyplane/config.json`，均可选。最常用的几项：
+`anyplane.config.json` in the project root or `~/.anyplane/config.json` — both optional.
 
 ```json
 {
@@ -88,20 +77,24 @@ AnyPlane 的本质是把「在本机起会话」开放给能访问该端口的�
 }
 ```
 
-- `permissionPolicy`：`"ask"`（默认，转发 UI 审批）| `"bypass"`（全自动，慎用）。
-- 推送通知需要 HTTPS 或 localhost；iOS 需先把站点添加到主屏幕再订阅。
-- 完整配置项、推送 webhook 通道、环境变量见 [docs/configuration.md](docs/configuration.md)；域名访问（80/443 网关）见 [docs/gateway.md](docs/gateway.md)。
+- `permissionPolicy`: `"ask"` (default, forwards approvals to the UI) or `"bypass"` (fully automatic — use with care).
+- Push notifications require HTTPS or localhost. On iOS the site must be added to the Home Screen before it can subscribe.
+- Full option reference, webhook channels and environment variables: [docs/configuration.md](docs/configuration.md). Domain access via the 80/443 gateway: [docs/gateway.md](docs/gateway.md).
 
-## 已知限制
+## Known limitations
 
-- 部分功能（如 /btw、目标）需要 Claude CLI ≥ 2.1.139。
-- 回滚依赖文件检查点：compact 边界之前的消息不可回滚；Codex 无文件检查点，只能回滚对话或分叉。
-- Codex 不持久化推理过程，AnyPlane 以侧车文件补记（`~/.anyplane/reasoning/`）。
-- 运行数据目录 `~/.anyplane/` 不自动清理，由用户自行管理。
+- Some features (`/btw`, goals) need Claude CLI ≥ 2.1.139.
+- **iOS has never been tested on a real device.** The Web Push path degrades correctly by capability detection (confirm page when notification buttons are unavailable), but the author doesn't own an iPhone. If you try it — working or not — please open an issue.
+- Rewind depends on file checkpoints: messages before a compact boundary can't be rewound, and Codex has no file checkpoints at all (conversation rewind and fork only).
+- Codex doesn't persist reasoning; AnyPlane records it in a sidecar at `~/.anyplane/reasoning/`.
+- `~/.anyplane/` is never cleaned automatically — it's yours to manage.
+- **The UI is currently Simplified Chinese only.** i18n isn't in place yet; the interface is readable but not translated. This is the next thing on the list.
 
-## 开发与贡献
+## Contributing
 
-- 架构决策与开发约定见 [AGENTS.md](AGENTS.md)；发版流程见 [docs/releasing.md](docs/releasing.md)。
-- 长文本文档（调研/规划/审计）放 `docs/`，各子目录角色见 [docs/README.md](docs/README.md)；**入库文档不要描述本地仓库路径、密钥位置等机器相关信息**，确有需要写 `*.local.md`（不进 git）。
-- 端到端验证脚本在 `server/scripts/`（需服务端已启动，会真实调用 claude/codex CLI）。
-- 官方文档本地镜像：`bun run docs:claude` / `bun run docs:codex`，写入 gitignore 的 `docs/claude-code/` 与 `docs/codex/`。
+- Architecture decisions and working conventions: [AGENTS.md](AGENTS.md). Release process: [docs/releasing.md](docs/releasing.md).
+- Long-form docs (research, planning, audits) live in `docs/` — see [docs/README.md](docs/README.md) for the map. Don't commit machine-specific paths or secret locations; use `*.local.md` (gitignored) if you must.
+- End-to-end scripts are in `server/scripts/` and require a running server plus the real CLIs.
+- Local mirrors of the vendor docs: `bun run docs:claude` / `bun run docs:codex`.
+
+MIT. Formerly cc-remote.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,111 @@
+<p align="center">
+  <img src="docs/media/AnyPlane-icon.png" width="64" height="64" alt="AnyPlane" />
+</p>
+
+# AnyPlane
+
+> Run your agents, on any plane.
+
+**让 agent 跑着任务，你去生活。它有事叫你，锁屏上就能放行。**
+
+**官网 [anyplane.run](https://anyplane.run)**（国内访问可试 [anyplane.cn](https://anyplane.cn)） · npm 包 [`anyplane`](https://www.npmjs.com/package/anyplane) · [English](README.md)
+
+<p align="center">
+  <img src="docs/media/Greeting.png" alt="AnyPlane 会话界面：一次真实对话里向 README 读者打招呼" />
+</p>
+
+## 它能帮你做什么
+
+- **离开电脑也能盯着 agent**：手机上查看流式输出、审批文件写入和命令执行，锁屏后推送照样到。
+- **一个界面管两家 agent**：Claude Code 和 Codex 的会话按项目目录分组，随时接续历史对话。
+- **长跑任务交给 agent 自己盯**：设定目标让它干到达成为止，完成、出错、等你审批都会通知你。
+- **会活也能玩出花**：一键分叉当前会话、让一个 agent 接力另一个的工作、回滚对话或文件改动。
+
+## 原理
+
+AnyPlane 不修改官方 CLI。服务端以子进程方式驱动两家 CLI 的 headless 协议——与 claude.ai/code 网页版桥接本地 CLI 用的是同一套本地协议；Codex 的事件在服务端翻译成与 Claude 相同的消息形状，前端因此一套界面通吃。
+
+## 快速开始
+
+需要：Bun ≥ 1.4.0，PATH 中有已登录的官方 `claude` CLI；使用 Codex 后端则另需 `codex` CLI（≥ 0.147）。
+
+```bash
+bunx anyplane
+```
+
+打开 <http://localhost:7480> 即可。前端已随 npm 包预构建，无需 clone 仓库；配置文件和运行数据默认放在 `~/.anyplane/`。
+
+没装 Bun 也可以从 npm 装（`npm i -g anyplane` / `npx anyplane`）——启动时会告诉你怎么补上 Bun。
+
+从源码运行（开发用，本项目仅使用 Bun，请勿用 npm / yarn / pnpm）：
+
+```bash
+bun install
+bun run build && bun run start   # 生产模式
+bun run dev                      # 开发模式：服务端 + Vite 热更新
+```
+
+## 功能一览
+
+**会话管理**
+- 会话按项目目录分组，显示 git 分支与状态徽标；新会话自动生成 AI 标题，支持改名、归档（回收站可恢复）。
+- 接续对话：精准恢复 Claude / Codex 的历史会话，上下文原样带回。
+
+**交互与审批**
+- 流式输出实时渲染 Markdown；工具调用与结果配对成卡片，子代理等后台任务收进右侧栏，可随时停止。
+- agent 请求权限时推到浏览器里裁决，允许/拒绝一键完成；也可以配置全自动模式或审批规则。
+- 模型、权限模式、effort 运行中随时切换；斜杠命令面板两家后端通吃。
+- 图片可直接粘贴发送；会话详情抽屉里有上下文用量、MCP 管理与 token 计量。
+
+**通知**
+- Web Push：页面关了也能收到审批/完成/错误通知。审批通知在 Android 与桌面 Chrome 上自带允许/拒绝按钮，不打开页面直接裁决；iOS 不支持通知按钮，点击会落到一个两按钮确认页（同样不加载完整应用）。
+- webhook 通道（ntfy / Bark / Server酱）：国内无 FCM 环境的出路，Server酱可直达微信。
+
+**高级玩法**
+- 接力：一键让另一个 agent 接续本目录工作，自带交接简报。
+- 分叉：当前会话开出分支，携带全部历史，原会话不动。
+- 目标：设定完成条件，agent 持续工作直到达成。
+- 回滚：回滚对话或文件改动；Codex 侧可「从此处分叉」。
+- 收件箱汇总所有会话的待办；PWA 可添加到手机主屏。
+
+## 安全
+
+AnyPlane 的本质是把「在本机起会话」开放给能访问该端口的人，而起会话等价于任意命令执行——请认真对待监听地址。
+
+- 默认只监听 `127.0.0.1`（仅本机），这是安全默认值。
+- **绑定非回环地址（如 `0.0.0.0`）必须同时配置 `authToken`**，否则服务端拒绝启动。
+- 配置 token 后，启动时终端会打印带 token 的扫码 URL 二维码，手机扫码即入。
+- 跨网段访问不建议自建公网穿透；Tailscale funnel / Cloudflare Tunnel / IPv6+DDNS 三套免 VPS 配方见 [docs/public-access.md](docs/public-access.md)。
+
+## 配置
+
+配置文件 `anyplane.config.json`（项目根目录）或 `~/.anyplane/config.json`，均可选。最常用的几项：
+
+```json
+{
+  "port": 7480,
+  "host": "127.0.0.1",
+  "authToken": "change-me",
+  "permissionPolicy": "ask"
+}
+```
+
+- `permissionPolicy`：`"ask"`（默认，转发 UI 审批）| `"bypass"`（全自动，慎用）。
+- 推送通知需要 HTTPS 或 localhost；iOS 需先把站点添加到主屏幕再订阅。
+- 完整配置项、推送 webhook 通道、环境变量见 [docs/configuration.md](docs/configuration.md)；域名访问（80/443 网关）见 [docs/gateway.md](docs/gateway.md)。
+
+## 已知限制
+
+- 部分功能（如 /btw、目标）需要 Claude CLI ≥ 2.1.139。
+- **iOS 尚未真机实测过**：Web Push 代码路径按 Safari 的能力做了降级（通知按钮不可用时落确认页），但作者手上没有 iPhone。如果你试了——无论成不成——欢迎开 issue 告诉我们。
+- 回滚依赖文件检查点：compact 边界之前的消息不可回滚；Codex 无文件检查点，只能回滚对话或分叉。
+- Codex 不持久化推理过程，AnyPlane 以侧车文件补记（`~/.anyplane/reasoning/`）。
+- 运行数据目录 `~/.anyplane/` 不自动清理，由用户自行管理。
+- 界面文案目前只有简体中文，i18n 尚未落地。
+
+## 开发与贡献
+
+- 架构决策与开发约定见 [AGENTS.md](AGENTS.md)；发版流程见 [docs/releasing.md](docs/releasing.md)。
+- 长文本文档（调研/规划/审计）放 `docs/`，各子目录角色见 [docs/README.md](docs/README.md)；**入库文档不要描述本地仓库路径、密钥位置等机器相关信息**，确有需要写 `*.local.md`（不进 git）。
+- 端到端验证脚本在 `server/scripts/`（需服务端已启动，会真实调用 claude/codex CLI）。
+- 官方文档本地镜像：`bun run docs:claude` / `bun run docs:codex`，写入 gitignore 的 `docs/claude-code/` 与 `docs/codex/`。

--- a/cli/anyplane.mjs
+++ b/cli/anyplane.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * npm 包的 bin 入口。存在的唯一理由：npm 生态装的是 Node，而本项目跑在 Bun 上。
+ *
+ * 直接把 bin 指向 `#!/usr/bin/env bun` 的 .ts 时，没装 Bun 的机器上 npm shim 会抛
+ * 「'"bun"' 不是内部或外部命令」——既不说缺什么也不说怎么装，用户只能放弃。
+ * 目标用户多是 npm 装的 claude / codex CLI 过来的，没装 Bun 是常态而非例外。
+ *
+ * 已在 Bun 里跑时（bunx / bun 全局安装）直接 import，不套子进程——
+ * 多一层包装进程会吞 Ctrl+C，绕过 server.stop(true) 的子进程树清理（见 AGENTS.md）。
+ */
+import { existsSync, readFileSync } from 'node:fs'
+import { delimiter, join } from 'node:path'
+import { homedir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const isWin = process.platform === 'win32'
+
+/** PATH 逐项查找 + Bun 官方安装位置兜底（装完没重开终端时 PATH 还没生效） */
+function findBun() {
+  const names = isWin ? ['bun.exe', 'bun.cmd', 'bun'] : ['bun']
+  for (const dir of (process.env.PATH ?? '').split(delimiter)) {
+    if (!dir) continue
+    for (const name of names) {
+      const p = join(dir, name)
+      if (existsSync(p)) return p
+    }
+  }
+  const fallback = isWin ? join(homedir(), '.bun', 'bin', 'bun.exe') : join(homedir(), '.bun', 'bin', 'bun')
+  return existsSync(fallback) ? fallback : null
+}
+
+function missingBunMessage() {
+  // 首推 npm：能跑到这里说明 npm 一定可用，比让用户自己去挑官方安装脚本少一步判断
+  const official = isWin
+    ? 'powershell -c "irm bun.sh/install.ps1 | iex"'
+    : 'curl -fsSL https://bun.sh/install | bash'
+  return [
+    '',
+    'AnyPlane 需要 Bun 运行时（>= 1.4.0），当前没有找到。',
+    '',
+    '安装（任选其一）：',
+    '  npm install -g bun',
+    `  ${official}`,
+    '',
+    '装好后重新运行本命令即可。已装却仍报这个错，多半是终端 PATH 还没刷新——重开一个终端再试。',
+    '',
+    '说明：AnyPlane 服务端跑在 Bun 上（无框架，直接 Bun.serve）。这不影响你用 npm 装的',
+    'claude / codex CLI——AnyPlane 以子进程方式驱动它们，两者各用各的运行时。',
+    '',
+  ].join('\n')
+}
+
+if (typeof globalThis.Bun !== 'undefined') {
+  // 已在 Bun 运行时：直接交棒，行为与改造前逐字节一致（无子进程、无信号中转）
+  await import('./anyplane.ts')
+} else {
+  const args = process.argv.slice(2)
+
+  // 版本查询不需要 Bun：npx 探活很常见，不该因为缺 Bun 就问不出版本
+  if (args[0] === 'version' || args[0] === '--version' || args[0] === '-v') {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
+    console.log(`anyplane ${pkg.version}`)
+    process.exit(0)
+  }
+
+  const bun = findBun()
+  if (!bun) {
+    process.stderr.write(missingBunMessage())
+    process.exit(1)
+  }
+
+  const { spawn } = await import('node:child_process')
+  const entry = fileURLToPath(new URL('./anyplane.ts', import.meta.url))
+  const child = spawn(bun, [entry, ...args], { stdio: 'inherit', windowsHide: false })
+
+  // Ctrl+C 由终端直接送达子进程（共享 stdio）。父进程按住信号不退，
+  // 等子进程跑完自己的优雅关闭再跟随退出——抢先退出会让终端以为命令已经结束。
+  for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+    process.on(sig, () => {})
+  }
+  child.on('error', (err) => {
+    process.stderr.write(`[anyplane] 无法启动 Bun（${bun}）：${err.message}\n`)
+    process.exit(1)
+  })
+  child.on('exit', (code, signal) => {
+    process.exit(code ?? (signal ? 1 : 0))
+  })
+}

--- a/cli/anyplane.mjs
+++ b/cli/anyplane.mjs
@@ -18,16 +18,25 @@ const isWin = process.platform === 'win32'
 
 /** PATH 逐项查找 + Bun 官方安装位置兜底（装完没重开终端时 PATH 还没生效） */
 function findBun() {
-  const names = isWin ? ['bun.exe', 'bun.cmd', 'bun'] : ['bun']
+  // Windows 只认 .exe/.cmd：无扩展名的同名文件是 Git Bash 的 sh shim，Node 无法 spawn。
+  // .cmd 只是 cmd 包装（Node 直 spawn 抛 EINVAL），而 npm i -g bun 在 Windows 只生成 shim——
+  // 先按 npm 全局布局解析它背后的真实 exe，解析不到才退回 shim 本体，由调用方套 cmd.exe。
+  const names = isWin ? ['bun.exe', 'bun.cmd'] : ['bun']
+  let shim = null
   for (const dir of (process.env.PATH ?? '').split(delimiter)) {
     if (!dir) continue
     for (const name of names) {
       const p = join(dir, name)
-      if (existsSync(p)) return p
+      if (!existsSync(p)) continue
+      if (name === 'bun.exe') return p
+      const real = join(dir, 'node_modules', 'bun', 'bin', 'bun.exe')
+      if (existsSync(real)) return real
+      shim ??= p
     }
   }
   const fallback = isWin ? join(homedir(), '.bun', 'bin', 'bun.exe') : join(homedir(), '.bun', 'bin', 'bun')
-  return existsSync(fallback) ? fallback : null
+  if (existsSync(fallback)) return fallback
+  return shim
 }
 
 function missingBunMessage() {
@@ -72,7 +81,19 @@ if (typeof globalThis.Bun !== 'undefined') {
 
   const { spawn } = await import('node:child_process')
   const entry = fileURLToPath(new URL('./anyplane.ts', import.meta.url))
-  const child = spawn(bun, [entry, ...args], { stdio: 'inherit', windowsHide: false })
+  // .cmd shim 必须经 cmd.exe 承载（同 resolveClaudeCommand 的 /d /s /c 包装）；
+  // Windows 上 Ctrl+C 由控制台送达整个进程组，这层包装不会吞信号
+  const isCmdShim = isWin && bun.toLowerCase().endsWith('.cmd')
+  const spawnArgs = isCmdShim ? ['/d', '/s', '/c', bun, entry, ...args] : [entry, ...args]
+  const spawnCmd = isCmdShim ? 'cmd.exe' : bun
+  // spawn 对损坏的 exe 可能同步抛（Windows EFTYPE），与异步 error 事件走同一条报错路径
+  let child
+  try {
+    child = spawn(spawnCmd, spawnArgs, { stdio: 'inherit', windowsHide: false })
+  } catch (err) {
+    process.stderr.write(`[anyplane] 无法启动 Bun（${bun}）：${err.message}\n`)
+    process.exit(1)
+  }
 
   // Ctrl+C 由终端直接送达子进程（共享 stdio）。父进程按住信号不退，
   // 等子进程跑完自己的优雅关闭再跟随退出——抢先退出会让终端以为命令已经结束。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,6 +7,11 @@
 
 官方远程能力（Remote Control / claude.ai/code / codex remoteControl）对 **API-key 与 gateway 用户硬性禁用**
 （Remote Control 文档：订阅限定；v2.1.196 起 ANTHROPIC_BASE_URL 指向 gateway 即禁用）。
+**2026-09-12 复核仍成立且排除范围在扩大**：官方文档明确 Pro/Max/Team/Enterprise 订阅限定、
+API key 不支持、`claude setup-token` 的长期 OAuth 同样被拒（inference-only scope）、
+Bedrock / Google Cloud Agent Platform / Microsoft Foundry 均不可用；v2.1.196 起连指向
+非 `api.anthropic.com` 的本地透明代理也一并禁用（此前该配置尚可工作）。
+上游 issue #50977 是被排除用户的公开诉求，已被官方回绝——本文档所有方向的前提由此成立。
 AnyPlane 是这群用户的控制面：本地优先、provider 中立、双供应商。以下方向都服务于这个定位，
 不追官方云能力（云同步/E2EE/多设备），不与官方 TUI（agent view）赛跑 UI。
 
@@ -27,17 +32,43 @@ AnyPlane 是这群用户的控制面：本地优先、provider 中立、双供�
   ntfy http action 真一键审批，Bark/Server酱 落 `GET /api/approval-page` 确认页（防预览误触）；
   webhook 能力密钥 = HMAC(vapid 私钥, 渠道标识) 派生，不落新状态。验证：`server/src/push.test.ts`
   webhook 段 7 项单测 + 真实服务端 mock 渠道活体全链路（审批 fanout/按钮 POST/确认页/done 扇出）。
-- iOS 实测：需 PWA 加到主屏幕后订阅；图标已备 PNG（icon-192/512）。
+- ~~iOS 实测~~ → **平台能力已查证并落降级（2026-09-12）**：Safari（iOS 与 macOS）**完全忽略**
+  notification `actions`，且不实现 `Notification.maxActions`（caniuse：iOS Safari 至 26.6 仍
+  Not supported；Apple Web Push 文档：通知表面只保留 title/body/tag/data，图标固定为 Web App 自身图标）。
+  按钮在 iPhone 上根本不渲染——**「锁屏一键审批」这条核心卖点在 iOS Web Push 上不成立**，
+  用户只看到「需要审批」却找不到怎么批。152 之前的 Firefox 桌面同理。
+  `sw.js` 已按 `maxActions` 运行时探测降级（**不靠 UA**：iOS 上任何浏览器壳都是 WebKit）：
+  不支持时不挂按钮、裁决入口折进 body、`notificationclick` 直达 `GET /api/approval-page` 确认页
+  而非完整应用壳。**零服务端改动**——`validSecret` 本就同时接受订阅密钥与 webhook 密钥，
+  直接复用 approval-action 上已补全的能力密钥即可。单测锁死两条分支（`web/src/sw.test.ts`，
+  放 src 而非 public 旁边：public 会被原样拷进 `web/dist`）。
+  能力矩阵：Android/桌面 Chrome 一步（通知按钮），iOS/旧 Firefox 两步（通知 → 确认页）。
+  **仍未做**：真机实测（作者无 iPhone；README 与官网已明示，本身作为征集反馈的钩子）。
+  **iOS 上要回到一步审批只有一条路——方向二的原生壳**，见下。
 
 ## 方向二：App 壳（Capacitor，不换技术栈）
 
 **定论**：不做 RN 重写（代码翻倍、维护翻倍，happy 的路线不是我们的路线）；
 用 **Capacitor 套壳现有 PWA** 打出 iOS/Android 原生包——日常开发仍是写 React，新增的只是构建链。
 
-**价值**：
-- App Store / Google Play 上架 = 分发实体（项目里程碑性质的目标）
-- 原生推送（APNs/FCM 插件）比 Web Push 更可靠，方向一可以先在壳内落地
+**价值**（2026-09-12 重排：第一条从「更可靠」这种软论据换成了硬论据，本方向优先级随之上调）：
+- **iOS 上恢复一步审批的唯一路径**。iOS 原生通知**支持**按钮（`UNNotificationCategory` +
+  `UNNotificationAction`）：Capacitor 侧用 `LocalNotifications.registerActionTypes` 在启动时注册
+  category，推送 payload 的 `aps.category` 带上同一标识符，系统即渲染按钮，点击经
+  `pushNotificationActionPerformed` 回传 `actionId`（`PushNotifications` 插件本身没有 action API，
+  但 category 机制跨插件通用——实施时先验证插件版本的可靠性，必要时补原生 delegate）。
+  方向一的降级只把 iOS 从「做不到」救到「两步」；**回到一步必须走原生壳**。
+  对一个把锁屏审批当核心卖点的项目，这条从「里程碑性质的目标」升级为「核心卖点的补全」。
+- App Store / Google Play 上架 = 分发实体
 - 分享面板、生物识别锁（可选）等原生能力解锁
+
+**信任面取舍（必须记下来，否则将来会重新论证一遍）**：
+iOS 的 Web Push 本来就走 APNs，换原生壳**不新增**第三方——这一点不构成阻碍。
+真正的变化是载荷可见性：Web Push 是 aes128gcm 端到端加密的（Apple 读不到正文），
+原生 APNs 推送的载荷 Apple 可读。审批通知的内容只有工具名 + 命令摘要 + 项目名，
+且 ntfy/Bark/Server酱 通道本来就是渠道可读（见 `push.ts` 的 webhook 段注释），
+故该取舍可接受；但**能力 URL 里的 secret 绝不能进 APNs 明文载荷**——
+原生壳应改为推送只带 requestId，客户端持长期凭据回连本机裁决。
 
 **步骤草拟**：
 1. `bun add @capacitor/core @capacitor/cli`，`npx cap init`（构建产物指向 `web/dist`）
@@ -273,6 +304,78 @@ Claude 侧有 `generate_session_title` 自动标题（2026-08-27 已接入），
 **暂不做的原因**：标题质量依赖一次额外问答（每新线程几百 token 成本），且 fork 问答
 在 turn 刚结束时与主线程共享进程管道、可能撞上用户的连续输入；先观察上游是否补齐。
 若做，必须复用现有 collector 超时/拒绝路径，不为标题引入新状态机。
+
+## 方向十：UI 国际化（i18n）
+
+**立项背景（2026-09-12）**：此前 UI 只有简体中文是可接受的——README 也是中文，受众一致。
+2026-09-12 把 `README.md` 换成英文（中文移至 `README.zh-CN.md`）之后，**断层是我们自己制造的**：
+官网英文、npm description 英文、README 英文、Show HN 稿英文，装上打开却是全中文界面。
+英文用户读完英文文档再撞上中文 UI，落差比过去全中文时更刺眼。
+
+**现状**：`web/src` 约 18,344 个中文字符，无任何 i18n 框架；另有硬编码 locale
+（`ChatHeader.tsx` 的 `toLocaleTimeString('zh-CN')`）。服务端 API 错误是英文短码、
+启动日志中英混合、`approvalPageHtml`（webhook/iOS 降级确认页）是中文——**确认页优先级高于主界面**，
+它是 iOS 与 webhook 用户唯一会看到的服务端渲染页面。
+
+**定论**：
+- **不引 i18next / react-intl**。零第三方依赖是本仓库的既定约束（见 `log.ts` 的同款决策）；
+  一个 `key → { en, zh }` 的扁平 map + 语言检测 + `t()` 足够，
+  官网 `site/index.html` 的三语内联字典就是现成的形制参考。
+- 语言检测顺序：显式设置（localStorage）> `navigator.language` > en。
+  **默认英文**——中文用户会主动切，英文用户不会找切换入口。
+- 抽取按可见度排序：确认页 → 审批卡与错误文案 → 会话列表 → 详情抽屉 → 低频面板。
+
+**排期约束（重要）**：**放在拿到第一批英文反馈之后**，不要提前做。
+18K 字符的抽取是纯体力活，为一个还没人用的界面做翻译是典型的沉没成本。
+先发布、先看有没有英文用户真的装上，再决定抽取范围。
+
+## 方向十一：分发与首次上手补完
+
+**立项背景**：生态研究的 Phase 1 清单里，功能性主项（审批规则引擎）已交付，
+剩余项**全部是分发与首次上手类**——与 2026-09-12 实测出的三个卡点同源，
+独立佐证了「瓶颈在可达性而非能力」。这一类此前只存在于研究库的 CHANGELOG，
+主仓库排期文档里没有位置，故立此方向。
+
+**已交付（2026-09-12）**：
+- npm bin 改 Node launcher（`cli/anyplane.mjs`）。原 bin 指向 `#!/usr/bin/env bun` 的 `.ts`，
+  没装 Bun 的机器上 npm shim 只抛 `'"bun"' 不是内部或外部命令`——不说缺什么也不说怎么装。
+  目标用户多是 npm 装 claude/codex CLI 过来的，**没装 Bun 是常态而非例外**。
+  **红线**：已在 Bun 运行时必须直接 `import` 不套子进程——多一层包装会吞 Ctrl+C，
+  绕过 `server.stop(true)` 的子进程树清理（见 AGENTS.md 的 Windows 注意事项）。
+  改造后 `bunx` 路径行为与改造前逐字节一致，回归面只有 Node 路径。
+- README 英文化与中文分离；官网 iOS 表述分平台化、Bun 门槛同步全平台 ≥ 1.4.0。
+
+**待排期**：
+- **Dockerfile**（优先级最高）：单阶段 Bun 镜像 + 双 CLI，挂载 `~/.anyplane` 与 CLI 凭证卷，
+  入口命令与 `bunx anyplane` 一致。对自托管人群是标配，且顺带绕开 Bun 门槛。
+- **双后端登录状态页**：Claude 走 `initialize.account` 或配置目录探测，Codex 走 `account/read`
+  或等效 RPC；列表页展示「Claude 已登录 / Codex 未登录 / API-key 组织用户」。
+  降低首次使用门槛——当前 CLI 未登录时的失败表现为会话起不来，用户不知道该去登录哪个。
+- **公网配方一键脚本**：封装 `docs/public-access.md` 三套配方的最小启动命令，
+  脚本只负责隧道创建与反代，不碰账号体系（保住「不依赖第三方账号」的底线）。
+- **待评估：把 `bun` 放进 `optionalDependencies`**，让 `npx anyplane` 彻底零门槛。
+  代价是包体积从当前量级涨到约 90MB。**先用 launcher 收集数据再决定**——
+  如果安装失败反馈消失，说明一行安装提示已经够了，不必付这个体积。
+
+## 方向十二：上量前的运行韧性与下一轮技术债
+
+**定论**：这些都不是当前痛点，但**全部会在有真实用户之后同时爆发**，
+且届时修复成本远高于现在。不提前做，但要在发布后按用户增长节奏还。
+
+- **全局异常兜底（缺失）**：服务端没有 `uncaughtException` / `unhandledRejection` 处理器。
+  `index.ts` 已有 SIGINT/SIGTERM 优雅退出、EADDRINUSE 自接管，唯独未捕获的 Promise 拒绝
+  会让用户看到「服务突然没了」却拿不到任何可上报的信息。单人维护尤其需要这层——
+  它决定了用户报 bug 时能不能附上有用的东西。**这项成本最低、收益最直接，可以先做。**
+- **下一个上帝文件：`backends/codex/runtime.ts`（约 1,349 行）**。方向六解耦了 `index.ts`
+  与 `Chat.tsx`，但 codex 的 RPC、历史双轨、streaming、子代理路由仍堆在一个文件里，
+  是全仓最大单体与最大回归风险源。拆分口径沿用方向六：先抽纯函数与协议翻译，
+  再切生命周期，**绝不与行为改动混杂**。
+- **零单测的编排层**：`index.ts`、全部 `routes/`、大部分 `hub/` 共 18 个生产文件无同名 test，
+  目前只由 e2e 脚本间接覆盖，而 e2e 不进 CI（需真实 CLI 与模型）。
+  用户上量后这里是回归重灾区。补测优先级：`routes/` > `hub/` > `index.ts`（装配层最难测、收益也最低）。
+- **会话列表的 O(n) 隐患**：列表端点每 10 秒轮询触发全盘 `listSessions()`，
+  缓存未命中时是 O(会话数 × 文件大小)。会话数达数百后开始劣化。
+  **等真实抱怨出现再改增量刷新**——提前优化会把一个简单端点变复杂。
 
 ## 已验证但暂不做的（决策记录）
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "bin": {
-    "anyplane": "cli/anyplane.ts"
+    "anyplane": "cli/anyplane.mjs"
   },
   "files": [
     "cli",

--- a/site/index.html
+++ b/site/index.html
@@ -295,8 +295,8 @@
       <h1 data-i18n="h1">Run your agents,<br><em>on any plane.</em></h1>
       <p class="lede" data-i18n="lede">
         Let the agents run — <strong>go live your life.</strong>
-        When Claude Code or Codex needs you, a push notification lands on your lock screen
-        with the ruling buttons already on it.
+        When Claude Code or Codex needs you, the approval lands on your lock screen —
+        clear it there and get back to what you were doing.
       </p>
       <div class="install">
         <span class="cmd"><span class="dollar">$</span> bunx anyplane
@@ -339,7 +339,7 @@
         <div class="gate-card">
           <span class="gate-tag">GATE B</span>
           <h3 data-i18n="gateB.h">Clearance from the lock screen</h3>
-          <p data-i18n="gateB.p">Approvals arrive as push notifications you can rule on without opening the page — capability URLs carry a one-tap secret. Web Push, ntfy, Bark and Server酱 channels included.</p>
+          <p data-i18n="gateB.p">Approvals arrive as push notifications carrying a one-tap capability secret. On Android and desktop Chrome you rule straight from the notification buttons; iOS ignores notification actions, so there the tap opens a two-button confirm page instead — either way you never load the full app. Web Push, ntfy, Bark and Server酱 channels included.</p>
         </div>
         <div class="gate-card">
           <span class="gate-tag">GATE C</span>
@@ -372,7 +372,7 @@
           <h3 data-i18n="step1.h">Run it</h3>
           <pre data-i18n="step1.pre"><span class="c"># one command, front-end prebuilt (via bunx)</span>
 bunx anyplane
-<span class="c"># or straight from npm (Bun still required on PATH)</span>
+<span class="c"># or from npm — it tells you how to get Bun if it's missing</span>
 npm i -g anyplane</pre>
         </div>
         <div class="step">
@@ -382,7 +382,7 @@ npm i -g anyplane</pre>
 <span class="c"># LAN access always requires a token.</span></pre>
         </div>
       </div>
-      <p class="req" data-i18n="req">REQUIRES — Bun ≥ 1.3.13 (Windows ≥ 1.4.0) · claude and/or codex CLI on PATH, logged in</p>
+      <p class="req" data-i18n="req">REQUIRES — Bun ≥ 1.4.0 · claude and/or codex CLI on PATH, logged in</p>
     </div>
   </section>
 </main>
@@ -405,7 +405,7 @@ npm i -g anyplane</pre>
       'meta.title': 'AnyPlane — Run your agents, on any plane',
       'eyebrow': 'SELF-HOSTED · NO ACCOUNT · MIT',
       'h1': 'Run your agents,<br><em>on any plane.</em>',
-      'lede': 'Let the agents run — <strong>go live your life.</strong> When Claude Code or Codex needs you, a push notification lands on your lock screen with the ruling buttons already on it.',
+      'lede': 'Let the agents run — <strong>go live your life.</strong> When Claude Code or Codex needs you, the approval lands on your lock screen — clear it there and get back to what you were doing.',
       'scrollcue': 'SCROLL',
       'boardcap': 'Your agents keep working while you\'re away. <strong>The board comes to your pocket</strong> — approve, deny, or just watch.',
       'proof.cap': 'THE TOWER, LIVE',
@@ -416,7 +416,7 @@ npm i -g anyplane</pre>
       'gateA.h': 'One tower, two runtimes',
       'gateA.p': 'Claude Code and Codex share a single structured message boundary. Approve, rewind, branch, hand off between agents — the same gestures for both, with zero frontend forks.',
       'gateB.h': 'Clearance from the lock screen',
-      'gateB.p': 'Approvals arrive as push notifications you can rule on without opening the page — capability URLs carry a one-tap secret. Web Push, ntfy, Bark and Server酱 channels included.',
+      'gateB.p': 'Approvals arrive as push notifications carrying a one-tap capability secret. On Android and desktop Chrome you rule straight from the notification buttons; iOS ignores notification actions, so there the tap opens a two-button confirm page instead — either way you never load the full app. Web Push, ntfy, Bark and Server酱 channels included.',
       'gateC.h': 'Your tower, your rules',
       'gateC.p': 'Self-hosted and vendor-neutral. Transcripts stay on disk, tokens stay local, no account, no relay. Works with API-key and gateway setups the official remotes exclude.',
       'sec.manual': 'FLIGHT MANUAL — WHAT THE PROTOCOL DEPTH BUYS',
@@ -430,17 +430,17 @@ npm i -g anyplane</pre>
       'm4': 'VAPID (RFC 8292) and aes128gcm payloads (RFC 8291) implemented in-house — no push SDK, no third party reading your approvals.',
       'sec.takeoff': 'TAKEOFF',
       'step1.h': 'Run it',
-      'step1.pre': '<span class="c"># one command, front-end prebuilt (via bunx)</span>\nbunx anyplane\n<span class="c"># or straight from npm (Bun still required on PATH)</span>\nnpm i -g anyplane',
+      'step1.pre': '<span class="c"># one command, front-end prebuilt (via bunx)</span>\nbunx anyplane\n<span class="c"># or from npm — it tells you how to get Bun if it\'s missing</span>\nnpm i -g anyplane',
       'step2.h': 'Configure (optional)',
       'step2.pre': '<span class="c"># ~/.anyplane/config.json</span>\n{ "host": "0.0.0.0", "authToken": "long-random" }\n<span class="c"># LAN access always requires a token.</span>',
-      'req': 'REQUIRES — Bun ≥ 1.3.13 (Windows ≥ 1.4.0) · claude and/or codex CLI on PATH, logged in',
+      'req': 'REQUIRES — Bun ≥ 1.4.0 · claude and/or codex CLI on PATH, logged in',
       'footer': 'MIT · FORMERLY CC-REMOTE',
     },
     'zh-CN': {
       'meta.title': 'AnyPlane — 你的 Agent，随地起降。',
       'eyebrow': '自托管 · 无账号 · MIT',
       'h1': '你的 Agent，<br><em>随地起降。</em>',
-      'lede': '让 agent 跑着任务，<strong>你去生活。</strong>Claude Code 或 Codex 需要你时，推送通知落上锁屏，裁决按钮就在通知上。',
+      'lede': '让 agent 跑着任务，<strong>你去生活。</strong>Claude Code 或 Codex 需要你时，审批落上锁屏——就地放行，然后继续手头的事。',
       'scrollcue': '下滑',
       'boardcap': '你不在电脑前，agent 照样干活。<strong>大屏装进你的口袋</strong>——批准、拒绝，或者只是看着。',
       'proof.cap': '塔台实况',
@@ -451,7 +451,7 @@ npm i -g anyplane</pre>
       'gateA.h': '一座塔台，两种运行时',
       'gateA.p': 'Claude Code 与 Codex 共享同一条结构化消息边界。审批、回滚、分叉、接力——两个 agent 用同一套手势，前端零分叉。',
       'gateB.h': '锁屏上直接放行',
-      'gateB.p': '审批以推送通知送达，无需打开页面即可裁决——能力 URL 携带一次性密钥。内置 Web Push、ntfy、Bark 与 Server酱通道。',
+      'gateB.p': '审批以推送通知送达，能力 URL 携带一次性密钥。Android 与桌面 Chrome 直接按通知上的按钮裁决；iOS 不支持通知按钮，点击改为打开一个两按钮确认页——两种路径都不需要加载完整应用。内置 Web Push、ntfy、Bark 与 Server酱通道。',
       'gateC.h': '你的塔台，你的规则',
       'gateC.p': '自托管、厂商中立。transcript 留在本地磁盘，token 留在本机，没有账号、没有中转。官方遥控排除的 API-key 与网关方案，这里照用。',
       'sec.manual': '飞行手册 — 协议深度换来了什么',
@@ -465,17 +465,17 @@ npm i -g anyplane</pre>
       'm4': 'VAPID（RFC 8292）与 aes128gcm 载荷（RFC 8291）全部自实现——不用推送 SDK，没有第三方读得到你的审批。',
       'sec.takeoff': '起飞',
       'step1.h': '跑起来',
-      'step1.pre': '<span class="c"># 一条命令，前端已预构建（经 bunx）</span>\nbunx anyplane\n<span class="c"># 或直接从 npm 安装（仍需 PATH 中有 Bun）</span>\nnpm i -g anyplane',
+      'step1.pre': '<span class="c"># 一条命令，前端已预构建（经 bunx）</span>\nbunx anyplane\n<span class="c"># 或从 npm 安装——缺 Bun 时会告诉你怎么装</span>\nnpm i -g anyplane',
       'step2.h': '配置（可选）',
       'step2.pre': '<span class="c"># ~/.anyplane/config.json</span>\n{ "host": "0.0.0.0", "authToken": "long-random" }\n<span class="c"># 局域网访问必须配置 token。</span>',
-      'req': '运行要求 — Bun ≥ 1.3.13（Windows ≥ 1.4.0）· PATH 中有已登录的 claude 和/或 codex CLI',
+      'req': '运行要求 — Bun ≥ 1.4.0 · PATH 中有已登录的 claude 和/或 codex CLI',
       'footer': 'MIT · 前身 CC-REMOTE',
     },
     'zh-TW': {
       'meta.title': 'AnyPlane — 你的 Agent，隨地起降。',
       'eyebrow': '自託管 · 無帳號 · MIT',
       'h1': '你的 Agent，<br><em>隨地起降。</em>',
-      'lede': '讓 agent 跑著任務，<strong>你去生活。</strong>Claude Code 或 Codex 需要你時，推播通知落上鎖定畫面，裁決按鈕就在通知上。',
+      'lede': '讓 agent 跑著任務，<strong>你去生活。</strong>Claude Code 或 Codex 需要你時，審批落上鎖定畫面——就地放行，然後繼續手頭的事。',
       'scrollcue': '下滑',
       'boardcap': '你不在電腦前，agent 照樣工作。<strong>大屏裝進你的口袋</strong>——批准、拒絕，或者只是看著。',
       'proof.cap': '塔台實況',
@@ -486,7 +486,7 @@ npm i -g anyplane</pre>
       'gateA.h': '一座塔台，兩種執行環境',
       'gateA.p': 'Claude Code 與 Codex 共用同一條結構化訊息邊界。審批、回溯、分叉、接力——兩個 agent 用同一套手勢，前端零分叉。',
       'gateB.h': '鎖定畫面直接放行',
-      'gateB.p': '審批以推播通知送達，無需開啟頁面即可裁決——能力 URL 攜帶一次性金鑰。內建 Web Push、ntfy、Bark 與 Server醬通道。',
+      'gateB.p': '審批以推播通知送達，能力 URL 攜帶一次性金鑰。Android 與桌面 Chrome 直接按通知上的按鈕裁決；iOS 不支援通知按鈕，點擊改為開啟一個兩按鈕確認頁——兩種路徑都不需要載入完整應用。內建 Web Push、ntfy、Bark 與 Server醬通道。',
       'gateC.h': '你的塔台，你的規則',
       'gateC.p': '自託管、廠商中立。transcript 留在本機磁碟，token 留在本機，沒有帳號、沒有中繼。官方遙控排除的 API-key 與閘道方案，這裡照用。',
       'sec.manual': '飛行手冊 — 協定深度換來了什麼',
@@ -500,10 +500,10 @@ npm i -g anyplane</pre>
       'm4': 'VAPID（RFC 8292）與 aes128gcm 酬載（RFC 8291）全部自行實作——不用推播 SDK，沒有第三方讀得到你的審批。',
       'sec.takeoff': '起飛',
       'step1.h': '跑起來',
-      'step1.pre': '<span class="c"># 一條指令，前端已預建置（經 bunx）</span>\nbunx anyplane\n<span class="c"># 或直接從 npm 安裝（仍需 PATH 中有 Bun）</span>\nnpm i -g anyplane',
+      'step1.pre': '<span class="c"># 一條指令，前端已預建置（經 bunx）</span>\nbunx anyplane\n<span class="c"># 或從 npm 安裝——缺 Bun 時會告訴你怎麼裝</span>\nnpm i -g anyplane',
       'step2.h': '設定（可選）',
       'step2.pre': '<span class="c"># ~/.anyplane/config.json</span>\n{ "host": "0.0.0.0", "authToken": "long-random" }\n<span class="c"># 區網存取必須設定 token。</span>',
-      'req': '執行需求 — Bun ≥ 1.3.13（Windows ≥ 1.4.0）· PATH 中有已登入的 claude 和/或 codex CLI',
+      'req': '執行需求 — Bun ≥ 1.4.0 · PATH 中有已登入的 claude 和/或 codex CLI',
       'footer': 'MIT · 前身 CC-REMOTE',
     },
   };

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -6,6 +6,30 @@ self.addEventListener('fetch', () => {})
 
 // ---------- Web Push ----------
 
+/** 通知按钮可用性。Safari（iOS 与 macOS）完全忽略 actions 数组，Firefox 桌面 152 之前同样不支持，
+ *  两者都不实现 Notification.maxActions——探测不到就按「没有按钮」走降级路径。
+ *  不能靠 UA 判断：这是能力差异，且 iOS 上任何浏览器壳都是 WebKit。 */
+function maxActions() {
+  const n = self.Notification
+  return n && typeof n.maxActions === 'number' ? n.maxActions : 0
+}
+
+/** 降级落点：把审批能力 URL 换成同 secret 的 GET 确认页（服务端 validSecret 同时认订阅密钥与
+ *  webhook 密钥，故无需服务端改动）。GET 只渲染不执行，链接被预览抓取也不会误触裁决。 */
+function approvalPageUrl(actions) {
+  if (!actions || !actions.allow) return undefined
+  try {
+    const u = new URL(actions.allow, self.location.origin)
+    const k = u.searchParams.get('k') || ''
+    const r = u.searchParams.get('r') || ''
+    const s = u.searchParams.get('s') || ''
+    if (!k || !r || !s) return undefined
+    return `/api/approval-page?k=${encodeURIComponent(k)}&r=${encodeURIComponent(r)}&s=${encodeURIComponent(s)}`
+  } catch {
+    return undefined
+  }
+}
+
 // payload 形状见 server/src/push.ts 的 PushPayload
 self.addEventListener('push', (e) => {
   if (!e.data) return
@@ -15,22 +39,25 @@ self.addEventListener('push', (e) => {
   } catch {
     return
   }
+  const isApproval = p.type === 'approval' && !!p.actions
+  const canAct = isApproval && maxActions() >= 2
+  const page = isApproval && !canAct ? approvalPageUrl(p.actions) : undefined
   const opts = {
-    body: p.body ?? '',
+    // 无按钮时把裁决入口折进正文——否则 iOS 用户只看到「需要审批」却找不到怎么批
+    body: page ? `${p.body ?? ''}\n（点击本通知前往审批）` : (p.body ?? ''),
     icon: '/icon-192.png',
     badge: '/icon-192.png',
     tag: p.tag ?? `ccr-${Date.now()}`,
     renotify: p.type === 'approval',
-    requireInteraction: p.type === 'approval', // 审批通知常驻直到用户处理
-    data: { key: p.key, requestId: p.requestId, actions: p.actions },
+    requireInteraction: p.type === 'approval', // 审批通知常驻直到用户处理（Safari 忽略，由系统托管）
+    data: { key: p.key, requestId: p.requestId, actions: p.actions, page },
     // 审批通知带直接裁决按钮（通知栏上完成审批，不打开页面）
-    actions:
-      p.type === 'approval' && p.actions
-        ? [
-            { action: 'allow', title: '✓ 允许' },
-            { action: 'deny', title: '✗ 拒绝' },
-          ]
-        : [],
+    actions: canAct
+      ? [
+          { action: 'allow', title: '✓ 允许' },
+          { action: 'deny', title: '✗ 拒绝' },
+        ]
+      : [],
   }
   e.waitUntil(self.registration.showNotification(p.title ?? 'AnyPlane', opts))
 })
@@ -59,8 +86,9 @@ self.addEventListener('notificationclick', (e) => {
     return
   }
 
-  // 普通点击：聚焦已有窗口，否则打开深链直达会话
-  const target = data.key ? `/#s=${encodeURIComponent(data.key)}` : '/'
+  // 无按钮平台的审批点击：直达轻量确认页而非整个应用壳——少一次前端加载与路由，
+  // 两步（点通知 → 按允许）的体感接近一键。普通通知仍走深链回会话。
+  const target = data.page ?? (data.key ? `/#s=${encodeURIComponent(data.key)}` : '/')
   e.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((list) => {
       for (const c of list) {

--- a/web/src/sw.test.ts
+++ b/web/src/sw.test.ts
@@ -1,0 +1,145 @@
+// sw.js 的审批通知分支测试。放在 src 下而非 public 旁边：public 会被原样拷进 web/dist，
+// 测试文件不能进生产构建。sw.js 仍是唯一正本，这里读源码在 stub 过的 self 上执行。
+//
+// 被锁住的行为：Safari（iOS/macOS）与旧 Firefox 桌面忽略通知 actions，按钮路径在这些平台
+// 必须降级为「点击直达 GET 确认页」，否则用户看到「需要审批」却无从裁决。
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SW_SRC = readFileSync(join(import.meta.dir, '..', 'public', 'sw.js'), 'utf8')
+
+const ORIGIN = 'http://localhost:7480'
+const ACTIONS = {
+  allow: '/api/approval-action?k=s%7Cslug%7Csid&r=req-1&d=allow&s=cap-secret',
+  deny: '/api/approval-action?k=s%7Cslug%7Csid&r=req-1&d=deny&s=cap-secret',
+}
+
+interface Shown {
+  title: string
+  opts: {
+    body: string
+    actions: Array<{ action: string; title: string }>
+    data: { key?: string; requestId?: string; actions?: typeof ACTIONS; page?: string }
+  }
+}
+
+/** 在 stub 的 self 上执行 sw.js，返回事件处理器与通知收集器。
+ *  maxActions 传 undefined 模拟 Safari（属性不存在），传数字模拟 Chromium。 */
+function loadSw(maxActions: number | undefined) {
+  const handlers: Record<string, (e: unknown) => void> = {}
+  const shown: Shown[] = []
+  const opened: string[] = []
+  const self_ = {
+    addEventListener: (type: string, h: (e: unknown) => void) => {
+      handlers[type] = h
+    },
+    Notification: maxActions === undefined ? {} : { maxActions },
+    location: { origin: ORIGIN },
+    registration: {
+      showNotification: (title: string, opts: Shown['opts']) => {
+        shown.push({ title, opts })
+      },
+    },
+    clients: {
+      claim: () => {},
+      matchAll: async () => [],
+      openWindow: async (u: string) => {
+        opened.push(u)
+      },
+    },
+  }
+  new Function('self', SW_SRC)(self_)
+  return { handlers, shown, opened }
+}
+
+function pushEvent(payload: unknown) {
+  return { data: { json: () => payload }, waitUntil: (p: unknown) => p }
+}
+
+const APPROVAL_PAYLOAD = {
+  type: 'approval',
+  title: '需要审批 · Bash',
+  body: 'anyplane｜git status',
+  key: 's|slug|sid',
+  requestId: 'req-1',
+  actions: ACTIONS,
+  tag: 'ccr-a-req-1',
+}
+
+describe('sw.js 审批通知：支持按钮的平台（Chromium）', () => {
+  test('挂载 allow/deny 按钮，body 不加引导，data.page 不生成', () => {
+    const { handlers, shown } = loadSw(2)
+    handlers.push!(pushEvent(APPROVAL_PAYLOAD))
+    expect(shown).toHaveLength(1)
+    const { opts } = shown[0]!
+    expect(opts.actions.map((a) => a.action)).toEqual(['allow', 'deny'])
+    expect(opts.body).toBe('anyplane｜git status')
+    expect(opts.data.page).toBeUndefined()
+  })
+})
+
+describe('sw.js 审批通知：忽略按钮的平台（Safari / 旧 Firefox 桌面）', () => {
+  test('不挂按钮，body 折入引导，data.page 指向同 secret 的 GET 确认页', () => {
+    const { handlers, shown } = loadSw(undefined)
+    handlers.push!(pushEvent(APPROVAL_PAYLOAD))
+    const { opts } = shown[0]!
+    expect(opts.actions).toEqual([])
+    expect(opts.body).toContain('点击本通知前往审批')
+    // 复用 approval-action 的能力密钥：validSecret 同时认订阅密钥与 webhook 密钥
+    const page = new URL(opts.data.page!, ORIGIN)
+    expect(page.pathname).toBe('/api/approval-page')
+    expect(page.searchParams.get('k')).toBe('s|slug|sid')
+    expect(page.searchParams.get('r')).toBe('req-1')
+    expect(page.searchParams.get('s')).toBe('cap-secret')
+    // 确认页是 GET 渲染页，绝不能把裁决动作带进 URL（链接被预览抓取即误触）
+    expect(page.searchParams.get('d')).toBeNull()
+  })
+
+  test('maxActions 为 1 时同样降级（按钮位不够放 allow+deny）', () => {
+    const { handlers, shown } = loadSw(1)
+    handlers.push!(pushEvent(APPROVAL_PAYLOAD))
+    expect(shown[0]!.opts.actions).toEqual([])
+    expect(shown[0]!.opts.data.page).toBeTruthy()
+  })
+
+  test('点击降级通知时打开确认页，而不是应用深链', async () => {
+    const { handlers, shown, opened } = loadSw(undefined)
+    handlers.push!(pushEvent(APPROVAL_PAYLOAD))
+    const data = shown[0]!.opts.data
+    const waits: Promise<unknown>[] = []
+    handlers.notificationclick!({
+      notification: { data, close: () => {} },
+      action: '',
+      waitUntil: (p: Promise<unknown>) => waits.push(p),
+    })
+    await Promise.all(waits)
+    expect(opened).toHaveLength(1)
+    expect(opened[0]).toContain('/api/approval-page')
+  })
+})
+
+describe('sw.js 非审批通知不受降级影响', () => {
+  test('done 通知在任何平台都不生成确认页，点击回会话深链', async () => {
+    const { handlers, shown, opened } = loadSw(undefined)
+    handlers.push!(pushEvent({ type: 'done', title: '✓ 完成', body: '会话已空闲', key: 'x|t1', tag: 'ccr-d' }))
+    const { opts } = shown[0]!
+    expect(opts.data.page).toBeUndefined()
+    expect(opts.body).toBe('会话已空闲')
+    const waits: Promise<unknown>[] = []
+    handlers.notificationclick!({
+      notification: { data: opts.data, close: () => {} },
+      action: '',
+      waitUntil: (p: Promise<unknown>) => waits.push(p),
+    })
+    await Promise.all(waits)
+    expect(opened[0]).toBe(`/#s=${encodeURIComponent('x|t1')}`)
+  })
+
+  test('能力 URL 缺字段时不生成确认页，退回深链（不构造半截 URL）', () => {
+    const { handlers, shown } = loadSw(undefined)
+    handlers.push!(pushEvent({ ...APPROVAL_PAYLOAD, actions: { allow: '/api/approval-action?k=a', deny: '' } }))
+    expect(shown[0]!.opts.data.page).toBeUndefined()
+    expect(shown[0]!.opts.body).toBe('anyplane｜git status')
+  })
+})


### PR DESCRIPTION
## 为什么是这三件

不是功能缺失，是「想用的人用不上」。当前外部指标：91 star / 0 fork / **0 条外部 issue** / npm 近一周日均 4.4 次下载（30 天中 4 天为 0，三个尖峰全落在发版日，是镜像站抓取）。star 说明定位有吸引力，0 issue 说明这批流量没有一个转化成可用的安装。

这三项都是本次实测复现的，都在「从看到到跑起来」这条路径上。

## 1. 没有 Bun 的机器上 `npx anyplane` 直接失败

**复现**：把 PATH 里的 bun 移除后 `npx anyplane@latest --version`，全部输出是

```
'"bun"' 不是内部或外部命令，也不是可运行的程序或批处理文件。
```

根因是 bin 指向 `#!/usr/bin/env bun` 的 `.ts`。这个损失是结构性的：Claude Code 自身用 `npm i -g` 安装，目标用户 100% 有 Node，其中装了 Bun 的是少数。他们看到项目的第一反应是 `npx anyplane`，然后收到一句看不懂的报错——连开 issue 的动机都没有。

**改法**：bin 换成零依赖的 Node launcher。

关键取舍是**已在 Bun 运行时就直接 `import`，不套子进程**。多一层包装进程会吞 Ctrl+C，绕过 `server.stop(true)` 的子进程树清理（AGENTS.md 的 Windows 红线）。所以 `bunx anyplane` 这条主路径行为与改造前逐字节一致，回归面只有 Node 路径。Node 下 spawn 时用 `stdio: 'inherit'` 让终端直接把 Ctrl+C 送到子进程，父进程按住信号等子进程走完优雅关闭再跟随退出。

找不到 Bun 时首推 `npm i -g bun`——能跑到这里说明 npm 必然可用。

## 2. 「锁屏一键审批」在 iPhone 上不成立

`sw.js` 此前无条件给审批通知挂 allow/deny 按钮，但 **Safari（iOS 与 macOS）完全忽略 notification `actions`**，且不实现 `Notification.maxActions`（caniuse 上 iOS Safari 直到 26.6 都是 Not supported；Apple 文档明确通知表面只保留 title/body/tag/data）。按钮在 iPhone 上根本不渲染——用户看到「需要审批」却找不到怎么批。官网 GATE B 和 README 的说法对 iOS 用户是错的。

**改法**：按 `maxActions` 运行时探测（不靠 UA——iOS 上任何浏览器壳都是 WebKit）。不支持时不挂按钮、把裁决入口折进 body，`notificationclick` 直达 `GET /api/approval-page` 确认页而不是完整应用壳。

**零服务端改动**：`validSecret` 本就同时接受订阅密钥与 webhook 密钥，直接复用 approval-action 上已补全的能力密钥拼确认页 URL 即可。确认页仍是 GET 只渲染不执行，裁决动作不进 URL。

能力矩阵现在是：

| 平台 | 路径 | 步数 |
|---|---|---|
| Android Chrome / 桌面 Chrome | 通知按钮直接裁决 | 1 |
| iOS / 桌面 Firefox（< 152） | 点通知 → 确认页两个按钮 | 2 |

## 3. 英文流量落到中文 README

官网、npm description、Show HN 稿都是英文，README 是中文且无英文版。`README.md` 改英文，中文移至 `README.zh-CN.md` 互链。官网三语的 lede 与 gateB.p 改为分平台如实表述；`req` 的 `Bun ≥ 1.3.13（Windows ≥ 1.4.0）` 同步为全平台 `≥ 1.4.0`（d741f7e 已统一门槛，官网漏改）。

README 与官网都明示了「iOS 尚未真机实测」和「UI 目前只有简体中文」。诚实优于含糊，而且这两条本身是征集反馈的钩子。

## 验证

- `bun test` **525 通过 / 0 失败**（新增 6 项，原 519）
- `bun run typecheck` 通过
- `bun run build` 通过；dist 产物无 test 文件，JS 体积未变（486.6 KB）
- launcher 四条路径实测：Node 无 Bun 给指引并退 1、Node 有 Bun 透传 help、bun 直跑走 import、未知命令退出码 1 正确转发
- 浏览器实测（chrome-devtools MCP，独立 7481 端口实例）：SW 注册成功、服务的 sw.js 含降级逻辑、Chrome `maxActions=2` 走按钮路径无回归、`/api/approval-page` 对无效密钥返回 403、会话列表正常渲染

sw.js 的降级分支在 Chrome 上测不出来（Chrome 支持按钮），所以补了单测把两条分支都锁住。测试文件放 `web/src/` 而非 `public/` 旁边——public 会被原样拷进 `web/dist`。

## 不在本轮

UI 的 18,344 个中文字符抽取与 i18n 层。应该在拿到第一批英文反馈之后做，避免为还没人用的界面做翻译。
